### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**version**
+
+[ Please specify which version of Athens you're using (you can find the git ref in the name of the distribution). The documentation on the
+master branch may be ahead of the most released version.
+
+**platform**
+
+[ Please specify which platform you are using Athens on (what browser, what JVM version) ]
+
+**problem**
+
+[ Please provide a short and to the point description of the problem ]
+
+**repro**
+
+[ Please provide a minimal working reproduction of the problem ]
+
+**expected behavior**
+
+[ What is the behavior you expected to see? Please provide a minimal working example ]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
These Github issue templates will help us structure the incoming information via Github issues

@tangjeff0 Maybe may you want to tweak them with links to [Contributing](https://github.com/athensresearch/athens/blob/master/CONTRIBUTING.md)

