### PR TITLE
refactor(icons): show macro and styling examples in devcard

### DIFF
--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -26,16 +26,17 @@
    [:> mui-icons/DirectionsTwoTone]
    [:> mui-icons/DirectionsSharp]])
 
+
 (defcard-rg Styling-icons
   "Color, opacity, and other properties can be applied to icons by placing them in an element with those styles applied."
   [:div
-    [:span (with-styles {:color (:link-color COLORS)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:color (:highlight-color COLORS)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:color (:warning-color COLORS)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:color (:confirmation-color COLORS)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:color (:body-text-color COLORS)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:opacity (nth OPACITIES 0)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:opacity (nth OPACITIES 1)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:opacity (nth OPACITIES 2)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:opacity (nth OPACITIES 3)}) (r/create-element mui-icons/Face)]
-    [:span (with-styles {:color (:body-text-color COLORS)}) (r/create-element mui-icons/Face)]])
+   [:span (with-styles {:color (:link-color COLORS)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:color (:highlight-color COLORS)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:color (:warning-color COLORS)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:color (:confirmation-color COLORS)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:color (:body-text-color COLORS)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:opacity (nth OPACITIES 0)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:opacity (nth OPACITIES 1)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:opacity (nth OPACITIES 2)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:opacity (nth OPACITIES 3)}) (r/create-element mui-icons/Face)]
+   [:span (with-styles {:color (:body-text-color COLORS)}) (r/create-element mui-icons/Face)]])

--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -2,6 +2,8 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db]
+    [athens.lib.dom.attributes :refer [with-styles with-attributes]]
+    [athens.style :refer [COLORS OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -15,11 +17,25 @@
    [:> mui-icons/Search]])
 
 
-(defcard-rg Icon-Styles
-  "Use different icon styles by appending one of Outlined, Rounded, TwoTone, or Sharp."
+(defcard-rg Icon-Types
+  "Use the different built-in icon types by appending one of `Outlined`, `Rounded`, `TwoTone`, or `Sharp` to the icon name."
   [:div
    [:> mui-icons/Directions]
    [:> mui-icons/DirectionsOutlined]
    [:> mui-icons/DirectionsRounded]
    [:> mui-icons/DirectionsTwoTone]
    [:> mui-icons/DirectionsSharp]])
+
+(defcard-rg Styling-icons
+  "Color, opacity, and other properties can be applied to icons by placing them in an element with those styles applied."
+  [:div
+    [:span (with-styles {:color (:link-color COLORS)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:color (:highlight-color COLORS)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:color (:warning-color COLORS)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:color (:confirmation-color COLORS)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:color (:body-text-color COLORS)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:opacity (nth OPACITIES 0)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:opacity (nth OPACITIES 1)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:opacity (nth OPACITIES 2)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:opacity (nth OPACITIES 3)}) (r/create-element mui-icons/Face)]
+    [:span (with-styles {:color (:body-text-color COLORS)}) (r/create-element mui-icons/Face)]])

--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -10,16 +10,16 @@
 
 (defcard-rg Standard-Icons
   [:div
-   [:span (r/create-element mui-icons/Face)]
-   [:span (r/create-element mui-icons/Settings)]
-   [:span (r/create-element mui-icons/Search)]])
+   [:> mui-icons/Face]
+   [:> mui-icons/Settings]
+   [:> mui-icons/Search]])
 
 
 (defcard-rg Icon-Styles
   "Use different icon styles by appending one of Outlined, Rounded, TwoTone, or Sharp."
   [:div
-   [:span (r/create-element mui-icons/Directions)]
-   [:span (r/create-element mui-icons/DirectionsOutlined)]
-   [:span (r/create-element mui-icons/DirectionsRounded)]
-   [:span (r/create-element mui-icons/DirectionsTwoTone)]
-   [:span (r/create-element mui-icons/DirectionsSharp)]])
+   [:> mui-icons/Directions]
+   [:> mui-icons/DirectionsOutlined]
+   [:> mui-icons/DirectionsRounded]
+   [:> mui-icons/DirectionsTwoTone]
+   [:> mui-icons/DirectionsSharp]])

--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db]
-    [athens.lib.dom.attributes :refer [with-styles with-attributes]]
+    [athens.lib.dom.attributes :refer [with-styles]]
     [athens.style :refer [COLORS OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]


### PR DESCRIPTION
- Use macro for simpler syntax where possible
- Provide examples of icons styled with design system properties