### PR TITLE
ClojureFam, an initiative to pair Clojure Learners and Mentors together

### DIFF
--- a/doc/ClojureFam.md
+++ b/doc/ClojureFam.md
@@ -1,0 +1,1 @@
+placeholder

--- a/doc/ClojureFam.md
+++ b/doc/ClojureFam.md
@@ -1,3 +1,12 @@
+# Table of Contents
+
+1. [Purpose](#purpose)
+1. [Program Overview](#program-overview)
+1. [Why Mentor](#why-contribute-as-a-mentor)
+1. [Clojure Learners](#clojure-learners)
+1. [Clojure Mentors](#clojure-mentors)
+
+
 # Purpose
 
 There is but one thing more joyful than programming Clojure. It is passing this joy onto others.
@@ -38,4 +47,56 @@ If you aren't aware, Roam Research is a note-taking app product built on Datascr
 
 The people using Roam and Athens are not random people. The users of these apps are hungry learners and auto-didacts who want to create and share knowledge. Many have non-trivial programming experience and work at top tier startups and corporations in Silicon Valley. They simply haven't used Clojure before. This is all to say that ClojureFam could be a great recruiting pipeline for your company :)
 
-# Athenians 💜 Aspiring Clojurians
+# Clojure Learners
+
+Note: This is **not** an exhaustive list.
+
+## lei2gh
+
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FEDPTductDn.png?alt=media&token=c281c7fd-e6e3-41af-88d0-5360d33029f3)
+
+## clement
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FEFKDUTZDAd.png?alt=media&token=2a3ec642-4dc3-43de-8f35-f0a773f3cdab)
+
+## jreinaldo
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FxGbiln7YKp.png?alt=media&token=b221ad24-2639-4557-ba2b-6836033e4bd1)
+
+## nathan
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FoMnTj34Z73.png?alt=media&token=b6a2632d-3877-44da-aafd-b361b36ece6d)
+
+## persnicketypear
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FAQUqGGQGs4.png?alt=media&token=b636e6ad-4fe1-49de-83a2-12f4bfbaf117)
+
+## anshbansal
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2F5G_5rmi9gb.png?alt=media&token=bb27b2ee-0202-4727-a6dc-17c8bff456a3)
+
+## bardia
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FuPsEa8Delx.png?alt=media&token=76cfbe05-77a5-43b3-ad07-38d0ae3d8b92)
+
+## gunar
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FP8C8-hu1iV.png?alt=media&token=2c9de1ee-0509-41cb-82b0-143b1b68be55)
+
+## joel
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FCrifkZuJlB.png?alt=media&token=4993dcd4-4d53-4712-9dbc-3690e081edfa)
+
+## deftrade
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FKrtQLx5xdq.png?alt=media&token=e4aff8f7-49c6-4484-bdc2-7f14ee4d8f31)
+
+## forrest
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FjSy5nAFTQ5.png?alt=media&token=a7db445a-ef95-4f47-b161-777f0c11ef6f)
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FMFsw2TJy76.png?alt=media&token=9b5c86bf-aab4-431a-b7e3-798f65e214c8)
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FpxscrXA87K.png?alt=media&token=36a29cbe-b088-4664-bad8-ee0305d0279c)
+
+# Clojure Mentors
+
+## jeroen
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2F3dRv3Dr0fr.png?alt=media&token=02b2da5f-5b21-48ca-b1ba-0468c2983c4b)
+
+## teodor
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2F6wAW-RN_rj.png?alt=media&token=70b0269e-2ecb-4153-8912-d7886394cb0e)
+
+## avichal
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FHmEj_WYEBg.png?alt=media&token=7c0e0780-8eee-4847-9f18-b82283d29d01)
+
+## tomisme
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2Fabt7Y9du9S.png?alt=media&token=35f75885-7d54-429f-a176-beebb9918af2)

--- a/doc/ClojureFam.md
+++ b/doc/ClojureFam.md
@@ -5,6 +5,7 @@
 1. [Why Mentor](#why-contribute-as-a-mentor)
 1. [Clojure Learners](#clojure-learners)
 1. [Clojure Mentors](#clojure-mentors)
+1. [Sign Up](#sign-up)
 
 
 # Purpose
@@ -51,15 +52,14 @@ The people using Roam and Athens are not random people. The users of these apps 
 
 Note: This is **not** an exhaustive list.
 
-## lei2gh
-
-![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FEDPTductDn.png?alt=media&token=c281c7fd-e6e3-41af-88d0-5360d33029f3)
-
 ## clement
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FEFKDUTZDAd.png?alt=media&token=2a3ec642-4dc3-43de-8f35-f0a773f3cdab)
 
 ## jreinaldo
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FxGbiln7YKp.png?alt=media&token=b221ad24-2639-4557-ba2b-6836033e4bd1)
+
+## lei2gh
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FEDPTductDn.png?alt=media&token=c281c7fd-e6e3-41af-88d0-5360d33029f3)
 
 ## nathan
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FoMnTj34Z73.png?alt=media&token=b6a2632d-3877-44da-aafd-b361b36ece6d)
@@ -85,7 +85,7 @@ Note: This is **not** an exhaustive list.
 ## forrest
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FjSy5nAFTQ5.png?alt=media&token=a7db445a-ef95-4f47-b161-777f0c11ef6f)
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FMFsw2TJy76.png?alt=media&token=9b5c86bf-aab4-431a-b7e3-798f65e214c8)
-![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FpxscrXA87K.png?alt=media&token=36a29cbe-b088-4664-bad8-ee0305d0279c)
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fego%2FgzqIzIkiD3.png?alt=media&token=b3445e14-62b0-4820-bd95-fc0858c49111)
 
 # Clojure Mentors
 
