### PR TITLE
feat: add title text with parse failure error messages

### DIFF
--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -46,13 +46,11 @@
   [string]
   (let [result (parser string)]
     (if (insta/failure? result)
-      (let [failure (insta/get-failure result)
-            {:keys [line column reason]} failure]
-        [:span
-         {:content-editable true
-          :title (str "parse error at line " line " col " column ": " reason)
-          :style {:color "red"}}
-         string])
+      [:span
+       {:content-editable true
+        :title (pr-str (insta/get-failure result))
+        :style {:color "red"}}
+       string]
       [:span
        {:content-editable true}
        (vec (transform result))])))

--- a/src/cljs/athens/parser.cljs
+++ b/src/cljs/athens/parser.cljs
@@ -43,13 +43,16 @@
 
 
 (defn parse
-  [str]
-  (let [result (parser str)]
+  [string]
+  (let [result (parser string)]
     (if (insta/failure? result)
-      [:span
-       {:content-editable true
-        :style {:color "red"}}
-       str]
+      (let [failure (insta/get-failure result)
+            {:keys [line column reason]} failure]
+        [:span
+         {:content-editable true
+          :title (str "parse error at line " line " col " column ": " reason)
+          :style {:color "red"}}
+         string])
       [:span
        {:content-editable true}
        (vec (transform result))])))


### PR DESCRIPTION
This will help users of the current version understand why there is red text everywhere, and help developers debug the parse failures. Example title text after this change:

> parse error at line 1 col 1: [{:tag :string, :expecting "#"} {:tag :string, :expecting "(("} {:tag :string, :expecting "[["} {:tag :regexp, :expecting #"^(\w|\s)+", :full true}]

> <img width="549" alt="example title text with parse failure error message" src="https://user-images.githubusercontent.com/79168/82653952-fa78da00-9bed-11ea-81de-eba3122c697b.png">

I renamed the `str` parameter to `string` so I could use the `clojure.core/str` function as `str`.