### PR TITLE
feat(parsing): parse formatting syntax within url-link-text

### DIFF
--- a/test/athens/parser_test.clj
+++ b/test/athens/parser_test.clj
@@ -51,6 +51,15 @@
     [:block [:url-link {:url "https://example.com/"} "an example"]]
     "[an example](https://example.com/)"
 
+    [:block [:url-link {:url "https://example.com/"} [:bold "bold"] " inside"]]
+    "[**bold** inside](https://example.com/)"
+
+    [:block [:url-link {:url "https://example.com/"} "no #hashtag or [[link]] inside"]]
+    "[no #hashtag or [[link]] inside](https://example.com/)"
+
+    [:block [:url-link {:url "https://example.com/"} "escaped ](#not-a-link)"]]
+    "[escaped \\](#not-a-link)](https://example.com/)"
+
     [:block [:url-link {:url "https://subdomain.example.com/path/page.html?query=very%20**bold**&p=5#top"} "example"]]
     "[example](https://subdomain.example.com/path/page.html?query=very%20**bold**&p=5#top)"
 
@@ -64,7 +73,17 @@
     "[escaped )()](https://example.com/close\\)open\\(close\\))"
 
     [:block [:url-link {:url "https://example.com/close)open(close)"} "combining escaping and nesting"]]
-    "[combining escaping and nesting](https://example.com/close\\)open(close))"))
+    "[combining escaping and nesting](https://example.com/close\\)open(close))"
+
+    [:block
+     "Multiple "
+     [:url-link {:url "https://example.com/a"} "links"]
+     " "
+     [:url-link {:url "#b"} "are detected"]
+     " as "
+     [:url-link {:url "https://example.com/c"} "separate"]
+     "."]
+    "Multiple [links](https://example.com/a) [are detected](#b) as [separate](https://example.com/c)."))
 
 
 (deftest combine-adjacent-strings-tests


### PR DESCRIPTION
Allow writing bold-formatted text in a link with `**foo**`, or writing a literal `]` with `\]`.

As the parsing of more formatting syntax such as `~~strikethrough~~` is implemented, this parse rule might need to be updated to accept that syntax as well. Only some of the new syntax will be allowed in link text.

The backslash-escaping was taken from Markdown. Roam doesn’t support that syntax (yet?), but I think Athens should.

[Add `?w=1` to the GitHub diff URL](https://github.com/athensresearch/athens/pull/127/files?w=1) to hide the whitespace-only changes in the second hunk of `src/cljc/athens/parser.cljc`.