### PR TITLE
Styling refactoring

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -64,9 +64,15 @@
 
 (defn boot-flow []
   {:first-dispatch
-          [:get-datoms]
-   :rules [{:when :seen? :events :parse-datoms :dispatch [:clear-loading] :halt? true}
-           {:when :seen? :events :api-request-error :dispatch [:alert-failure "Boot Error"] :halt? true}]})
+   [:get-datoms]
+   :rules [{:when :seen?
+            :events :parse-datoms
+            :dispatch [:clear-loading]
+            :halt? true}
+           {:when :seen?
+            :events :api-request-error
+            :dispatch [:alert-failure "Boot Error"]
+            :halt? true}]})
 
 (reg-event-fx
  :boot

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -47,12 +47,6 @@
  (fn-traced [_ [_event eid open-state]]
             [[:db/add eid :block/open (not open-state)]]))
 
-
-(reg-event-ds
- :block/toggle-editing
- (fn-traced [_ [_event eid editing-state]]
-            [[:db/add eid :block/editing (not editing-state)]]))
-
 (reg-event-db
  :alert-failure
  (fn-traced [db error]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -43,15 +43,20 @@
              (db/str-to-db-tx json-str)))
 
 (reg-event-ds
-  :block/toggle-open
-  (fn-traced [_ [_event eid open-state]]
-    [[:db/add eid :block/open (not open-state)]]
-    ))
+ :block/toggle-open
+ (fn-traced [_ [_event eid open-state]]
+            [[:db/add eid :block/open (not open-state)]]))
+
+
+(reg-event-ds
+ :block/toggle-editing
+ (fn-traced [_ [_event eid editing-state]]
+            [[:db/add eid :block/editing (not editing-state)]]))
 
 (reg-event-db
-  :alert-failure
-  (fn-traced [db error]
-    (assoc-in db [:errors] error)))
+ :alert-failure
+ (fn-traced [db error]
+            (assoc-in db [:errors] error)))
 
 (reg-event-db
   :clear-errors
@@ -70,6 +75,6 @@
            {:when :seen? :events :api-request-error :dispatch [:alert-failure "Boot Error"] :halt? true}]})
 
 (reg-event-fx
-  :boot
-  (fn-traced [_ _]
-    {:async-flow (boot-flow)}))
+ :boot
+ (fn-traced [_ _]
+            {:async-flow (boot-flow)}))

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -14,7 +14,7 @@
       [:div {:class "content-block"}
        (doall
         (for [ch (:block/children @block)]
-          (let [{:block/keys [uid string open children editing] dbid :db/id} ch
+          (let [{:block/keys [uid string open children] dbid :db/id} ch
                 children? (not-empty children)]
             ^{:key uid}
             [:div
@@ -32,11 +32,7 @@
                                             :cursor         "pointer" :display "inline-block" :background-color "black"
                                             :vertical-align "middle"}
                                  :on-click #(on-block-click uid)}]]]
-              (if editing
-                [:textarea.editing {:auto-focus true
-                                    :on-blur #(dispatch [:block/toggle-editing dbid editing])
-                                    :value (parse string)}]
-                [:span.text {:on-click #(dispatch [:block/toggle-editing dbid editing])} (parse string)])]
+              [:span.text {:content-editable true} (parse string)]]
              (when open
                [:div {:style {:margin-left 20}}
                 [render-blocks uid]])])))])))

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -4,10 +4,6 @@
             #_[reitit.frontend.easy :as rfee]
             #_[reagent.core :as reagent]))
 
