### PR TITLE
chore: Add with-attributes to clean up attributes

### DIFF
--- a/src/cljc/athens/lib/dom/attributes.cljc
+++ b/src/cljc/athens/lib/dom/attributes.cljc
@@ -40,7 +40,8 @@
   (def +heavily-styled
     (comp
      (with-classes "strong" "happy")
-     (with-style {:color :green})))
+     (with-style {:color :green
+                  :background :white})))
 
   ;; Usage:
 
@@ -72,18 +73,11 @@
                          map-or-fn)
 
               :else
-              (throw (ex-info (str "Expected map or function, got " (class map-or-fn))
-                              {:attributes attributes}))))
+              (throw (ex-info (str "Expected map or function") {:value map-or-fn}))))
           {} attributes))
 
 
 (comment
-
-  (def +heavily-styled
-    (comp
-     (with-classes "strong" "happy")
-     (with-style {:color :green
-                  :background :white})))
 
   (with-attributes
     +heavily-styled

--- a/src/cljc/athens/lib/dom/attributes.cljc
+++ b/src/cljc/athens/lib/dom/attributes.cljc
@@ -47,7 +47,7 @@
 
   [:h1 (+heavily-styled) "some statement"]
 
-  [:h1 (+heavily-styled {:on-click (fn [_e] (js/alert "something else"))}) "some statement"]
+  [:h1 (+heavily-styled {:on-click (fn [_e] #_(js/alert "something else"))}) "some statement"]
 
   )
 
@@ -82,18 +82,13 @@
   (def +heavily-styled
     (comp
      (with-classes "strong" "happy")
-     (with-style {:color :green})))
-
-
-  (def +heavily-styled
-    (comp
-     (with-classes "strong" "happy")
-     (with-style {:color :green})))
-
+     (with-style {:color :green
+                  :background :white})))
 
   (with-attributes
     +heavily-styled
     {:class "foo bar"}
-    {:class "baz poo"} ;;
+    {:class "baz poo"}
+    {:style {:color :red}}
     )
   )

--- a/src/cljc/athens/lib/dom/attributes.cljc
+++ b/src/cljc/athens/lib/dom/attributes.cljc
@@ -1,0 +1,99 @@
+(ns athens.lib.dom.attributes
+  (:require
+    [clojure.string]))
+
+
+(defn merge-dom-classes
+  [attrs dom-classes]
+  (let [class-str (if (string? dom-classes)
+                    dom-classes
+                    (clojure.string/join " " dom-classes))]
+    (update attrs :class (fn [s]
+                           (if s
+                             (str s " " class-str)
+                             class-str)))))
+
+
+(defn with-classes
+  [& dom-classes]
+  (fn f
+    ([] (f nil))
+    ([attrs]
+     (merge-dom-classes attrs dom-classes))))
+
+
+(defn merge-styles
+  [attrs styles]
+  (update attrs :style merge styles))
+
+
+(defn with-style
+  [styles]
+  (fn f
+    ([] (f nil))
+    ([attrs] (merge-styles attrs styles))))
+
+
+(comment
+
+  ;; Combine with-classes and with-style
+  (def +heavily-styled
+    (comp
+     (with-classes "strong" "happy")
+     (with-style {:color :green})))
+
+  ;; Usage:
+
+
+  [:h1 (+heavily-styled) "some statement"]
+
+  [:h1 (+heavily-styled {:on-click (fn [_e] (js/alert "something else"))}) "some statement"]
+
+  )
+
+
+(defn with-attributes
+  [& attributes]
+  (reduce (fn [acc map-or-fn]
+            (cond
+              (fn? map-or-fn)
+              (map-or-fn acc)
+
+              (map? map-or-fn)
+              (reduce-kv (fn [acc0 attribute v]
+                           (case attribute
+                             :style (merge-styles      acc0 v)
+                             :class (merge-dom-classes acc0 v)
+
+                             ;; Potentially override whatever is there
+                             ;;  (e.g. we cannot merge on-change handlers)
+                             (assoc acc0 attribute v)))
+                         acc
+                         map-or-fn)
+
+              :else
+              (throw (ex-info (str "Expected map or function, got " (class map-or-fn))
+                              {:attributes attributes}))))
+          {} attributes))
+
+
+(comment
+
+  (def +heavily-styled
+    (comp
+     (with-classes "strong" "happy")
+     (with-style {:color :green})))
+
+
+  (def +heavily-styled
+    (comp
+     (with-classes "strong" "happy")
+     (with-style {:color :green})))
+
+
+  (with-attributes
+    +heavily-styled
+    {:class "foo bar"}
+    {:class "baz poo"} ;;
+    )
+  )

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,5 +1,6 @@
 (ns athens.style
   (:require
+    [athens.lib.dom.attributes :refer [with-classes with-style]]
     [garden.core :refer [css]]
     [garden.selectors :refer [nth-child]]))
 
@@ -28,40 +29,6 @@
          {:padding 0
           :margin 0
           :list-style-type "none"}])])
-
-
-(defn with-classes
-  [& css-classes]
-  (fn f
-    ([] (f nil))
-    ([attrs]
-     (update attrs :class (partial str " ") (clojure.string/join " " css-classes)))))
-
-
-(defn with-style
-  [css-styling]
-  (fn f
-    ([] (f nil))
-    ([attrs]
-     (update attrs :style merge css-styling))))
-
-
-(comment
-
-  ;; Combine with-classes and with-style
-  (def +heavily-styled
-    (comp
-     (with-classes "strong" "happy")
-     (with-style {:color :green})))
-
-  ;; Usage:
-
-
-  [:h1 (+heavily-styled) "some statement"]
-
-  [:h1 (+heavily-styled {:on-click (fn [_e] (js/alert "something else"))}) "some statement"]
-
-  )
 
 
 ;; Functions that add styles to an element. Prefer to directly add styles when possible, otherwise

--- a/test/athens/lib/dom/attributes_test.cljc
+++ b/test/athens/lib/dom/attributes_test.cljc
@@ -1,0 +1,43 @@
+(ns athens.lib.dom.attributes-test
+  (:require
+    [athens.lib.dom.attributes :refer [with-attributes with-classes with-style]]
+    [clojure.test :refer [deftest is are]]))
+
+
+(def +heavily-styled
+  (comp
+    (with-classes "strong" "happy")
+    (with-style {:color :green
+                 :background :white})))
+
+
+(deftest attributes-test
+  (are [x y z] (= (with-attributes x y) z)
+
+    {:class "foo bar"}
+    {:class "baz poo"}
+    {:class "foo bar baz poo"}
+
+    {:class "foo bar"}
+    {:class ["baz" "poo"]}
+    {:class "foo bar baz poo"}
+
+    {:class "foo bar"}
+    {:style {:color :green}}
+    {:class "foo bar"
+     :style {:color :green}}
+
+    {:class "foo bar"}
+    {:something-else {:color :green}}
+    {:class "foo bar"
+     :something-else {:color :green}}
+
+    {:something-else 1}
+    {:something-else 2}
+    {:something-else 2}
+
+    +heavily-styled
+    {:style {:color :red}}
+    {:class "strong happy"
+     :style {:color :red
+             :background :white}}))


### PR DESCRIPTION
@tangjeff0 What do you think about this? It should make combining styles, classes and later other things like event listeners much cleaner (see #111)

I'm thinking about adding specialized key listeners in the same like `:on-keypress {:ESC (fn [event] )}` later. This will help implement #64 