### PR TITLE
Add basic styling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,8 @@
                  [day8.re-frame/async-flow-fx "0.1.0"]
                  [metosin/reitit "0.4.2"]
                  [instaparse "1.4.10"]
-                 [devcards "0.2.6"]]
+                 [devcards "0.2.6"]
+                 [garden "1.3.10"]]
 
   :plugins [[lein-shell "0.5.0"]]
 

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -7,7 +7,7 @@
 (defn render-blocks []
   (fn [block-uid]
     (let [block (subscribe [:block/children-sorted [:block/uid block-uid]])]
-      [:div
+      [:div {:class "content-block"}
        (doall
         (for [ch (:block/children @block)]
           (let [{:block/keys [uid string open children] dbid :db/id} ch

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -3,18 +3,29 @@
 (defn loading-css
   []
   (fn []
-    [:style (css [
-      :body {:font-family "sans-serif"}
-      :#loading-text {:font-size "1.3rem"}
-    ])]
+    [:style (css
+      [:body {
+        :font-family "sans-serif"
+        :font-size "1.3rem"
+      }]
+    )]
   )
 )
 
 (defn main-css
   []
   (fn []
-    [:style (css [
-      :body {:font-family "sans-serif"}
-    ])]
+    [:style
+      (clojure.string/join "" [
+          (css [:body {:font-family "sans-serif"}])
+          (css :.pages-table [
+            :th {
+              :font-weight "bold"
+              :min-width "11em"
+            }
+          ])
+        ]
+      )
+    ]
   )
 )

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,0 +1,20 @@
+(ns athens.style (:require  [garden.core :refer [css]]))
+
+(defn loading-css
+  []
+  (fn []
+    [:style (css [
+      :body {:font-family "sans-serif"}
+      :#loading-text {:font-size "1.3rem"}
+    ])]
+  )
+)
+
+(defn main-css
+  []
+  (fn []
+    [:style (css [
+      :body {:font-family "sans-serif"}
+    ])]
+  )
+)

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -19,7 +19,7 @@
 
 (defn table
   [nodes]
-  [:table {:style {:width "60%" :margin-top 20}}
+  [:table {:style {:width "60%" :margin-top 20} :class "pages-table"}
    [:thead
     [:tr
      [:th {:style {:text-align "left"}} "Page"]

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -2,6 +2,7 @@
   (:require
    [athens.page :as page]
    [athens.subs]
+   [athens.style :as style]
    [re-frame.core :as rf :refer [subscribe dispatch]]
    #_[reitit.frontend :as rfe]
    [reitit.frontend.easy :as rfee]
@@ -87,7 +88,11 @@
     (fn []
       [alert]
       (if @loading
-        [:h4 "Loading... (at least it'll be faster than Roam)"]
+        [:div
+          [style/loading-css]
+          [:h4 {:id "loading-text"} "Loading... (at least it'll be faster than Roam)"]
+        ]
         [:div {:style {:display "flex"}}
+         [style/main-css]
          [left-sidebar]
          [match-panel (-> @current-route :data :name)]]))))


### PR DESCRIPTION
See #10. This uses [Garden](https://github.com/noprompt/garden) for some basic styling. Now, the body uses the browser's default sans-serif font, instead of not specifying one (some browsers use Time New Roman in this case, some use Arial, some use Tinos (a Times New Roman clone)). Also, it makes sure there is enough room for the dates on the home page.
I'm not very experienced with Clojure, but it does appear to work correctly to me.

![image](https://user-images.githubusercontent.com/10530973/81877876-4b386500-9554-11ea-9814-37c228677579.png)