@@ -100,3 +100,11 @@ Note: This is **not** an exhaustive list.
 
 ## tomisme
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2Fabt7Y9du9S.png?alt=media&token=35f75885-7d54-429f-a176-beebb9918af2)
+
+# Sign Up
+
+## Mentors
+https://athensresearch.typeform.com/to/TcGMWl
+
+## Learners
+https://athensresearch.typeform.com/to/P486SB

--- a/doc/ClojureFam.md
+++ b/doc/ClojureFam.md
@@ -1,1 +1,41 @@
-placeholder
+# Purpose
+
+There is but one thing more joyful than programming Clojure. It is passing this joy onto others.
+
+The purpose of this program, ClojureFam, is to promote joyful Clojure programming by first increasing the total number of Clojure developers in the world, and second by strengthening the relationships within the global Clojure community.
+
+We believe if there are more Clojure developers in the world, more material value will be created. Furthermore, we believe developers and non-developers alike will have a more positive view of programming and technology at large.
+
+# Program Overview
+
+- "Learners" — those who have minimal Clojure experience — will partner with each other. For the first iterations, Learners are expected to have at least one synchronous video call / pair programming session per week with their partner.
+- "Mentors" — those who have experience programming Clojure and mentoring others — will be placed with a pair of Learners. Mentors are expected to answer technical and professional questions from the partners asynchronously.
+- "Curriculum" — the first cohorts of this program will follow the resources and material in [Onboarding for New Clojurians](https://www.notion.so/Onboarding-for-New-Clojurians-b34b38f30902448cae68afffa02425c1). The goals are:
+    - Completing 100 problems on 4clojure.
+    - Working through Clojure from the Ground Up, completing exercises.
+    - Working through Brave Clojure, completing exercises.
+- The program will culminate in the Learners working together to merge a Pull Request addressing an Athens issue tagged "good first issue".
+- Learners are encouraged to blog or Tweet about their experience learning Clojure, so as to get more people interested in the joy of Clojure programming.
+- Learners are encouraged to create and refine Clojure learning material.
+  - Material could be appended to the current markdown file ([example](https://github.com/aphyr/distsys-class)). This content would evolve, each generation adding and refining their own learnings. 
+  - Material could be learners making their own Clojure Koans for future learners. We've created a #koans channel in our Discord for this purpose.
+  - Material could be learning maps and guides such as [Onboarding for new Clojurians](https://www.notion.so/athensresearch/Onboarding-for-New-Clojurians-b34b38f30902448cae68afffa02425c1).
+  - Ultimately, everyone learns differently. A plurality of content that hopefully evolves and builds off of other resources will support the unique learning styles of this world.
+- Learners, after they have sufficiently developed their Clojure-fu are strongly encouraged to become Mentors for the next generations of Learners.
+    - Clojure-fu can be gauged by how active and helpful the Learner is in open-source projects and in creating learning materials for the Clojure community, for instance.
+
+# Why contribute as a mentor?
+
+The Clojure community is friendly and welcoming like no other. Ask a question on Clojureverse, and you're bound to get a decent reply. Find the right channel on Slack, and you might just get bespoke support from the library author him or herself.
+
+So why take part in the ClojureFam program?
+
+Questions come and go. Libraries and side-projects get abandoned. The flux of people can make us lose track of the individuals.
+
+As a ClojureFam mentor, you have the chance to connect personally to motivated programmers, who are learning Clojure primarily to contribute to Athens Research.
+
+If you aren't aware, Roam Research is a note-taking app product built on Datascript. It is currently the hottest startup in Silicon Valley. Because of scalability issues, they closed their beta, effectively leaving tens of thousands of users eagerly waiting outside the gates. Athens is an open-source version of this trailblazing technology.
+
+The people using Roam and Athens are not random people. The users of these apps are hungry learners and auto-didacts who want to create and share knowledge. Many have non-trivial programming experience and work at top tier startups and corporations in Silicon Valley. They simply haven't used Clojure before. This is all to say that ClojureFam could be a great recruiting pipeline for your company :)
+
+# Athenians 💜 Aspiring Clojurians

--- a/doc/ClojureFam.md
+++ b/doc/ClojureFam.md
@@ -1,3 +1,7 @@
+> “The object of education is to teach us to love what is beautiful.”
+
+— Plato, *The Republic*
+
 # Table of Contents
 
 1. [Purpose](#purpose)

--- a/doc/ClojureFam.md
+++ b/doc/ClojureFam.md
@@ -83,7 +83,7 @@ Note: This is **not** an exhaustive list.
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FKrtQLx5xdq.png?alt=media&token=e4aff8f7-49c6-4484-bdc2-7f14ee4d8f31)
 
 ## forrest
-![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FjSy5nAFTQ5.png?alt=media&token=a7db445a-ef95-4f47-b161-777f0c11ef6f)
+![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fego%2F98hIDjEo3I.png?alt=media&token=52ca3a88-a43f-4a7c-895a-5316a588c7af)
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fjefftang%2FMFsw2TJy76.png?alt=media&token=9b5c86bf-aab4-431a-b7e3-798f65e214c8)
 ![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2Fego%2FgzqIzIkiD3.png?alt=media&token=b3445e14-62b0-4820-bd95-fc0858c49111)
 


### PR DESCRIPTION
I'm excited to announce the pilot for ClojureFam, a program to partner **Clojure Learners** with one another, as well as with **Clojure Mentors**. [Please read about the entire program](https://github.com/athensresearch/athens/blob/ClojureFam/doc/ClojureFam.md), make comments directly on the diffs, and discuss below.

Note: this first week will be piloted only with current Athenians. If you are interested in becoming a Learner or Mentor for later cohorts, sign-up using the links in the markdown file. 🙂