### PR TITLE
refactor(styles): use stylefy

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,8 @@
                  [instaparse "1.4.10"]
                  [devcards "0.2.6"]
                  [borkdude/sci "0.0.13-alpha.22"]
-                 [garden "1.3.10"]]
+                 [garden "1.3.10"]
+                 [stylefy "2.2.0"]]
 
   :plugins [[lein-shell "0.5.0"]]
 

--- a/resources/public/cards.html
+++ b/resources/public/cards.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans+Condensed:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Serif:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
     <title>Athens DevCards</title>
+    <style id="_stylefy-constant-styles_"></style>
+    <style id="_stylefy-styles_"></style>
   </head>
   <body>
     <div id="app"></div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -4,6 +4,8 @@
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width,initial-scale=1">
       <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans+Condensed:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Serif:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
+      <style id="_stylefy-constant-styles_"></style>
+      <style id="_stylefy-styles_"></style>
   </head>
   <body>
     <div id="app">

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -9,7 +9,8 @@
     [athens.views :as views]
     [re-frame.core :as rf]
     #_[re-posh.core :as rp]
-    [reagent.core :as reagent]))
+    [reagent.core :as reagent]
+    [stylefy.core :as stylefy]))
 
 
 (defn dev-setup
@@ -28,6 +29,7 @@
 
 (defn init
   []
+  (stylefy/init)
   (rf/dispatch-sync [:init-rfdb])
   ;; when dev, download datoms directly
   ;; FIXME without this dispatch nothing works, so enabling it for now

--- a/src/cljs/athens/devcards.cljs
+++ b/src/cljs/athens/devcards.cljs
@@ -11,9 +11,11 @@
     [athens.devcards.style-guide]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [devcards.core]))
+    [devcards.core]
+    [stylefy.core :as stylefy]))
 
 
 (defn ^:export main
   []
+  (stylefy/init)
   (devcards.core/start-devcard-ui!))

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -3,7 +3,7 @@
     [athens.devcards.db :refer [new-conn posh-conn! load-real-db-button]]
     [athens.lib.dom.attributes :refer [with-styles with-attributes]]
     [athens.router :refer [navigate-page]]
-    [athens.style :as style :refer [style-guide-css +text-align-right +text-align-left +link]]
+    [athens.style :as style :refer [base-styles +text-align-right +text-align-left +link]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard defcard-rg]]
@@ -12,7 +12,7 @@
 
 
 (defcard-rg Import-Styles
-  [style-guide-css])
+  [base-styles])
 
 
 (defcard-rg Modify-Devcards

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -5,7 +5,7 @@
     [athens.events]
     [athens.lib.dom.attributes :refer [with-attributes with-styles]]
     [athens.router :refer [navigate-page]]
-    [athens.style :refer [style-guide-css +flex-space-between +depth-64]]
+    [athens.style :refer [base-styles +flex-space-between +depth-64]]
     [athens.subs]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -16,7 +16,7 @@
 
 
 (defcard-rg Import-Styles
-  [style-guide-css])
+  [base-styles])
 
 
 (defcard-rg Instantiate-app-db

--- a/src/cljs/athens/devcards/buttons.cljs
+++ b/src/cljs/athens/devcards/buttons.cljs
@@ -1,23 +1,58 @@
 (ns athens.devcards.buttons
   (:require
+    ["@material-ui/icons" :as mui-icons]
     [athens.db]
-    [athens.style :refer [style-guide-css]]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [devcards.core :refer-macros [defcard-rg]]))
+    [devcards.core :refer-macros [defcard-rg]]
+    [garden.selectors :as selectors]
+    [stylefy.core :as stylefy :refer [use-style]]))
 
 
-(defcard-rg Import-Styles
-  [style-guide-css])
+
+
+
+(def buttons {:cursor "pointer"
+              :padding          "6px 10px"
+              :border-radius    "4px"
+              :font-weight      "500"
+              :font-family      "IBM Plex Sans"
+              :border           "none"
+              :display          "inline-flex"
+              :align-self       "flex-start"
+              :align-items      "center"
+              :color            "rgba(50, 47, 56, 1)"
+              :background-color "transparent"
+              ::stylefy/mode [[:hover {:background-color "#EFEDEB"}]
+                              [:active {:color "rgba(0, 117, 225)"
+                                        :background-color "rgba(0, 117, 225, 0.1)"}]
+                              [:disabled {:color "rgba(0, 0, 0, 0.3)"
+                                          :background-color "#EFEDEB"
+                                          :cursor "default"}]]
+              ::stylefy/manual [[:svg {:font-size "145%"
+                                       :vertical-align "-0.05em"}
+                                 [(selectors/& (selectors/not (selectors/last-child))) {:margin-inline-end "0.251em"}]
+                                 [(selectors/& (selectors/not (selectors/first-child))) {:margin-inline-start "0.251em"}]]]})
+
+(def buttons-primary (merge buttons {:color "rgba(0, 117, 225)"
+                           :background-color "rgba(0, 117, 225, 0.1)"
+                           ::stylefy/mode [
+                             [:hover {:background-color "rgba(0, 117, 225, 0.25)"}]
+                             [:active {:color "white"
+                                       :background-color "rgba(0, 117, 225, 1)"}]]}))
 
 
 (defcard-rg Button
-  [:button "Press Me"])
+  [:div
+    [:button (use-style buttons) [:> mui-icons/Face]]
+    [:button (use-style buttons) [:span "Press Me"]]
+    [:button (use-style buttons) [:> mui-icons/Face] [:span "Press Me"]]
+    [:button (use-style buttons) [:span "Press Me"] [:> mui-icons/Face]]])
 
 
 (defcard-rg Disabled-Button
-  [:button {:disabled true} "Disabled"])
+  [:button (use-style buttons {:disabled true}) "Disabled"])
 
 
 (defcard-rg Primary-Button
-  [:button.primary "Press Me"])
+  [:button.primary (use-style buttons-primary) "Press Me"])

