### PR TITLE
Editable blocks refactor

### DIFF
--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -1,5 +1,6 @@
 (ns athens.page
   (:require [athens.parser :refer [parse]]
+            [athens.router :refer [navigate-page toggle-open]]
             [re-frame.core :refer [subscribe dispatch]]
             #_[reitit.frontend.easy :as rfee]
             #_[reagent.core :as reagent]))
@@ -23,14 +24,14 @@
                                                                  :border-top   "5px solid black"
                                                                  :cursor "pointer"
                                                                  :margin-top 4}
-                                                         :on-click #(dispatch [:block/toggle-open dbid open])}]
+                                                         :on-click #(toggle-open dbid open)}]
                  (and children? (not open)) [:span.arrow-right {:style {:width        0 :height 0
                                                                         :border-top  "5px solid transparent"
                                                                         :border-bottom "5px solid transparent"
                                                                         :border-left   "5px solid black"
                                                                         :cursor "pointer"
                                                                         :margin-right 4}
-                                                                :on-click #(dispatch [:block/toggle-open dbid open])}]
+                                                                :on-click #(toggle-open dbid open)}]
                  :else [:span {:style {:width 10}}])
                [:span {:style {:height         12 :width 12 :border-radius "50%" :margin-right 5
                                :cursor         "pointer" :display "flex" :background-color (if (not open) "lightgray" nil)
@@ -38,7 +39,7 @@
                 [:span.controls {:style    {:height         5 :width 5 :border-radius "50%"
                                             :cursor         "pointer" :display "inline-block" :background-color "black"
                                             :vertical-align "middle"}
-                                 :on-click #(dispatch [:navigate :page {:id uid}])}]]]
+                                 :on-click #(navigate-block uid)}]]]
               [:span (parse string)]]
              (when open
                [:div {:style {:margin-left 20}}
@@ -68,7 +69,7 @@
                             ^{:key uid}
                             [:span
                              {:style {:cursor "pointer"}
-                              :on-click #(dispatch [:navigate :page {:id uid}])}
+                              :on-click #(on-block-click uid)}
                              (or string title)]))
                         @parents))]
        [:h2 {:style {:margin 0}} (str "• " (:block/string @node))]

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -39,7 +39,7 @@
                 [:span.controls {:style    {:height         5 :width 5 :border-radius "50%"
                                             :cursor         "pointer" :display "inline-block" :background-color "black"
                                             :vertical-align "middle"}
-                                 :on-click #(navigate-block uid)}]]]
+                                 :on-click #(navigate-page uid)}]]]
               [:span (parse string)]]
              (when open
                [:div {:style {:margin-left 20}}
@@ -69,10 +69,12 @@
                             ^{:key uid}
                             [:span
                              {:style {:cursor "pointer"}
-                              :on-click #(on-block-click uid)}
+                              :on-click #(navigate-page uid)}
                              (or string title)]))
                         @parents))]
-       [:h2 {:style {:margin 0}} (str "• " (:block/string @node))]
+       [:h2
+        {:content-editable true
+         :style {:margin 0}} (str "• " (:block/string @node))]
        [:div {:style {:margin-left 20}}
         [render-blocks (:block/uid @node)]]])))
 
@@ -81,7 +83,8 @@
     (let [linked-refs   (subscribe [:node/refs (linked-pattern   (:node/title node))])
           unlinked-refs (subscribe [:node/refs (unlinked-pattern (:node/title node))])]
       [:div
-       [:h2 (:node/title node)]
+       [:h2
+        {:content-editable true} (:node/title node)]
        [render-blocks (:block/uid node)]
        [:div
         [:h3 "Linked References"]

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -42,5 +42,10 @@
 (defn parse [str]
   (let [result (parser str)]
     (if (insta/failure? result)
-      [:span {:style {:color "red"}} str]
-      [:span (vec (transform result))])))
+      [:span
+       {:content-editable true
+        :style {:color "red"}}
+       str]
+      [:span
+       {:content-editable true}
+       (vec (transform result))])))

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -54,6 +54,12 @@
   (when new-match
     (dispatch [:navigated new-match])))
 
+(defn navigate-page [uid]
+  (dispatch [:navigate :page {:id uid}]))
+
+(defn toggle-open [dbid open]
+  (dispatch [:block/toggle-open dbid open]))
+
 (defn init-routes! []
   (prn "Initializing routes")
   (rfee/start!


### PR DESCRIPTION
Added :content-editable HTML attribute to text and title
  - Discussion on rationale is found in #70.

Refactored navigate-page and toggle-open re-frame functions into athens.router namespace
- Reason given in #70