### PR TITLE
feat(parsing): basic support for URL links

### DIFF
--- a/src/cljc/athens/parser.cljc
+++ b/src/cljc/athens/parser.cljc
@@ -12,15 +12,19 @@
 (defparser block-parser
   "(* This first rule is the top-level one. *)
    block = ( syntax-in-block / any-char )*
-   (* `/` ordered alternation is used to, for example, try to interpret a string beginning with '[[' as a block-link before interpreting it as raw characters. *)
+   (* `/` ordered alternation is used to, for example, try to interpret a string beginning with '[[' as a page-link before interpreting it as raw characters. *)
    
-   <syntax-in-block> = (block-link | block-ref | hashtag | bold)
+   <syntax-in-block> = (page-link | block-ref | hashtag | url-link | bold)
    
-   block-link = <'[['> any-chars <']]'>
+   page-link = <'[['> any-chars <']]'>
    
    block-ref = <'(('> any-chars <'))'>
    
    hashtag = <'#'> any-chars | <'#'> <'[['> any-chars <']]'>
+   
+   url-link = url-link-text url-link-url
+   <url-link-text> = <'['> any-chars <']'>
+   <url-link-url> = <'('> any-chars <')'>
    
    bold = <'**'> any-chars <'**'>
    
@@ -54,6 +58,8 @@
     {:block      (fn [& raw-contents]
                     ;; use combine-adjacent-strings to collapse individual characters from any-char into one string
                    (into [:block] (combine-adjacent-strings raw-contents)))
+     :url-link   (fn [text url]
+                   [:url-link {:url url} text])
      :any-chars  (fn [& chars]
                    (clojure.string/join chars))}
     tree))

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -15,28 +15,32 @@
   "Transforms Instaparse output to Hiccup."
   [tree]
   (insta/transform
-    {:block      (fn [& contents]
-                   (concat [:span {:class "block"}] contents))
-     :block-link (fn [title]
-                   (let [id (subscribe [:block/uid [:node/title title]])]
-                     [:span {:class "block-link"}
-                      [:span {:style {:color "gray"}} "[["]
-                      [:a {:href  (rfee/href :page {:id (:block/uid @id)})
-                           :style {:text-decoration "none" :color "dodgerblue"}} title]
-                      [:span {:style {:color "gray"}} "]]"]]))
-     :block-ref  (fn [id]
-                   (let [string (subscribe [:block/string [:block/uid id]])]
-                     [:span {:class "block-ref"
-                             :style {:font-size "0.9em" :border-bottom "1px solid gray"}}
-                      [:a {:href (rfee/href :page {:id id})} (parse-and-render (:block/string @string))]]))
-     :hashtag    (fn [tag-name]
-                   (let [id (subscribe [:block/uid [:node/title tag-name]])]
-                     [:a {:class "hashtag"
-                          :style {:color "gray" :text-decoration "none" :font-weight "bold"}
-                          :href  (rfee/href :page {:id (:block/uid @id)})}
-                      (str "#" tag-name)]))
-     :bold       (fn [text]
-                   [:strong {:class "bold"} text])}
+    {:block     (fn [& contents]
+                  (concat [:span {:class "block"}] contents))
+     :page-link (fn [title]
+                  (let [id (subscribe [:block/uid [:node/title title]])]
+                    [:span {:class "page-link"}
+                     [:span {:style {:color "gray"}} "[["]
+                     [:a {:href  (rfee/href :page {:id (:block/uid @id)})
+                          :style {:text-decoration "none" :color "dodgerblue"}} title]
+                     [:span {:style {:color "gray"}} "]]"]]))
+     :block-ref (fn [id]
+                  (let [string (subscribe [:block/string [:block/uid id]])]
+                    [:span {:class "block-ref"
+                            :style {:font-size "0.9em" :border-bottom "1px solid gray"}}
+                     [:a {:href (rfee/href :page {:id id})} (parse-and-render (:block/string @string))]]))
+     :hashtag   (fn [tag-name]
+                  (let [id (subscribe [:block/uid [:node/title tag-name]])]
+                    [:a {:class "hashtag"
+                         :style {:color "gray" :text-decoration "none" :font-weight "bold"}
+                         :href  (rfee/href :page {:id (:block/uid @id)})}
+                     (str "#" tag-name)]))
+     :url-link  (fn [{url :url} text]
+                  [:a {:class "url-link"
+                       :href url}
+                   text])
+     :bold      (fn [text]
+                  [:strong {:class "bold"} text])}
     tree))
 
 

--- a/test/athens/parser_test.clj
+++ b/test/athens/parser_test.clj
@@ -7,8 +7,10 @@
 (deftest block-parser-tests
   (is (= [:block] (parse-to-ast "")))
   (is (= [:block "OK? Yes."] (parse-to-ast "OK? Yes.")))
-  (is (= [:block [:block-link "link"]] (parse-to-ast "[[link]]")))
+  (is (= [:block [:page-link "link"]] (parse-to-ast "[[link]]")))
+  (is (= [:block "A " [:page-link "link"] "."] (parse-to-ast "A [[link]].")))
   (is (= [:block "[[text"] (parse-to-ast "[[text")))
+  (is (= [:block [:url-link {:url "https://example.com/"} "an example"]] (parse-to-ast "[an example](https://example.com/)")))
   ;; Not including tests for every type of syntax because I expect the trees they are parsed to to change soon.
   ;; For now, additional tests would probably be more annoying than useful.
   )


### PR DESCRIPTION
This PR is a draft because it’s built on top of the commits in PR #102. That PR must be reviewed and merged first. Only the commit “feat(parsing): basic support for URL links” is new to this PR.

## Before

![Athens before support for parsing URL links](https://user-images.githubusercontent.com/79168/83310392-dc0c7300-a1d9-11ea-838f-33329921418b.png)

## After

![Athens after support for parsing URL links](https://user-images.githubusercontent.com/79168/83310396-e0389080-a1d9-11ea-8db1-3aea4460d41c.png)