--- a/src/cljs/athens/devcards/buttons.cljs
+++ b/src/cljs/athens/devcards/buttons.cljs
@@ -9,45 +9,44 @@
     [stylefy.core :as stylefy :refer [use-style]]))
 
 
+(def buttons
+  {:cursor "pointer"
+   :padding          "6px 10px"
+   :border-radius    "4px"
+   :font-weight      "500"
+   :font-family      "IBM Plex Sans"
+   :border           "none"
+   :display          "inline-flex"
+   :align-self       "flex-start"
+   :align-items      "center"
+   :color            "rgba(50, 47, 56, 1)"
+   :background-color "transparent"
+   ::stylefy/mode [[:hover {:background-color "#EFEDEB"}]
+                   [:active {:color "rgba(0, 117, 225)"
+                             :background-color "rgba(0, 117, 225, 0.1)"}]
+                   [:disabled {:color "rgba(0, 0, 0, 0.3)"
+                               :background-color "#EFEDEB"
+                               :cursor "default"}]]
+   ::stylefy/manual [[:svg {:font-size "145%"
+                            :vertical-align "-0.05em"}
+                      [(selectors/& (selectors/not (selectors/last-child))) {:margin-inline-end "0.251em"}]
+                      [(selectors/& (selectors/not (selectors/first-child))) {:margin-inline-start "0.251em"}]]]})
 
 
-
-(def buttons {:cursor "pointer"
-              :padding          "6px 10px"
-              :border-radius    "4px"
-              :font-weight      "500"
-              :font-family      "IBM Plex Sans"
-              :border           "none"
-              :display          "inline-flex"
-              :align-self       "flex-start"
-              :align-items      "center"
-              :color            "rgba(50, 47, 56, 1)"
-              :background-color "transparent"
-              ::stylefy/mode [[:hover {:background-color "#EFEDEB"}]
-                              [:active {:color "rgba(0, 117, 225)"
-                                        :background-color "rgba(0, 117, 225, 0.1)"}]
-                              [:disabled {:color "rgba(0, 0, 0, 0.3)"
-                                          :background-color "#EFEDEB"
-                                          :cursor "default"}]]
-              ::stylefy/manual [[:svg {:font-size "145%"
-                                       :vertical-align "-0.05em"}
-                                 [(selectors/& (selectors/not (selectors/last-child))) {:margin-inline-end "0.251em"}]
-                                 [(selectors/& (selectors/not (selectors/first-child))) {:margin-inline-start "0.251em"}]]]})
-
-(def buttons-primary (merge buttons {:color "rgba(0, 117, 225)"
-                           :background-color "rgba(0, 117, 225, 0.1)"
-                           ::stylefy/mode [
-                             [:hover {:background-color "rgba(0, 117, 225, 0.25)"}]
-                             [:active {:color "white"
-                                       :background-color "rgba(0, 117, 225, 1)"}]]}))
+(def buttons-primary
+  (merge buttons {:color "rgba(0, 117, 225)"
+                  :background-color "rgba(0, 117, 225, 0.1)"
+                  ::stylefy/mode [[:hover {:background-color "rgba(0, 117, 225, 0.25)"}]
+                                  [:active {:color "white"
+                                            :background-color "rgba(0, 117, 225, 1)"}]]}))
 
 
 (defcard-rg Button
   [:div
-    [:button (use-style buttons) [:> mui-icons/Face]]
-    [:button (use-style buttons) [:span "Press Me"]]
-    [:button (use-style buttons) [:> mui-icons/Face] [:span "Press Me"]]
-    [:button (use-style buttons) [:span "Press Me"] [:> mui-icons/Face]]])
+   [:button (use-style buttons) [:> mui-icons/Face]]
+   [:button (use-style buttons) [:span "Press Me"]]
+   [:button (use-style buttons) [:> mui-icons/Face] [:span "Press Me"]]
+   [:button (use-style buttons) [:span "Press Me"] [:> mui-icons/Face]]])
 
 
 (defcard-rg Disabled-Button

--- a/src/cljs/athens/devcards/db_boxes.cljs
+++ b/src/cljs/athens/devcards/db_boxes.cljs
@@ -2,7 +2,7 @@
   (:require
     [athens.db :as db]
     [athens.lib.dom.attributes :refer [with-styles]]
-    [athens.style :refer [style-guide-css]]
+    [athens.style :refer [base-styles]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [<!]]
     [cljsjs.react]
@@ -23,7 +23,7 @@
 
 
 (defcard-rg Import-Styles
-  [style-guide-css])
+  [base-styles])
 
 
 (defcard "

--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -5,7 +5,7 @@
     [athens.devcards.db :refer [new-conn posh-conn!]]
     [athens.lib.dom.attributes :refer [with-styles with-attributes]]
     [athens.router :refer [navigate navigate-page]]
-    [athens.style :refer [style-guide-css +link +flex-column +flex-space-between +width-100]]
+    [athens.style :refer [base-styles +link +flex-column +flex-space-between +width-100]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard-rg]]
@@ -15,7 +15,7 @@
 
 
 (defcard-rg Import-Styles
-  [style-guide-css])
+  [base-styles])
 
 
 (defcard-rg Instantiate-Dsdb)

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -5,7 +5,7 @@
     [athens.style :refer [+flex-center +flex-space-between +flex-space-around +flex-column +flex-wrap
                           +text-shadow +box-shadow
                           +link-bg
-                          style-guide-css COLORS OPACITIES]]
+                          base-styles COLORS OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]))
@@ -19,7 +19,7 @@
 
 (defcard-rg Import-Styles
   "CSS is imported here"
-  [style-guide-css])
+  [base-styles])
 
 
 (defcard-rg Colors

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -2,7 +2,7 @@
   (:require
     [athens.lib.dom.attributes :refer [with-styles]]
     [garden.color :refer [opacify hex->hsl]]
-    [garden.core :refer [css]])
+    [garden.core :refer [css]]))
 
 
 (def COLORS

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -2,8 +2,7 @@
   (:require
     [athens.lib.dom.attributes :refer [with-styles]]
     [garden.color :refer [opacify hex->hsl]]
-    [garden.core :refer [css]]
-    [stylefy.core :as stylefy]))
+    [garden.core :refer [css]])
 
 
 (def COLORS

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -131,33 +131,6 @@
             [:tbody
              [:tr
               [:&:hover {:background-color (opacify (:panel-color HSL-COLORS) (first OPACITIES))}]]]
-            [:button :.input-file {:cursor           "pointer"
-                                   :padding          "6px 10px"
-                                   :border-radius    "4px"
-                                   :font-weight      "500"
-                                   :border           "none"
-                                   :display          "inline-flex"
-                                   :align-items      "center"
-                                   :color            "rgba(50, 47, 56, 1)"
-                                   :background-color "transparent"}
-             [:&:disabled {:color "rgba(0, 0, 0, 0.3)"
-                           :background-color "#EFEDEB"
-                           :cursor "default"}]
-             [:&:hover {:background-color "#EFEDEB"}]
-             [:&:active {:color            "rgba(0, 117, 225)"
-                         :background-color "rgba(0, 117, 225, 0.1)"}]
-             [:&.primary {:color            "rgba(0, 117, 225)"
-                          :background-color "rgba(0, 117, 225, 0.1)"}
-              [:&:hover {:background-color "rgba(0, 117, 225, 0.25)"}]
-              [:&:active {:color "white"
-                          :background-color "rgba(0, 117, 225, 1)"}]]
-             [:svg {:font-size "145%"
-                    :vertical-align "-0.05em"}
-              [(s/& (s/not (s/last-child))) {:margin-inline-end "0.251em"}]
-              [(s/& (s/not (s/first-child))) {:margin-inline-start "0.251em"}]]]
-            [:.MuiSvgIcon-root {:font-size "145%"
-                                :vertical-align "-0.05em"
-                                :line-height "inherit"}]
             [:.athena-result {:display "flex"
                               :padding "12px 32px 12px 32px"
                               :border-top "1px solid rgba(67, 63, 56, 0.2)"}

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -3,7 +3,7 @@
     [athens.lib.dom.attributes :refer [with-styles]]
     [garden.color :refer [opacify hex->hsl]]
     [garden.core :refer [css]]
-    [garden.selectors :as s]))
+    [stylefy.core :as stylefy]))
 
 
 (def COLORS
@@ -94,15 +94,14 @@
 
 ;; Style Guide
 
-
-(defn style-guide-css
+(defn base-styles
   []
   [:style (css
             [:body {:margin 0
+                    :font-family "IBM Plex Sans, Sans-Serif"
                     :font-size "16px"
                     :line-height "32px"}]
-            [:* {:font-family "IBM Plex Sans, Sans-Serif"
-                 :box-sizing "border-box"}]
+            [:* {:box-sizing "border-box"}]
             [:p :span {:color (:body-text-color COLORS)}]
             [:h1 :h2 :h3 :h4 :h5 :h6 {:margin "0.2em 0"
                                       :color (:header-text-color COLORS)}]

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -62,14 +62,14 @@
         loading (subscribe [:loading])]
     (fn []
       [:<>
-       [style/style-guide-css]
+       [style/base-styles]
        [alert]
        [athena db/dsdb]
        (if @loading
          [:h1 (with-styles {:margin-top "50vh" :text-align "center" :opacity "0.9"}) "Loading Athens 😈"]
          [:div
           (with-styles {:display "flex" :height "100vh"})
-          [style/style-guide-css]
+          [style/base-styles]
           [left-sidebar db/dsdb]
           [:div
            (with-styles {:flex "1 1 100%" :overflow-y "auto"})

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,11 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
+
 anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
@@ -526,6 +531,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-parse@1.7.x:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-1.7.0.tgz#321f6cf73782a6ff751111390fc05e2c657d8c9b"
+  integrity sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=
+
 css-vendor@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
@@ -549,6 +559,13 @@ date-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
   integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
 
+debug@*, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -560,13 +577,6 @@ debug@^3.0.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -853,6 +863,18 @@ glob-parent@~5.1.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
+
+glob@7.0.x:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  integrity sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.3:
   version "7.1.6"
@@ -1217,6 +1239,21 @@ karma@^4.4.1:
     tmp "0.0.33"
     useragent "2.3.0"
 
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
+lodash.merge@^4.6.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
 lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -1319,7 +1356,7 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-mkdirp@^0.5.1:
+mkdirp@0.5.x, mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -1480,6 +1517,11 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 pbkdf2@^3.0.3:
   version "3.0.17"
@@ -1677,7 +1719,7 @@ react@16.9.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -1711,6 +1753,13 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resolve@^1.1.5:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
 
 rfdc@^1.1.4:
   version "1.1.4"
@@ -1746,6 +1795,11 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@0.5.x:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
+  integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
 scheduler@^0.15.0:
   version "0.15.0"
@@ -1851,6 +1905,13 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map@0.1.x:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -1926,6 +1987,39 @@ strip-url-auth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
   integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
+
+stylify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/stylify/-/stylify-1.4.0.tgz#9c54dcbc0303ed02ac95df9c03eebacf4dbb809a"
+  integrity sha1-nFTcvAMD7QKsld+cA+66z027gJo=
+  dependencies:
+    glob "^7.1.1"
+    lodash.flatten "^4.4.0"
+    lodash.merge "^4.6.0"
+    lodash.uniq "^4.5.0"
+    resolve "^1.1.5"
+    stylus "0.54.5"
+    through2 "^2.0.0"
+
+stylus@0.54.5:
+  version "0.54.5"
+  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.5.tgz#42b9560931ca7090ce8515a798ba9e6aa3d6dc79"
+  integrity sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=
+  dependencies:
+    css-parse "1.7.x"
+    debug "*"
+    glob "7.0.x"
+    mkdirp "0.5.x"
+    sax "0.5.x"
+    source-map "0.1.x"
+
+through2@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
 
 timers-browserify@^2.0.4:
   version "2.0.11"
@@ -2099,7 +2193,7 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
### What This Is
A trial refactor of Stylefy, attempting to prove out its use for better creation of component styles.

Check out the buttons devcard to see it in use. Other pages are broken by the refactor, but if this direction is acceptable the next steps will be to:
1. Update other components to use Stylefy rather than the base stylesheet for styles
2. Refactor reusable components such as Button to function more like styled components.


**Changes**
- Adds Stylefy
- Renames `style-guide-css` to `base-styles` to more accurately describe their current use
- Refactors Button component, removing styles from `style-guide-css` and implementing them in the Button devcard.