### PR TITLE
Improve datascript explorer

### DIFF
--- a/src/cljs/athens/devcards/db_boxes.cljs
+++ b/src/cljs/athens/devcards/db_boxes.cljs
@@ -136,7 +136,11 @@
 
 (defcard-rg Modify-Devcards
   "Increase width to 90% for table"
-  [:style (css [:.com-rigsomelight-devcards-container {:width "90%"}])])
+  [:style (css [:.com-rigsomelight-devcards-container {:width "90%"}]
+               [:.com-rigsomelight-devcards_rendered-card {:display "flex";
+                                                           :flex-direction "column-reverse"}])]);
+
+
 
 
 (defn headings


### PR DESCRIPTION
This PR includes two minor additions to the Datascript explorer based on the feedback from @tomisme and @tangjeff0 in #67:

1. Reverse the flexbox direction of the datascript browse card, so the control box (allowing you to go back to earlier states of the card) is on top.
2. Add reverse references when browsing individual entities: this let's you browse "up" the graph.

As always: any feedback is welcome!