-
-(defn on-block-click [uid]
-  (dispatch [:navigate :page {:id uid}]))
-
 (defn render-blocks []
   (fn [block-uid]
     (let [block (subscribe [:block/children-sorted [:block/uid block-uid]])]
@@ -52,7 +48,7 @@
                           :display "inline-block"
                           :background-color "black"
                           :vertical-align "middle"}
-                  :on-click #(on-block-click uid)}]]]
+                  :on-click #(dispatch [:navigate :page {:id uid}])}]]]
               [:span (parse string)]]
              (when open
                [:div {:style {:margin-left 20}}
@@ -82,12 +78,11 @@
                             ^{:key uid}
                             [:span
                              {:style {:cursor "pointer"}
-                              :on-click #(on-block-click uid)}
+                              :on-click #(dispatch [:navigate :page {:id uid}])}
                              (or string title)]))
                         @parents))]
        [:div
-        {:style {:margin 0}
-         :content-editable true}
+        {:style {:margin 0}}
         (str "• " (:block/string @node))]
        [:div
         {:style {:margin-left 20}}
@@ -99,7 +94,6 @@
           unlinked-refs (subscribe [:node/refs (unlinked-pattern (:node/title node))])]
       [:div
        [:h2
-        {:content-editable true}
         (:node/title node)]
        [render-blocks (:block/uid node)]
        [:div.lnk-refs-wrap

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -82,19 +82,19 @@
       [:div
        [:h2 (:node/title node)]
        [render-blocks (:block/uid node)]
-       [:div
+       [:div.linked-references-wrapper
         [:h3 "Linked References"]
-        [:div
+        [:div.linked-references
          (for [id (reduce into [] @linked-refs)]
            ^{:key id}
-           [:div {:style {:background-color "lightblue" :margin "15px 0px" :padding 5}}
+           [:div.linked-reference
             [block-page id]])]]
-       [:div
+       [:div.unlinked-references-wrapper
         [:h3 "Unlinked References"]
-        [:div
+        [:div.unlinked-references
          (for [id (reduce into [] @unlinked-refs)]
            ^{:key id}
-           [:div {:style {:background-color "lightblue" :margin "15px 0px" :padding 5}}
+           [:div.unlinked-reference
             [block-page id]])]]])))
 
 (defn main []

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -53,9 +53,7 @@
                           :background-color "black"
                           :vertical-align "middle"}
                   :on-click #(on-block-click uid)}]]]
-              [:span.text
-               {:content-editable true}
-               (parse string)]]
+              [:span (parse string)]]
              (when open
                [:div {:style {:margin-left 20}}
                 [render-blocks uid]])])))])))
@@ -87,8 +85,9 @@
                               :on-click #(on-block-click uid)}
                              (or string title)]))
                         @parents))]
