### PR TITLE
fix: add .cpcache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 
 .clj-kondo/.cache
 
+# cache directory for dependencies installed with deps.edn
+.cpcache
+
 # Mac OS files
 .DS_Store
 


### PR DESCRIPTION
The `.cpcache` directory was created after I installed the `clojure` binary and ran `script/carve`.

`.cpcache` is described here: https://clojure.org/reference/deps_and_cli#_directories