### PR TITLE
Add clj-kondo script + build step

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,24 @@
+{:linters {:unused-namespace
+           {:exclude [clj-kondo.impl.rewrite-clj-patch
+                      rewrite-clj.parser.core
+                      clj-kondo.impl.var-info-gen
+                      clj-kondo.impl.node.seq
+                      clj-kondo.impl.profiler]}
+           :unresolved-symbol
+           {:exclude [(clj-kondo.impl.utils/one-of)]}
+           :unused-referred-var
+           {:exclude {clojure.test [is deftest testing]}}
+           :type-mismatch
+           {:level :warning
+            :namespaces
+            {clj-kondo.core {print! {:arities {1 {:args [:map]
+                                                  :ret :nil}}}
+                             run! {:arities {1 {:args [:map]
+                                                :ret :map}}}}
+             clj-kondo.impl.config #include "../src/clj_kondo/impl/config.types.edn"
+             clj-kondo.impl.findings #include "../src/clj_kondo/impl/findings.types.edn"}}
+           :missing-docstring {:level :off}
+           :unsorted-required-namespaces {:level :warning}}
+ :lint-as {me.raynes.conch/programs clojure.core/declare
+           me.raynes.conch/let-programs clojure.core/let}
+ :output {:exclude-files ["src/clj_kondo/impl/rewrite_clj_patch.clj"]}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,34 @@ jobs:
       - name: Run tests
         run: |
           script/test/jvm
+          
+  lint:
+    # ubuntu 18.04 comes with lein + java8 installed
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: 'true'
+ 
+      - name: Cache deps
+        uses: actions/cache@v1
+        id: cache-deps
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
+          restore-keys: |
+                ${{ runner.os }}-maven-
+      - name: Fetch deps
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          lein deps
+          
+      - uses: DeLaGuardo/setup-clj-kondo@v1
+        with:
+          version: '2020.04.05'
+          
+      - name: Lint 
+        run: |
+          script/lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,19 +54,6 @@ jobs:
           fetch-depth: 1
           submodules: 'true'
  
-      - name: Cache deps
-        uses: actions/cache@v1
-        id: cache-deps
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
-          restore-keys: |
-                ${{ runner.os }}-maven-
-      - name: Fetch deps
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          lein deps
-          
       - uses: DeLaGuardo/setup-clj-kondo@v1
         with:
           version: '2020.04.05'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 /.shadow-cljs/
 .idea/
 
+.clj-kondo/.cache
+
 # Mac OS files
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@
 # shadow-cljs cache, port files
 /.shadow-cljs/
 .idea/
+
+# Mac OS files
+.DS_Store
+
+# Emacs files
+.#*

--- a/script/lint
+++ b/script/lint
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Find installation instructions here https://github.com/borkdude/clj-kondo/blob/554d7d93e2eb78ff21cfbbee4a084c4b6e089411/doc/install.md
+
+clj-kondo --lint src

--- a/script/lint
+++ b/script/lint
@@ -4,6 +4,6 @@ set -eo pipefail
 
 # Find installation instructions here https://github.com/borkdude/clj-kondo/blob/554d7d93e2eb78ff21cfbbee4a084c4b6e089411/doc/install.md
 
-
+# TODO remove this when all warnings have been fixed
 clj-kondo --lint src || echo "
 [FIXME] fix above warnings and remove this warning"

--- a/script/lint
+++ b/script/lint
@@ -4,4 +4,6 @@ set -eo pipefail
 
 # Find installation instructions here https://github.com/borkdude/clj-kondo/blob/554d7d93e2eb78ff21cfbbee4a084c4b6e089411/doc/install.md
 
-clj-kondo --lint src
+
+clj-kondo --lint src || echo "
+[FIXME] fix above warnings and remove this warning"


### PR DESCRIPTION
`clj-kondo` is an extra shield that will help us with:

* Unused variables, namespaces, shadowing, typos
* Adhere to generally accepted clojure code style (mostly coming from https://github.com/bbatsov/clojure-style-guide)
* Adhere to generally accepted clojure idioms