### PR TITLE
[#39] Fix more lint warnings, adapt config.edn

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,29 +1,8 @@
-{:linters {:unused-namespace
-           {:exclude [clj-kondo.impl.rewrite-clj-patch
-                      rewrite-clj.parser.core
-                      clj-kondo.impl.var-info-gen
-                      clj-kondo.impl.node.seq
-                      clj-kondo.impl.profiler]}
-           :unresolved-symbol
-           {:exclude [goog.DEBUG
-                      (clj-kondo.impl.utils/one-of)
-                      (devcards.core/defcard)
+{:linters {:unresolved-symbol
+           {:exclude [(devcards.core/defcard)
                       (devcards.core/defcard-rg)]}
            :unused-referred-var
            {:exclude {clojure.test [is deftest testing]}}
-           :type-mismatch
-           {:level :warning
-            :namespaces
-            {clj-kondo.core {print! {:arities {1 {:args [:map]
-                                                  :ret :nil}}}
-                             run! {:arities {1 {:args [:map]
-                                                :ret :map}}}}
-             clj-kondo.impl.config #include "../src/clj_kondo/impl/config.types.edn"
-             clj-kondo.impl.findings #include "../src/clj_kondo/impl/findings.types.edn"}}
-           :missing-docstring {:level :off}
            :unsorted-required-namespaces {:level :warning}}
- :lint-as {me.raynes.conch/programs clojure.core/declare
-           me.raynes.conch/let-programs clojure.core/let
-           day8.re-frame.tracing/fn-traced clojure.core/fn
-           day8.re-frame.tracing/defn-traced clojure.core/defn}
- :output {:exclude-files ["src/clj_kondo/impl/rewrite_clj_patch.clj"]}}
+ :lint-as {day8.re-frame.tracing/fn-traced clojure.core/fn
+           day8.re-frame.tracing/defn-traced clojure.core/defn}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: 'true'
- 
+
       - name: Cache deps
         uses: actions/cache@v1
         id: cache-deps
@@ -43,7 +43,7 @@ jobs:
       - name: Run tests
         run: |
           script/test/jvm
-          
+
   lint:
     # ubuntu 18.04 comes with lein + java8 installed
     runs-on: ubuntu-18.04
@@ -53,12 +53,12 @@ jobs:
         with:
           fetch-depth: 1
           submodules: 'true'
- 
+
       - uses: DeLaGuardo/setup-clj-kondo@v1
         with:
-          version: '2020.04.05'
-          
-      - name: Lint 
+          version: '2020.05.09'
+
+      - name: Lint
         run: |
           script/lint
 
@@ -72,7 +72,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: 'true'
-  
+
       - name: Cache deps
         uses: actions/cache@v1
         id: cache-deps
@@ -85,21 +85,19 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           lein deps
-          
+
       - name: Athens version
         id: athens-version
         run: |
           ATHENS_VERSION=$(echo $GITHUB_SHA | head -c 7)
-          echo "##[set-output name=version;]${ATHENS_VERSION}"          
+          echo "##[set-output name=version;]${ATHENS_VERSION}"
           echo "##[set-output name=release-name;]athens-app-${ATHENS_VERSION}"
-          
-      - name: Release 
+
+      - name: Release
         run: |
           RELEASE_NAME=${{ steps.athens-version.outputs.release-name }} script/build/athens-app
-          
+
       - uses: actions/upload-artifact@v1
         with:
           name: app
           path: ${{ steps.athens-version.outputs.release-name }}.tar.gz
-
-          

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,4 +1,5 @@
-(ns athens.style (:require  [garden.core :refer [css]]))
+(ns athens.style (:require [clojure.string :as str]
+                           [garden.core :refer [css]]))
 
 (defn loading-css
   []
@@ -16,7 +17,7 @@
   []
   (fn []
     [:style
-      (clojure.string/join "" [
+      (str/join "" [
           (css [:body {:font-family "sans-serif"}])
           (css :.pages-table [
             :th {

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -1,12 +1,11 @@
 (ns athens.views
   (:require
-   [athens.page :as page]
-   [athens.subs]
-   [athens.style :as style]
-   [re-frame.core :as rf :refer [subscribe dispatch]]
    #_[reitit.frontend :as rfe]
-   [reitit.frontend.easy :as rfee]
-   ))
+   [athens.page :as page]
+   [athens.style :as style]
+   [athens.subs]
+   [re-frame.core :as rf :refer [subscribe dispatch]]
+   [reitit.frontend.easy :as rfee]))
 
 (defn about-panel []
   [:div [:h1 "About Panel"]])

--- a/test/athens/block_test.clj
+++ b/test/athens/block_test.clj
@@ -1,6 +1,6 @@
 (ns athens.block-test
-  (:require [clojure.test :refer [deftest is]]
-            [athens.blocks :as blocks]))
+  (:require [athens.blocks :as blocks]
+            [clojure.test :refer [deftest is]]))
 
 
 (deftest sort-block-test


### PR DESCRIPTION
This PR fixes the clj-kondo config.

The PR 
- Removes things that are specific to clj-kondo's own code
- Fixes additional lint warnings.
- Updates the clj-kondo version in Github actions
- Cleans up whitespace in build.yml file

cc @jeroenvandijk 