### PR TITLE
Add: trigger vercel deploy in gh action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,20 @@ jobs:
       - name: Release 
         run: |
           RELEASE_NAME=${{ steps.athens-version.outputs.release-name }} script/build/athens-app
+
+      - uses: amondnet/now-deployment@v2
+        # add github secrets at https://github.com/athensresearch/athens/settings/secrets
+        with:
+          # only comment on pr events
+          github-comment: ${{ contains(github.event_name, 'pull_request') }}
+          # vercel token, generated here https://vercel.com/account/tokens
+          zeit-token: ${{ secrets.VERCEL_TOKEN }} 
+          # gh action built-in env
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # below two is based on vercel's project linking feature
+          # instructions: https://github.com/amondnet/now-deployment#project-linking
+          now-org-id: ${{ secrets.VERCEL_ORG_ID}}
+          now-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
           
       - uses: actions/upload-artifact@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 
 # Emacs files
 .#*
+
+.vercel


### PR DESCRIPTION
This commit add the github action to deploy `resource/public` to vercel. There's a demo PR [here](https://github.com/yqrashawn/athens-fork-for-gh-actions/pull/5). I have to create an unforked repo to tweak the gh action.

There're several things need to be done before making this possible.
1. create a vercel account at https://vercel.com/
2. create a vercel token at https://vercel.com/account/tokens as `VERCEL_TOKEN`
3. install the [vercel cli](https://github.com/zeit/now/tree/master/packages/now-cli) with `yarn global add vertical` or `npm install vercel -g`
4. cleanup `resource/public` folder, remove files generated by `lein dev` (too much files may reach vercel's free account upload limit)
5. at root dir of athens, run `vercel --token=$VERCEL_TOKEN`
	- `Set up and deploy “/path/to/athens”? [Y/n]`: **yes**
	- `Link to existing project? [y/N]`: **no**
	- `What’s your project’s name?` **athens**
	- `In which directory is your code located?` **./**
	- `Want to override the settings? [y/N]`: **yes**
	- `Which settings would you like to overwrite (select multiple)? Build Command, Output Directory, Development Command`: **choose all three options with space and arrow key**
		- `Build Command`: **leave empty**
		- `Output Directory`: **resources/public**
		- `Development Command`: **leave empty**

6. there will be a `.vercel/project.json` file created in athens root dir
7. open https://github.com/athensresearch/athens/settings/secrets
	- add `VERCEL_TOKEN` same as above
	- add `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` with the value `orgId`, `projectId` from `.vercel/project.json`

Then the action should work fine.