### PR TITLE
feat(parsing): more accurately parse block-ref, hashtag, and url-link-url

### DIFF
--- a/src/cljc/athens/parser.cljc
+++ b/src/cljc/athens/parser.cljc
@@ -18,13 +18,18 @@
    
    page-link = <'[['> any-chars <']]'>
    
-   block-ref = <'(('> any-chars <'))'>
+   block-ref = <'(('> #'[a-zA-Z0-9_\\-]+' <'))'>
    
-   hashtag = <'#'> any-chars | <'#'> <'[['> any-chars <']]'>
+   hashtag = hashtag-bare | hashtag-delimited
+   <hashtag-bare> = <'#'> #'[\\p{L}\\p{M}\\p{N}_]+'  (* Unicode: L = letters, M = combining marks, N = numbers *)
+   <hashtag-delimited> = <'#'> <'[['> #'[^\\]]+' <']]'>
    
    url-link = url-link-text url-link-url
    <url-link-text> = <'['> any-chars <']'>
-   <url-link-url> = <'('> any-chars <')'>
+   <url-link-url> = <'('> url-link-url-parts <')'>
+   url-link-url-parts = url-link-url-part+
+   <url-link-url-part> = (backslash-escaped-paren | '(' url-link-url-part* ')') / any-char
+   <backslash-escaped-paren> = <'\\\\'> ('(' | ')')
    
    bold = <'**'> any-chars <'**'>
    
@@ -55,13 +60,15 @@
   "Transforms the Instaparse output tree to an abstract syntax tree for Athens markup."
   [tree]
   (insta/transform
-    {:block      (fn [& raw-contents]
-                    ;; use combine-adjacent-strings to collapse individual characters from any-char into one string
-                   (into [:block] (combine-adjacent-strings raw-contents)))
-     :url-link   (fn [text url]
-                   [:url-link {:url url} text])
-     :any-chars  (fn [& chars]
-                   (clojure.string/join chars))}
+    {:block               (fn [& raw-contents]
+                             ;; use combine-adjacent-strings to collapse individual characters from any-char into one string
+                            (into [:block] (combine-adjacent-strings raw-contents)))
+     :url-link            (fn [text url]
+                            [:url-link {:url url} text])
+     :url-link-url-parts  (fn [& chars]
+                            (clojure.string/join chars))
+     :any-chars           (fn [& chars]
+                            (clojure.string/join chars))}
     tree))
 
 


### PR DESCRIPTION
I replaced `any-chars` with more specific rules and then added tests for those rules. I also added tests for the untested parser rules `block-ref` and `bold`.

I based `url-link-url`’s escaping rules off [CommonMark’s escaping rules for links](https://spec.commonmark.org/0.29/#links). Roam doesn’t implement those escaping rules, but I think they should be implemented. There are some links in the sample database `data/athens.datoms`, e.g. `[Syncope](https://en.wikipedia.org/wiki/Syncope_(medicine))`, that are parsed incorrectly in Roam and are now parsed correctly in Athens.

The uses of `any-chars` I replaced were all of the uses that represented limited, non-generically-formattable text. The remaining uses of `any-chars` in the current parser will need to support recursive formatting such as bold text.

When viewing the diff on GitHub, you can hide the lines whose only changes were to indentation by [adding `?w=1` to the URL][whitespace-ignored-diff]. The last hunk of changes in `src/cljc/athens/parser.cljc` will be easier to read that way.

[whitespace-ignored-diff]: https://github.com/athensresearch/athens/pull/124/files?w=1