### PR TITLE
feat(athena): draft React hooks example, close Athena on click outside

### DIFF
--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
-    [athens.devcards.athena :refer [athena-prompt]]
+    [athens.devcards.athena :refer [athena-prompt-el]]
     [athens.devcards.buttons :refer [button button-primary]]
     [athens.router :refer [navigate navigate-page]]
     [athens.style :refer [color OPACITIES]]
@@ -137,7 +137,7 @@
           ;; IF EXPANDED
           [:div (use-style left-sidebar-style)
            [:div (use-sub-style left-sidebar-style :top-line)
-            [athena-prompt]
+            [athena-prompt-el]
             [button {:on-click-fn #(swap! open? not)
                      :label [:> mui-icons/ChevronLeft]}]]
            [:nav (use-style main-navigation-style)

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -2,7 +2,7 @@
   (:require
     [athens.db :as db]
     [athens.devcards.all-pages :refer [table]]
-    [athens.devcards.athena :refer [athena]]
+    [athens.devcards.athena :refer [athena-component]]
     [athens.devcards.block-page :refer [block-page-component]]
     [athens.devcards.left-sidebar :refer [left-sidebar]]
     [athens.devcards.node-page :refer [node-page-component]]
@@ -107,7 +107,7 @@
     (fn []
       [:<>
        [alert]
-       [athena db/dsdb]
+       [athena-component]
        (if @loading
          [:h1 (use-style loading-message-style) "Loading Athens 😈"]
          [:div (use-style app-wrapper-style)


### PR DESCRIPTION
No plans to merge this in, just wanted to store an example of React refs and hooks.

Ultimately, we will want to control open state of Athena with re-frame, not locally as a React class component OR as a function component.

Will wait until we have key presses setup to return to this.