### PR TITLE
Adds merge prompt

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -40,7 +40,7 @@
         :start (swap! timers assoc id (js/setTimeout #(dispatch event) wait))
         :clear (do (js/clearTimeout (get @timers id))
                    (swap! timers dissoc id))))))
-                   
+
 
 (reg-event-fx
   :get-datoms
@@ -109,7 +109,11 @@
                (if (node-with-title ds new-title)
                  {:db (assoc db :merge-prompt {:active true
                                                :old-title old-title
-                                               :new-title new-title})}
+                                               :new-title new-title})
+                  :timeout {:action :start
+                            :id :merge-prompt
+                            :wait 7000
+                            :event [:node/merge-canceled]}}
                  {:transact (rename-tx ds old-title new-title)}))))
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -32,6 +32,16 @@
           (dispatch (conj on-failure all)))))))
 
 
+(reg-fx
+  :timeout
+  (let [timers (atom {})]
+    (fn [{:keys [action id event wait]}]
+      (case action
+        :start (swap! timers assoc id (js/setTimeout #(dispatch event) wait))
+        :clear (do (js/clearTimeout (get @timers id))
+                   (swap! timers dissoc id))))))
+                   
+
 (reg-event-fx
   :get-datoms
   (fn [_ _]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -122,8 +122,8 @@
   (d/q '[:find (count ?children) .
          :in $ ?title
          :where [?e :node/title ?title]
-                [?e :block/children ?children]]
-    ds title))
+         [?e :block/children ?children]]
+       ds title))
 
 
 (defn get-children-eids
@@ -131,8 +131,8 @@
   (d/q '[:find [?children ...]
          :in $ ?title
          :where [?e :node/title ?title]
-                [?e :block/children ?children]]
-    ds title))
+         [?e :block/children ?children]]
+       ds title))
 
 
 (defn move-blocks-tx
@@ -148,19 +148,14 @@
 
 (reg-event-fx
   :node/merged
+  [(rp/inject-cofx :ds)]
   (fn-traced [{:keys [db ds]} [_ primary-title secondary-title]]
              {:db (dissoc db :merge-prompt)
               :timeout {:action :clear
                         :id :merge-prompt}
-              :transact (let [tx (concat [[:db.fn/retractEntity [:node/title secondary-title]]]
-                                         (move-blocks-tx ds secondary-title primary-title)
-                                         (rename-tx ds primary-title secondary-title))]
-                          (println tx)
-                          tx)}))
-
-(concat [[:db.fn/retractEntity [:node/title "Athens Change Log"]]]
-        (move-blocks-tx @db/dsdb "Athens Change Log" "type")
-        (rename-tx @db/dsdb "type" "Athens Change Log"))
+              :transact (concat [[:db.fn/retractEntity [:node/title secondary-title]]]
+                                (move-blocks-tx ds secondary-title primary-title)
+                                (rename-tx ds primary-title secondary-title))}))
 
 
 (reg-event-fx

--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -79,7 +79,7 @@
                          :current-title title})
         save! (fn [new-title]
                 (swap! s assoc :editing false)
-                (dispatch [:node/rename (:current-title @s) new-title]))
+                (dispatch [:node/renamed (:current-title @s) new-title]))
         cancel! (fn [] (swap! s assoc :editing false))]
     (fn [title]
       (if (:editing @s)
@@ -100,11 +100,27 @@
          title]))))
 
 
+(defn merge-prompt
+  [{:keys [old-title new-title]}]
+  [:div {:style {:background "red"
+                 :color "white"}}
+    (str "\"" new-title "\" already exists, merge pages?")
+    [:a {:on-click #(dispatch [:node/merged old-title new-title])
+         :style {:margin-left "30px"}}
+     "yes"]
+    [:a {:on-click #(dispatch [:node/merge-canceled])
+         :style {:margin-left "30px"}}
+     "no"]])
+
+
 (defn node-page []
   (fn [node]
     (let [linked-refs   (subscribe [:node/refs (patterns/linked   (:node/title node))])
-          unlinked-refs (subscribe [:node/refs (patterns/unlinked (:node/title node))])]
+          unlinked-refs (subscribe [:node/refs (patterns/unlinked (:node/title node))])
+          merge         (subscribe [:merge-prompt])]
       [:div
+       (when (get @merge :active false)
+         [merge-prompt @merge])
        [title-comp (:node/title node)]
        [render-blocks (:block/uid node)]
        [:div

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -2,7 +2,7 @@
   (:require
     #_[athens.views :as views]
     [day8.re-frame.tracing :refer-macros [fn-traced]]
-    [re-frame.core :refer [subscribe dispatch reg-sub reg-event-db reg-event-fx reg-fx]]
+    [re-frame.core :refer [subscribe dispatch reg-sub reg-event-fx reg-fx]]
     [reitit.coercion.spec :as rss]
     [reitit.frontend :as rfe]
     [reitit.frontend.controllers :as rfc]

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -21,14 +21,19 @@
     {:navigate! route}))
 
 
-(reg-event-db
+(reg-event-fx
   :navigated
-  (fn [db [_ new-match]]
+  (fn [{:keys [db]} [_ new-match]]
     (let [old-match   (:current-route db)
           controllers (rfc/apply-controllers (:controllers old-match) new-match)
           node (subscribe [:node [:block/uid (-> new-match :path-params :id)]])] ;; TODO make the page title query work when zoomed in on a block
       (set! (.-title js/document) (or (:node/title @node) "Athens Research")) ;; TODO make this side effect explicit
-      (assoc db :current-route (assoc new-match :controllers controllers)))))
+      {:db (-> db
+               (assoc :current-route (assoc new-match :controllers controllers))
+               (dissoc :merge-prompt))
+       :timeout {:action :clear
+                 :id :merge-prompt}})))
+
 
 ;; effects
 

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -3,8 +3,8 @@
     [athens.blocks :as blocks]
     [day8.re-frame.tracing :refer-macros [fn-traced]]
     [re-frame.core :as re-frame]
-    [re-posh.core :as re-posh :refer [subscribe reg-query-sub reg-pull-sub ;; reg-pull-many-sub
-                                      ]]))
+    [re-posh.core :as re-posh :refer [subscribe reg-query-sub reg-pull-sub]])) ;; reg-pull-many-sub
+
 ;; note: not refering reg-sub because re-posh and re-frame have different reg-subs
 
 ;; re-frame subscriptions
@@ -24,6 +24,12 @@
   :loading
   (fn [db _]
     (:loading db)))
+
+
+(re-frame/reg-sub
+  :merge-prompt
+  (fn [db _]
+    (:merge-prompt db)))
 
 ;; datascript queries
 (reg-query-sub


### PR DESCRIPTION
First work on #61. The (very ugly) prompt does appear when trying to rename to a page title that already exists. I do have some questions about completing this PR:

- Are there conventions about how re-frame's app db should be structured?
- What should happen when a user navigates away from the page without responding to the prompt? Maybe the `:navigated` event should clear it?
- Should the transaction to do the actual merge be part of this PR?

