### PR TITLE
fix: remaining clj-kondo lint warnings

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,6 @@
-{:linters {:unresolved-symbol
+{:linters {:unresolved-namespace
+           {:exclude [clojure.string]}
+           :unresolved-symbol
            {:exclude [(devcards.core/defcard)
                       (devcards.core/defcard-rg)]}
            :unused-referred-var

--- a/script/lint
+++ b/script/lint
@@ -4,6 +4,4 @@ set -eo pipefail
 
 # Find installation instructions here https://github.com/borkdude/clj-kondo/blob/554d7d93e2eb78ff21cfbbee4a084c4b6e089411/doc/install.md
 
-# TODO remove this when all warnings have been fixed
-clj-kondo --lint src || echo "
-[FIXME] fix above warnings and remove this warning"
+clj-kondo --lint src

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -3,7 +3,7 @@
     [athens.parser :refer [parse]]
     [athens.patterns :as patterns]
     [athens.router :refer [navigate-page toggle-open]]
-    [re-frame.core :refer [subscribe dispatch]]
+    [re-frame.core :refer [subscribe]]
     #_[reagent.core :as reagent]
     #_[reitit.frontend.easy :as rfee]))
 

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -59,7 +59,7 @@
 
   [:h1 (+heavily-styled) "some statement"]
 
-  [:h1 (+heavily-styled {:on-click (fn [e] (js/alert "something else"))}) "some statement"]
+  [:h1 (+heavily-styled {:on-click (fn [_e] (js/alert "something else"))}) "some statement"]
 
   )
 


### PR DESCRIPTION
`script/lint` output before this change:

~~~
src/cljs/athens/page.cljs:6:38: warning: #'re-frame.core/dispatch is referred but never used
src/cljs/athens/style.cljs:38:46: warning: Unresolved namespace clojure.string. Are you missing a require?
src/cljs/athens/style.cljs:62:41: warning: unused binding e
linting took 137ms, errors: 0, warnings: 3

[FIXME] fix above warnings and remove this warning
~~~

`script/lint` output after this change:

~~~
linting took 141ms, errors: 0, warnings: 0
~~~

I wasn’t sure if it was right to assume that the `clojure.string` namespace is always available, so I tested it by creating and running the following standalone file:

~~~clj
#!/usr/bin/env boot

(defn -main [& _args]
  (println (clojure.string/join "|" [1 2 3])))
~~~

Since that program printed “1|2|3” with no errors, I think I can assume `clojure.string` is always available, and thus it is safe to ignore warnings to require it. Please correct me if I’m wrong.