-       [:h2
-        {:style {:margin 0}}
+       [:div
+        {:style {:margin 0}
+         :content-editable true}
         (str "• " (:block/string @node))]
        [:div
         {:style {:margin-left 20}}
@@ -99,7 +98,9 @@
     (let [linked-refs   (subscribe [:node/refs (linked-pattern   (:node/title node))])
           unlinked-refs (subscribe [:node/refs (unlinked-pattern (:node/title node))])]
       [:div
-       [:h2 (:node/title node)]
+       [:h2
+        {:content-editable true}
+        (:node/title node)]
        [render-blocks (:block/uid node)]
        [:div.lnk-refs-wrap
         [:h3 "Linked References"]

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -60,8 +60,8 @@
                             ^{:key uid}
                             [:span
                              {:style {:cursor "pointer"}
-                              :on-click #(on-block-click uid)
-                              (or string title)}]))
+                              :on-click #(on-block-click uid)}
+                             (or string title)]))
                         @parents))]
        [:h2 {:style {:margin 0}} (str "• " (:block/string @node))]
        [:div {:style {:margin-left 20}}

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -18,26 +18,49 @@
                 children? (not-empty children)]
             ^{:key uid}
             [:div
-             [:div.block {:style {:display "flex"}
-                          :on-click #()}
-              [:div.controls {:style {:display "flex" :align-items "flex-start" :padding-top 5}}
+             [:div.block
+              ;; TODO refactor into style.cljs
+              {:style {:display "flex"}
+               :on-click #()}
+              [:div.controls
+               ;; TODO refactor into style.cljs
+               {:style {:display "flex"
+                        :align-items "flex-start"
+                        :padding-top 5}}
                (cond
                  (and children? open) [:span.arrow-down {:on-click #(dispatch [:block/toggle-open dbid open])}]
                  (and children? (not open)) [:span.arrow-right {:on-click #(dispatch [:block/toggle-open dbid open])}]
                  :else [:span {:style {:width 10}}])
-               [:span {:style {:height         12 :width 12 :border-radius "50%" :margin-right 5
-                               :cursor         "pointer" :display "flex" :background-color (if (not open) "lightgray" nil)
-                               :vertical-align "middle" :align-items "center" :justify-content "center"}}
-                [:span.controls {:style    {:height         5 :width 5 :border-radius "50%"
-                                            :cursor         "pointer" :display "inline-block" :background-color "black"
-                                            :vertical-align "middle"}
-                                 :on-click #(on-block-click uid)}]]]
-              [:span.text {:content-editable true} (parse string)]]
+               [:span.bullet
+                ;; TODO refactor into style.cljs
+                {:style {:height 12
+                         :width 12
+                         :border-radius "50%"
+                         :margin-right 5
+                         :cursor "pointer"
+                         :display "flex"
+                         :background-color (if (not open) "lightgray" nil)
+                         :vertical-align "middle"
+                         :align-items "center"
+                         :justify-content "center"}}
+                [:span.controls
+                 ;; TODO refactor into style.cljs
+                 {:style {:height 5
+                          :width 5
+                          :border-radius "50%"
+                          :cursor "pointer"
+                          :display "inline-block"
+                          :background-color "black"
+                          :vertical-align "middle"}
+                  :on-click #(on-block-click uid)}]]]
+              [:span.text
+               {:content-editable true}
+               (parse string)]]
              (when open
                [:div {:style {:margin-left 20}}
                 [render-blocks uid]])])))])))
 
-; match [[title]] or #title or #[[title]]
+                                        ; :match [[title]] or #title or #[[title]]
 (defn linked-pattern [string]
   (re-pattern (str "("
                    "\\[{2}" string "\\]{2}"
@@ -64,8 +87,11 @@
                               :on-click #(on-block-click uid)}
                              (or string title)]))
                         @parents))]
-       [:h2 {:style {:margin 0}} (str "• " (:block/string @node))]
-       [:div {:style {:margin-left 20}}
+       [:h2
+        {:style {:margin 0}}
+        (str "• " (:block/string @node))]
+       [:div
+        {:style {:margin-left 20}}
         [render-blocks (:block/uid @node)]]])))
 
 (defn node-page []

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -17,20 +17,8 @@
              [:div.block {:style {:display "flex"}}
               [:div.controls {:style {:display "flex" :align-items "flex-start" :padding-top 5}}
                (cond
-                 (and children? open) [:span.arrow-down {:style {:width        0 :height 0
-                                                                 :border-left  "5px solid transparent"
-                                                                 :border-right "5px solid transparent"
-                                                                 :border-top   "5px solid black"
-                                                                 :cursor "pointer"
-                                                                 :margin-top 4}
-                                                         :on-click #(dispatch [:block/toggle-open dbid open])}]
-                 (and children? (not open)) [:span.arrow-right {:style {:width        0 :height 0
-                                                                        :border-top  "5px solid transparent"
-                                                                        :border-bottom "5px solid transparent"
-                                                                        :border-left   "5px solid black"
-                                                                        :cursor "pointer"
-                                                                        :margin-right 4}
-                                                                :on-click #(dispatch [:block/toggle-open dbid open])}]
+                 (and children? open) [:span.arrow-down {:on-click #(dispatch [:block/toggle-open dbid open])}]
+                 (and children? (not open)) [:span.arrow-right {:on-click #(dispatch [:block/toggle-open dbid open])}]
                  :else [:span {:style {:width 10}}])
                [:span {:style {:height         12 :width 12 :border-radius "50%" :margin-right 5
                                :cursor         "pointer" :display "flex" :background-color (if (not open) "lightgray" nil)
@@ -56,6 +44,10 @@
 (defn unlinked-pattern [string]
   (re-pattern (str "[^\\[|#]" string)))
 
+
+(defn on-block-click [uid]
+  (dispatch [:navigate :page {:id uid}]))
+
 (defn block-page []
   (fn [id]
     (let [node (subscribe [:node [:block/uid id]])
@@ -68,8 +60,8 @@
                             ^{:key uid}
                             [:span
                              {:style {:cursor "pointer"}
-                              :on-click #(dispatch [:navigate :page {:id uid}])}
-                             (or string title)]))
+                              :on-click #(on-block-click uid)
+                              (or string title)}]))
                         @parents))]
        [:h2 {:style {:margin 0}} (str "• " (:block/string @node))]
        [:div {:style {:margin-left 20}}
@@ -82,19 +74,19 @@
       [:div
        [:h2 (:node/title node)]
        [render-blocks (:block/uid node)]
-       [:div.linked-references-wrapper
+       [:div.lnk-refs-wrap
         [:h3 "Linked References"]
-        [:div.linked-references
+        [:div.lnk-refs
          (for [id (reduce into [] @linked-refs)]
            ^{:key id}
-           [:div.linked-reference
+           [:div.lnk-ref
             [block-page id]])]]
-       [:div.unlinked-references-wrapper
+       [:div.unl-refs-wrap
         [:h3 "Unlinked References"]
-        [:div.unlinked-references
+        [:div.unl-refs
          (for [id (reduce into [] @unlinked-refs)]
            ^{:key id}
-           [:div.unlinked-reference
+           [:div.unl-ref
             [block-page id]])]]])))
 
 (defn main []

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -54,7 +54,9 @@
   (let [result (parser str)]
     (if (insta/failure? result)
       [:span
-       {:style {:color "red"}}
+       {:style {:color "red"}
+        :content-editable true}
        str]
       [:span
+       {:content-editable true}
        (vec (transform result))])))

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -18,29 +18,43 @@
   "Transforms instaparse output to hiccup."
   [tree]
   (insta/transform
-    {:S    (fn [x] [:span x])
-     :link (fn [title]
-             (let [id (subscribe [:block/uid [:node/title title]])]
+   {:S    (fn [x] [:span x])
+    :link (fn [title]
+            (let [id (subscribe [:block/uid [:node/title title]])]
+              [:span
                [:span
-                [:span {:style {:color "gray"}} "[["]
-                [:a {:href  (rfee/href :page {:id (:block/uid @id)})
-                     :style {:text-decoration "none" :color "dodgerblue"}} title]
-                [:span {:style {:color "gray"}} "]]"]
-                ]))
-     :hash (fn [title]
-             (let [id (subscribe [:block/uid [:node/title title]])]
-               [:a {:style {:color "gray" :text-decoration "none" :font-weight "bold"}
-                    :href  (rfee/href :page {:id (:block/uid @id)})}
-                (str "#" title)]))
-     :bref (fn [id]
-             (let [string (subscribe [:block/string [:block/uid id]])]
-               [:span {:style {:font-size "0.9em" :border-bottom "1px solid gray"}}
-                [:a {:href (rfee/href :page {:id id})} (parse (:block/string @string))]]))}
-    tree))
+                {:style {:color "gray"}}
+                "[["]
+               [:a
+                {:href  (rfee/href :page {:id (:block/uid @id)})
+                 :style {:text-decoration "none"
+                         :color "dodgerblue"}}
+                title]
+               [:span {:style {:color "gray"}}
+                "]]"]]))
+    :hash (fn [title]
+            (let [id (subscribe [:block/uid [:node/title title]])]
+              [:a
+               {:style {:color "gray"
+                        :text-decoration "none"
+                        :font-weight "bold"}
+                :href  (rfee/href :page {:id (:block/uid @id)})}
+               (str "#" title)]))
+    :bref (fn [id]
+            (let [string (subscribe [:block/string [:block/uid id]])]
+              [:span
+               {:style {:font-size "0.9em"
+                        :border-bottom "1px solid gray"}}
+               [:a
+                {:href (rfee/href :page {:id id})}
+                (parse (:block/string @string))]]))} tree))
 
 
 (defn parse [str]
   (let [result (parser str)]
     (if (insta/failure? result)
-      [:span {:style {:color "red"}} str]
-      [:span (vec (transform result))])))
+      [:span
+       {:style {:color "red"}}
+       str]
+      [:span
+       (vec (transform result))])))

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -42,5 +42,5 @@
 (defn parse [str]
   (let [result (parser str)]
     (if (insta/failure? result)
-      [:span {:style {:color "red"}} str]
-      [:span (vec (transform result))])))
+      str
+      (vec (transform result)))))

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -54,9 +54,7 @@
   (let [result (parser str)]
     (if (insta/failure? result)
       [:span
-       {:style {:color "red"}
-        :content-editable true}
+       {:style {:color "red"}}
        str]
       [:span
-       {:content-editable true}
        (vec (transform result))])))

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -42,5 +42,5 @@
 (defn parse [str]
   (let [result (parser str)]
     (if (insta/failure? result)
-      str
-      (vec (transform result)))))
+      [:span {:style {:color "red"}} str]
+      [:span (vec (transform result))])))

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -10,12 +10,35 @@
   (fn []
     [:style
      (str/join "" [(css [:body
-                         {:font-family "sans-serif"}
-                         [:.linked-reference
-                          {:background-color "lightblue" :margin "15px 0px" :padding 5}]
-                         [:.unlinked-reference
-                          {:background-color "lightblue" :margin "15px 0px" :padding 5}]])
+                         {:font-family "sans-serif"}])
+                   (css [:.arrow-down
+                         {:width 0
+                          :height 0
+                          :border-left  "5px solid transparent"
+                          :border-right "5px solid transparent"
+                          :border-top   "5px solid black"
+                          :cursor "pointer"
+                          :margin-top 4}])
+                   (css [:.arrow-right
+                         {:width 0
+                          :height 0
+                          :border-top  "5px solid transparent"
+                          :border-bottom "5px solid transparent"
+                          :border-left   "5px solid black"
+                          :cursor "pointer"
+                          :margin-right 4}])
+                   (css :.lnk-refs-wrap
+                        :.lnk-refs
+                        [:.lnk-ref
+                         {:background-color "lightblue"
+                          :margin "15px 0px"
+                          :padding 5}])
+                   (css :.unl-refs-wrap
+                        :.unl-refs
+                        [:.unl-ref
+                         {:background-color "lightblue"
+                          :margin "15px 0px"
+                          :padding 5}])
                    (css :.pages-table
                         [:th {:font-weight "bold"
-                              :min-width "11em"
-                              }])])]))
+                              :min-width "11em"}])])]))

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -11,14 +11,6 @@
     [:style
      (str/join "" [(css [:body
                          {:font-family "sans-serif"}])
-                   (css [:.controls
-                         {:height 5
-                          :width 5
-                          :border-radius "50%"
-                          :cursor "pointer"
-                          :display "inline-block"
-                          :background-color "black"
-                          :vertical-align "middle"}])
                    (css [:.arrow-down
                          {:width 0
                           :height 0

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -11,6 +11,14 @@
     [:style
      (str/join "" [(css [:body
                          {:font-family "sans-serif"}])
+                   (css [:.controls
+                         {:height 5
+                          :width 5
+                          :border-radius "50%"
+                          :cursor "pointer"
+                          :display "inline-block"
+                          :background-color "black"
+                          :vertical-align "middle"}])
                    (css [:.arrow-down
                          {:width 0
                           :height 0

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,32 +1,21 @@
 (ns athens.style (:require [clojure.string :as str]
                            [garden.core :refer [css]]))
 
-(defn loading-css
-  []
+(defn loading-css []
   (fn []
-    [:style (css
-      [:body {
-        :font-family "sans-serif"
-        :font-size "1.3rem"
-      }]
-    )]
-  )
-)
+    [:style (css [:body {:font-family "sans-serif"
+                         :font-size "1.3rem"}])]))
 
-(defn main-css
-  []
+(defn main-css []
   (fn []
     [:style
-      (str/join "" [
-          (css [:body {:font-family "sans-serif"}])
-          (css :.pages-table [
-            :th {
-              :font-weight "bold"
-              :min-width "11em"
-            }
-          ])
-        ]
-      )
-    ]
-  )
-)
+     (str/join "" [(css [:body
+                         {:font-family "sans-serif"}
+                         [:.linked-reference
+                          {:background-color "lightblue" :margin "15px 0px" :padding 5}]
+                         [:.unlinked-reference
+                          {:background-color "lightblue" :margin "15px 0px" :padding 5}]])
+                   (css :.pages-table
+                        [:th {:font-weight "bold"
+                              :min-width "11em"
+                              }])])]))

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -68,8 +68,8 @@
  '[:block/string {:block/children ...}])
 
 (reg-pull-sub
-  :block/children
-  '[:block/uid :block/string :block/order :block/open :db/id {:block/children ...}])
+ :block/children
+ '[:block/uid :block/string :block/order :block/open :block/editing :db/id {:block/children ...}])
 
 (re-frame/reg-sub
   :block/children-sorted

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -11,20 +11,17 @@
 (re-frame/reg-sub
  :user
  (fn [db _]
-   (:user db)
-   ))
+   (:user db)))
 
 (re-frame/reg-sub
-  :errors
-  (fn [db _]
-    (:errors db)
-    ))
+ :errors
+ (fn [db _]
+   (:errors db)))
 
 (re-frame/reg-sub
-  :loading
-  (fn [db _]
-    (:loading db)
-    ))
+ :loading
+ (fn [db _]
+   (:loading db)))
 
 ;; datascript queries
 (reg-query-sub
@@ -65,11 +62,17 @@
 
 (reg-pull-sub
  :blocks
- '[:block/string {:block/children ...}])
+ '[:block/string
+   {:block/children ...}])
 
 (reg-pull-sub
  :block/children
- '[:block/uid :block/string :block/order :block/open :db/id {:block/children ...}])
+ '[:block/uid
+   :block/string
+   :block/order
+   :block/open
+   :db/id
+   {:block/children ...}])
 
 (re-frame/reg-sub
   :block/children-sorted
@@ -79,8 +82,11 @@
     (blocks/sort-block block)))
 
 (reg-pull-sub
-  :block/_children
-  '[:block/uid :block/string :node/title {:block/_children ...}])
+ :block/_children
+ '[:block/uid
+   :block/string
+   :node/title
+   {:block/_children ...}])
 
 ;; layer 3 subscriptions
 
@@ -107,13 +113,12 @@
     :ids nodes}))
 
 (re-frame/reg-sub
-  :favorites
-  :<- [:page/sidebar]
-  (fn-traced [nodes _]
-    (->> nodes
-         (into [])
-         (sort-by first))
-    ))
+ :favorites
+ :<- [:page/sidebar]
+ (fn-traced [nodes _]
+            (->> nodes
+                 (into [])
+                 (sort-by first))))
 
 ;; (rp/reg-sub
 ;;  :node/refs2

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -69,7 +69,7 @@
 
 (reg-pull-sub
  :block/children
- '[:block/uid :block/string :block/order :block/open :block/editing :db/id {:block/children ...}])
+ '[:block/uid :block/string :block/order :block/open :db/id {:block/children ...}])
 
 (re-frame/reg-sub
   :block/children-sorted

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -21,9 +21,15 @@
   [:table {:style {:width "60%" :margin-top 20} :class "pages-table"}
    [:thead
     [:tr
-     [:th {:style {:text-align "left"}} "Page"]
-     [:th {:style {:text-align "left"}} "Last Edit"]
-     [:th {:style {:text-align "left"}} "Created At"]]]
+     [:th
+      {:style {:text-align "left"}}
+      "Page"]
+     [:th
+      {:style {:text-align "left"}}
+      "Last Edit"]
+     [:th
+      {:style {:text-align "left"}}
+      "Created At"]]]
    [:tbody
     (for [{id :db/id
            bid :block/uid
@@ -32,16 +38,22 @@
            e-time :edit/time} nodes]
       ^{:key id}
       [:tr
-       [:td {:style {:height 24}} [:a {:href (rfee/href :page {:id bid})} title]]
-       [:td (.toLocaleString  (js/Date. c-time))]
-       [:td (.toLocaleString  (js/Date. e-time))]
-       ])]])
+       [:td
+        {:style {:height 24}}
+        [:a
+         {:href (rfee/href :page {:id bid})}
+         title]]
+       [:td
+        (.toLocaleString  (js/Date. c-time))]
+       [:td
+        (.toLocaleString  (js/Date. e-time))]])]])
 
 (defn pages-panel []
   (let [nodes (subscribe [:pull-nodes])]
     (fn []
       [:div
-       [:p "Upload your DB " [:a {:href ""} "(tutorial)"]]
+       [:p "Upload your DB "
+        [:a {:href ""} "(tutorial)"]]
        [:input {:type "file"
                 :name "file-input"
                 :on-change (fn [e] (file-cb e))}]
@@ -52,19 +64,33 @@
     [:div
      [:h1 "Home Panel"]]))
 
-(defn left-sidebar
-  []
+(defn left-sidebar []
   (fn []
     (let [favorites (subscribe [:favorites])
           current-route (subscribe [:current-route])]
-      [:div {:style {:margin "0 10px" :max-width 250}}
-       [:div [:a {:href (rfee/href :pages)} "All /pages"]]
-       [:div [:span {:style {}} "Current Route: " [:b (-> @current-route :path)]]]
-       [:div {:style {:border-bottom "1px solid gray" :margin "10px 0"}}]
-       [:ol {:style {:padding 0 :margin 0 :list-style-type "none"}}
+      [:div
+       {:style {:margin "0 10px"
+                :max-width 250}}
+       [:div
+        [:a
+         {:href (rfee/href :pages)}
+         "All /pages"]]
+       [:div
+        [:span
+         "Current Route: "
+         [:b (-> @current-route :path)]]]
+       [:div
+        {:style {:border-bottom "1px solid gray"
+                 :margin "10px 0"}}]
+       [:ol
+        {:style {:padding 0
+                 :margin 0
+                 :list-style-type "none"}}
         (for [[_order title bid] @favorites]
-          ^{:key bid} [:li [:a {:href (rfee/href :page {:id bid})} title]])]
-       ])))
+          ^{:key bid} [:li
+                       [:a
+                        {:href (rfee/href :page {:id bid})}
+                        title]])]])))
 
 (defn alert
   "When `:errors` subscription is updated, global alert will be called with its contents and then cleared."
@@ -89,9 +115,11 @@
       (if @loading
         [:div
          [style/loading-css]
-         [:h4 {:id "loading-text"} "Loading... (at least it'll be faster than Roam)"]
-         ]
-        [:div {:style {:display "flex"}}
+         [:h4
+          {:id "loading-text"}
+          "Loading... (at least it'll be faster than Roam)"]]
+        [:div
+         {:style {:display "flex"}}
          [style/main-css]
          [left-sidebar]
          [match-panel (-> @current-route :data :name)]]))))

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -88,9 +88,9 @@
       [alert]
       (if @loading
         [:div
-          [style/loading-css]
-          [:h4 {:id "loading-text"} "Loading... (at least it'll be faster than Roam)"]
-        ]
+         [style/loading-css]
+         [:h4 {:id "loading-text"} "Loading... (at least it'll be faster than Roam)"]
+         ]
         [:div {:style {:display "flex"}}
          [style/main-css]
          [left-sidebar]


### PR DESCRIPTION
Emulated the Roam editable blocks functionality but with the HTML `:content-editable` attribute. Originally, I tried using re-frame state to toggle the editing state for each block so it would switch from being a span to a textarea. We should be careful that this method we are using now will work with persisting edits in the future.

I also made some styling refactoring, moving some styling to the `stylings.cljs`, although for the bullets and controls sections, when I moved the stylings outside of inline, the styling would break. I couldn't see to troubleshoot this so I left it as a TODO.

The final change I made was moving the on-block-click function to a global function so when we implement shift-click for the sidebar and other potential ways of clicking, we just add a conditional to the global function.