### PR TITLE
feat: add event :node/rename that also updates referencing blocks

### DIFF
--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -1,0 +1,15 @@
+(ns athens.patterns)
+
+; match [[title]] or #title or #[[title]]
+; provides groups useful for replacing
+; e.g.: $1$3$4new-string$2$5
+(defn linked
+  [string]
+  (re-pattern (str "(\\[{2})" string "(\\]{2})"
+                   "|" "(#)" string
+                   "|" "(#\\[{2})" string "(\\]{2})")))
+
+; also excludes [title] :(
+(defn unlinked
+  [string]
+  (re-pattern (str "[^\\[|#]" string)))

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -1,5 +1,6 @@
 (ns athens.page
   (:require [athens.parser :refer [parse]]
+            [athens.patterns :as patterns]
             [athens.router :refer [navigate-page toggle-open]]
             [re-frame.core :refer [subscribe dispatch]]
             #_[reitit.frontend.easy :as rfee]
@@ -45,18 +46,6 @@
                [:div {:style {:margin-left 20}}
                 [render-blocks uid]])])))])))
 
-; match [[title]] or #title or #[[title]]
-(defn linked-pattern [string]
-  (re-pattern (str "("
-                   "\\[{2}" string "\\]{2}"
-                   "|" "#" string
-                   "|" "#" "\\[{2}" string "\\[{2}"
-                   ")")))
-
-; also excludes [title] :(
-(defn unlinked-pattern [string]
-  (re-pattern (str "[^\\[|#]" string)))
-
 (defn block-page []
   (fn [id]
     (let [node (subscribe [:node [:block/uid id]])
@@ -80,8 +69,8 @@
 
 (defn node-page []
   (fn [node]
-    (let [linked-refs   (subscribe [:node/refs (linked-pattern   (:node/title node))])
-          unlinked-refs (subscribe [:node/refs (unlinked-pattern (:node/title node))])]
+    (let [linked-refs   (subscribe [:node/refs (patterns/linked   (:node/title node))])
+          unlinked-refs (subscribe [:node/refs (patterns/unlinked (:node/title node))])]
       [:div
        [:h2
         {:content-editable true} (:node/title node)]

--- a/test/athens/patterns_test.clj
+++ b/test/athens/patterns_test.clj
@@ -1,0 +1,29 @@
+(ns athens.patterns-test
+  (:require [athens.patterns :as patterns]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is]]))
+
+(defn update-links-in-block
+  [s old-title new-title]
+  (str/replace s
+               (patterns/linked old-title)
+               (str "$1$3$4" new-title "$2$5")))
+
+(def text
+  "A block with multipe link to [[AnotherPage]] in different forms #[[AnotherPage]] #AnotherPage.")
+
+(def new-text
+  "A block with multipe link to [[AwesomePage]] in different forms #[[AwesomePage]] #AwesomePage.")
+
+(deftest linked-patterns-tests
+  (is (= "[[Page Title]]"
+         (first (re-find (patterns/linked "Page Title")
+                  "Some text with a [[Page Title]]"))))
+  (is (= "#PageTitle"
+         (first (re-find (patterns/linked "PageTitle")
+                  "Some text with a #PageTitle"))))
+  (is (= "#[[Page Title]]"
+         (first (re-find (patterns/linked "Page Title")
+                  "Some text with a #[[Page Title]]"))))
+  (is (= new-text
+         (update-links-in-block text "AnotherPage" "AwesomePage"))))


### PR DESCRIPTION
First PR for this project. Any and all feedback is welcome. Although the requested functionality is there, you can't use it yet from the ui, because editing titles isn't possible yet. 

So I guess this PR is mainly here for feedback, I can update it when #70 is merged. If another workflow is preferred, please let me know!

- TODO: use the event when updating title is supported in the ui
- TODO: handle edge cases #61 and #66

close #62 