### PR TITLE
Add build step to export app artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,3 +61,44 @@ jobs:
       - name: Lint 
         run: |
           script/lint
+
+  build-app:
+    needs: [test]
+    # ubuntu 18.04 comes with lein + java8 installed
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: 'true'
+  
+      - name: Cache deps
+        uses: actions/cache@v1
+        id: cache-deps
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
+          restore-keys: |
+                ${{ runner.os }}-maven-
+      - name: Fetch deps
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          lein deps
+          
+      - name: Athens version
+        id: athens-version
+        run: |
+          ATHENS_VERSION=$(echo $GITHUB_SHA | head -c 7)
+          echo "##[set-output name=version;]${ATHENS_VERSION}"
+          
+      - name: Release 
+        run: |
+          RELEASE_NAME=${{ steps.athens-version.outputs.version }} script/build/athens-app
+          
+      - uses: actions/upload-artifact@v1
+        with:
+          name: app
+          path: ${{ steps.athens-version.outputs.version }}.tar.gz
+
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           
       - name: Release 
         run: |
-          RELEASE_NAME=${{ steps.athens-version.outputs.version }} script/build/athens-app
+          RELEASE_NAME=athens-app-${{ steps.athens-version.outputs.version }} script/build/athens-app
           
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,15 +90,16 @@ jobs:
         id: athens-version
         run: |
           ATHENS_VERSION=$(echo $GITHUB_SHA | head -c 7)
-          echo "##[set-output name=version;]${ATHENS_VERSION}"
+          echo "##[set-output name=version;]${ATHENS_VERSION}"          
+          echo "##[set-output name=release-name;]athens-app-${ATHENS_VERSION}"
           
       - name: Release 
         run: |
-          RELEASE_NAME=athens-app-${{ steps.athens-version.outputs.version }} script/build/athens-app
+          RELEASE_NAME=${{ steps.athens-version.outputs.release-name }} script/build/athens-app
           
       - uses: actions/upload-artifact@v1
         with:
           name: app
-          path: ${{ steps.athens-version.outputs.version }}.tar.gz
+          path: ${{ steps.athens-version.outputs.release-name }}.tar.gz
 
           

--- a/script/build/athens-app
+++ b/script/build/athens-app
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# lein prod
+
+RELEASE_NAME=${RELEASE_NAME:-"athens-app"}
+
+# Clean before
+rm -rf $RELEASE_NAME
+
+cp -R resources/public $RELEASE_NAME
+
+tar -zcvf $RELEASE_NAME.tar.gz $RELEASE_NAME
+
+# Clean after
+rm -rf $RELEASE_NAME
+
+

--- a/script/build/athens-app
+++ b/script/build/athens-app
@@ -2,8 +2,10 @@
 
 set -eo pipefail
 
+# Make sure all JS deps are available
 yarn
 
+# Build app (see shadow-cljs.edn config)
 lein prod
 
 RELEASE_NAME=${RELEASE_NAME:-"athens-app"}

--- a/script/build/athens-app
+++ b/script/build/athens-app
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-# lein prod
+lein prod
 
 RELEASE_NAME=${RELEASE_NAME:-"athens-app"}
 

--- a/script/build/athens-app
+++ b/script/build/athens-app
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+yarn
+
 lein prod
 
 RELEASE_NAME=${RELEASE_NAME:-"athens-app"}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,6 +6,10 @@
                 :modules         {:app {:init-fn athens.core/init
                                         :preloads [devtools.preload
                                                    day8.re-frame-10x.preload]}}
+                :compiler-options {:source-map true
+                                   :source-map-detail-level :all
+                                   :source-map-include-sources-content true}
+
                 :dev             {:compiler-options
                                   {:closure-defines {re-frame.trace.trace-enabled?        true
                                                      day8.re-frame.tracing.trace-enabled? true}}}


### PR DESCRIPTION
This build step to export the html app can help us to do quick tests and compare versions

Note that this production release is not working well (not due the build script). I'll make a separate pull request to fix that.

Artifact can be found here https://github.com/jeroenvandijk/athens/actions/runs/99358303