### PR TITLE
Adds title component that supports page renaming

### DIFF
--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -70,6 +70,9 @@
        [:div {:style {:margin-left 20}}
         [render-blocks (:block/uid @node)]]])))
 
+(def enter-keycode 13)
+(def esc-keycode 27)
+
 (defn title-comp [title]
   (let [s (reagent/atom {:editing false
                          :current-title title
@@ -86,8 +89,8 @@
                  :on-change #(swap! s assoc :new-title (-> % .-target .-value))
                  :on-blur save!
                  :on-key-down #(case (.-which %)
-                                 13 (save!) ; save on enter
-                                 27 (cancel!) ; cancel on esc
+                                 enter-keycode (save!) ; save on enter
+                                 esc-keycode (cancel!) ; cancel on esc
                                  nil)}]
         [:h2 {:on-click (fn [_] (swap! s #(-> %
                                               (assoc :editing true)

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -77,8 +77,8 @@
   (let [s (reagent/atom {:editing false
                          :current-title title})
         save! (fn [new-title]
-                (dispatch [:node/rename (:current-title @s) new-title])
-                (swap! s assoc :editing false))
+                (swap! s assoc :editing false)
+                (dispatch [:node/rename (:current-title @s) new-title]))
         cancel! (fn [] (swap! s assoc :editing false))]
     (fn [title]
       (if (:editing @s)

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -70,7 +70,7 @@
        [:div {:style {:margin-left 20}}
         [render-blocks (:block/uid @node)]]])))
 
-(defn title [title]
+(defn title-comp [title]
   (let [s (reagent/atom {:editing false
                          :current-title title
                          :new-title title})
@@ -100,7 +100,7 @@
     (let [linked-refs   (subscribe [:node/refs (patterns/linked   (:node/title node))])
           unlinked-refs (subscribe [:node/refs (patterns/unlinked (:node/title node))])]
       [:div
-       [title (:node/title node)]
+       [title-comp (:node/title node)]
        [render-blocks (:block/uid node)]
        [:div
         [:h3 "Linked References"]

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -70,8 +70,10 @@
        [:div {:style {:margin-left 20}}
         [render-blocks (:block/uid @node)]]])))
 
+
 (def enter-keycode 13)
 (def esc-keycode 27)
+
 
 (defn title-comp [title]
   (let [s (reagent/atom {:editing false
@@ -97,6 +99,7 @@
                                               (assoc :editing true)
                                               (assoc :current-title title))))}
          title]))))
+
 
 (defn node-page []
   (fn [node]

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -75,27 +75,27 @@
 
 (defn title-comp [title]
   (let [s (reagent/atom {:editing false
-                         :current-title title
-                         :new-title title})
-        save! (fn [] (dispatch [:node/rename (:current-title @s) (:new-title @s)])
-                     (swap! s assoc :editing false))
-        cancel! (fn [] (swap! s #(-> %
-                                     (assoc :editing false)
-                                     (assoc :new-title (:current-title @s)))))]
+                         :current-title title})
+        save! (fn [new-title]
+                (dispatch [:node/rename (:current-title @s) new-title])
+                (swap! s assoc :editing false))
+        cancel! (fn [] (swap! s assoc :editing false))]
     (fn [title]
       (if (:editing @s)
-        [:input {:value (:new-title @s)
+        [:input {:default-value title
                  :auto-focus true
-                 :on-change #(swap! s assoc :new-title (-> % .-target .-value))
-                 :on-blur save!
-                 :on-key-down #(case (.-which %)
-                                 enter-keycode (save!) ; save on enter
-                                 esc-keycode (cancel!) ; cancel on esc
-                                 nil)}]
+                 :on-blur #(save! (-> % .-target .-value))
+                 :on-key-down #(cond
+                                 (= (.-keyCode %) enter-keycode)
+                                 (save! (-> % .-target .-value))
+
+                                 (= (.-keyCode %) esc-keycode)
+                                 (cancel!)
+
+                                 :else nil)}]
         [:h2 {:on-click (fn [_] (swap! s #(-> %
                                               (assoc :editing true)
-                                              (assoc :current-title title)
-                                              (assoc :new-title title))))}
+                                              (assoc :current-title title))))}
          title]))))
 
 (defn node-page []


### PR DESCRIPTION
Next step in dealing with #62. Haven't yet dealt with #61 and #66. I've also realized that I should deal with renames that include `#hash-style-links` being renamed to `#[[title that includes whitespace]]`.

I don't really expect this to be merged yet until I deal with these issues, but would appreciate some feedback whether I'm on the right track with this.