### PR TITLE
design system: add fallback font and fix some CI test failures

### DIFF
--- a/src/cljs/athens/devcards.cljs
+++ b/src/cljs/athens/devcards.cljs
@@ -1,12 +1,12 @@
 (ns athens.devcards
   (:require
-   [athens.devcards.db]
-   [athens.devcards.sci-boxes]
-   [athens.devcards.style-guide]
-   [cljsjs.react]
-   [cljsjs.react.dom]
-   [devcards.core :as devcards :include-macros true :refer [defcard]]
-   [reagent.core :as r :include-macros true]))
+    [athens.devcards.db]
+    [athens.devcards.sci-boxes]
+    [athens.devcards.style-guide]
+    [cljsjs.react]
+    [cljsjs.react.dom]
+    [devcards.core :as devcards :include-macros true :refer [defcard]]
+    [reagent.core :as r :include-macros true]))
 
 
 (def bmi-data (r/atom {:height 180 :weight 80}))

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -1,16 +1,19 @@
 (ns athens.devcards.style-guide
   (:require
-   [athens.style :as s]
-   [cljsjs.react]
-   [cljsjs.react.dom]
-   [devcards.core :refer-macros [defcard defcard-rg]]
-   [garden.core :refer [css]]
-   [garden.stylesheet :refer [at-import]]))
+    [athens.style :as s]
+    [cljsjs.react]
+    [cljsjs.react.dom]
+    [devcards.core :refer-macros [defcard defcard-rg]]
+    [garden.core :refer [css]]
+    #_[garden.stylesheet :refer [at-import]]))
+
 
 (def log js/console.log)
 
+
 (def +flex-center
   (s/with-style {:display "flex" :flex-direction "column" :justify-content "center" :align-items "center"}))
+
 
 (def +flex-space-between
   (s/with-style {:display "flex" :align-items "center" :justify-content "space-between"}))
@@ -22,9 +25,11 @@
         (s/with-style {:background "#E5E5E5"
                        :padding 20})))
 
+
 (def +circle (s/with-style {:width 80
                             :height 80
                             :border-radius 40}))
+
 
 (def colors
   [:blue :orange :red :green
@@ -67,7 +72,9 @@
                   :line-height "16px"
                   :text-transform "uppercase"}])])
 
+
 (def types [:h1 :h2 :h3 :h4 :h5])
+
 
 (defcard-rg Serif-Types
   [:div
@@ -77,6 +84,7 @@
      [:div (+flex-space-between)
       [:span t]
       [t "Welcome to Athens"]])])
+
 
 (defcard Font "Not sure how to import fonts.
 

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -50,7 +50,7 @@
 (defn main-css
   []
   [:style (css
-            [:* {:font-family "IBM Plex Sans"}]
+            [:* {:font-family "IBM Plex Sans, sans-serif"}]
             [:h1 {:font-size "50px"
                   :font-weight 600
                   :line-height "65px"}]

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,14 +1,14 @@
 (ns athens.style
   (:require
-   [garden.core :refer [css]]
-   [garden.selectors :refer [nth-child]]))
+    [garden.core :refer [css]]
+    [garden.selectors :refer [nth-child]]))
 
 ;; Styles for the loading screen
 (defn loading-css
   []
   [:style (css
-           [:body {:font-family "sans-serif"
-                   :font-size "1.3rem"}])])
+            [:body {:font-family "sans-serif"
+                    :font-size "1.3rem"}])])
 
 ;; Styles for the main app.
 (defn main-css
@@ -80,20 +80,24 @@
 
 ;;;;;;;;;;;;;;;; Style Guide ;;;;;;;;;;;;;;;;
 
-(def COLORS {:blue "#0075E1" ;; links          
-             :orange "#F9A132" ;; highlights
-             :red "#D20000" ;; warnings
-             :green "#009E23" ;; confirmation
-             :dark-gray "#322F38" ;; headings
-             :warm-gray "#433F38"  ;; body text
-             :ivory "#EFEDEB" ;; borders and panels
-             :white "#FFFFFF"})
-  
-(def OPACITIES {:100 1
-                :75 0.75
-                :50 0.5
-                :25 0.25
-                :1 0.1})
+(def COLORS
+  {:blue "#0075E1" ;; links          
+   :orange "#F9A132" ;; highlights
+   :red "#D20000" ;; warnings
+   :green "#009E23" ;; confirmation
+   :dark-gray "#322F38" ;; headings
+   :warm-gray "#433F38"  ;; body text
+   :ivory "#EFEDEB" ;; borders and panels
+   :white "#FFFFFF"})
+
+
+(def OPACITIES
+  {:100 1
+   :75 0.75
+   :50 0.5
+   :25 0.25
+   :1 0.1})
+
 
 (def HEADERS)
 
@@ -101,11 +105,14 @@
 (def +blue-bg
   (with-style {:background (COLORS :blue)}))
 
+
 (def +red-bg
   (with-style {:background (COLORS :red)}))
 
+
 (def +orange-bg
   (with-style {:background (COLORS :orange)}))
+
 
 (def +green-bg
   (with-style {:background (COLORS :green)}))


### PR DESCRIPTION
I see you’re developing devcards in this `design-system` branch. I wasn’t sure how to view these devcards in the browser, so my CSS change in the first commit was made blind. Please add instructions for opening the devcards to `CONTRIBUTING.md` at some point.

In my second commit, I fixed `script/style` and `script/lint`, but I didn’t fix `script/carve` since I’m not sure whether you want to ignore the unused variables (e.g. `OPACITIES`) or wait until code is added that uses them.