### PR TITLE
fix: remove content-editable

### DIFF
--- a/src/cljs/athens/page.cljs
+++ b/src/cljs/athens/page.cljs
@@ -64,9 +64,8 @@
                               :on-click #(navigate-page uid)}
                              (or string title)]))
                         @parents))]
-       [:h2
-        {:content-editable true
-         :style {:margin 0}} (str "• " (:block/string @node))]
+       [:h2 {:style {:margin 0}}
+        (str "• " (:block/string @node))]
        [:div {:style {:margin-left 20}}
         [render-blocks (:block/uid @node)]]])))
 

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -51,10 +51,8 @@
   (let [result (parser/block-parser string)]
     (if (insta/failure? result)
       [:span
-       {:content-editable true
-        :title (pr-str (insta/get-failure result))
+       {:title (pr-str (insta/get-failure result))
         :style {:color "red"}}
        string]
       [:span
-       {:content-editable true}
        (vec (transform result))])))


### PR DESCRIPTION
We were going to remove it at some point because in a change of plans, we decided to implement the first version of editing using textareas instead of contentEditable. I’m doing the removal now to solve these two problems caused by contentEditable:

- It causes React to output warnings to the browser console, cluttering the console output:

  > Warning: A component is `contentEditable` and contains `children` managed by React. It is now your responsibility to guarantee that none of those nodes are unexpectedly modified or duplicated. This is probably not intentional.

- It prevents links within blocks from being clicked: clicking a link just places the cursor there.