### PR TITLE
feat(db-boxes): more usable results table

### DIFF
--- a/src/cljs/athens/devcards/db_boxes.cljs
+++ b/src/cljs/athens/devcards/db_boxes.cljs
@@ -1,7 +1,7 @@
 (ns athens.devcards.db-boxes
   (:require
     [athens.db :as db]
-    [athens.style :refer [base-styles]]
+    [athens.style :refer [base-styles COLORS HSL-COLORS]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [<!]]
     [cljsjs.react]
@@ -10,8 +10,10 @@
     [datascript.core :as d]
     [devcards.core :as devcards :refer [defcard defcard-rg]]
     [garden.core :refer [css]]
+    [garden.color :refer [opacify]]
     [reagent.core :as r]
-    [sci.core :as sci])
+    [sci.core :as sci]
+    [stylefy.core :as stylefy :refer [use-style]])
   (:require-macros
     [cljs.core.async.macros :refer [go]]))
 
@@ -330,13 +332,43 @@
     ""))
 
 
+(def table-style {:border-collapse "collapse"
+                  :font-size "12px"
+                  :font-family "IBM Plex Sans Condensed"
+                  :letter-spacing "-0.01em"
+                  :margin "8px 0 0"
+                  :min-width "100%"
+                  ::stylefy/manual [[:td {:border-top (str "1px solid " (:panel-color COLORS))
+                                              :padding "2px"}]
+                                    [:tbody {:vertical-align "top"}]
+                                    [:th {:text-align "left" :padding "2px 2px"}]
+                                    [:tr {:transition "all 0.05s ease"}]
+                                    [:td:first-child :th:first-child {:padding-left "8px"}]
+                                    [:td:last-child :th-last-child {:padding-right "8px"}]
+                                    [:tbody [:tr:hover {:background (opacify (:panel-color HSL-COLORS) 0.15)
+                                                        :color (:header-text-color COLORS)}]]
+                                    [:td>ul {:padding "0"
+                                             :margin "0"
+                                             :list-style "none"}]
+                                    [:td [:li {:margin "0 0 4px"
+                                               :padding-top "4px";
+                                               :border-top (str "1px solid " (:panel-color COLORS))}]]
+                                    [:td [:li:first-child {:border-top "none" :margin-top "0" :padding-top "0"}]]
+                                    [:a {:color (:link-color COLORS)}]
+                                    [:a:hover {:text-decoration "underline"}]
+                                    ]})
+
+
+(def footer-style {:margin "8px 0"
+                   ::stylefy/manual [[:a {:color (:link-color COLORS)}]]})
+
+
 (defn table-view
   [data mode limit]
   (let [hs (headings data mode)
         rows (get-rows data mode)]
-    [:div {:styles {:font-size "12px"
-                    :overflow-x "auto"}}
-     [:table
+    [:div {:style {:overflow-x "auto"}}
+     [:table (use-style table-style)
       [:thead
        [:tr (for [h hs]
               ^{:key (str "heading-" h)}
@@ -383,7 +415,7 @@
 
            :else
            (str result))]
-   [:div (when (and (coll? result)
+   [:div (use-style footer-style) (when (and (coll? result)
                     (not (map? result))
                     (< limit (count result)))
            [:span (str "Showing " limit " out of " (count result) " rows ")

--- a/src/cljs/athens/devcards/db_boxes.cljs
+++ b/src/cljs/athens/devcards/db_boxes.cljs
@@ -9,8 +9,8 @@
     [clojure.string :as str]
     [datascript.core :as d]
     [devcards.core :as devcards :refer [defcard defcard-rg]]
-    [garden.core :refer [css]]
     [garden.color :refer [opacify]]
+    [garden.core :refer [css]]
     [reagent.core :as r]
     [sci.core :as sci]
     [stylefy.core :as stylefy :refer [use-style]])
@@ -332,35 +332,36 @@
     ""))
 
 
-(def table-style {:border-collapse "collapse"
-                  :font-size "12px"
-                  :font-family "IBM Plex Sans Condensed"
-                  :letter-spacing "-0.01em"
-                  :margin "8px 0 0"
-                  :min-width "100%"
-                  ::stylefy/manual [[:td {:border-top (str "1px solid " (:panel-color COLORS))
-                                              :padding "2px"}]
-                                    [:tbody {:vertical-align "top"}]
-                                    [:th {:text-align "left" :padding "2px 2px"}]
-                                    [:tr {:transition "all 0.05s ease"}]
-                                    [:td:first-child :th:first-child {:padding-left "8px"}]
-                                    [:td:last-child :th-last-child {:padding-right "8px"}]
-                                    [:tbody [:tr:hover {:background (opacify (:panel-color HSL-COLORS) 0.15)
-                                                        :color (:header-text-color COLORS)}]]
-                                    [:td>ul {:padding "0"
-                                             :margin "0"
-                                             :list-style "none"}]
-                                    [:td [:li {:margin "0 0 4px"
-                                               :padding-top "4px";
-                                               :border-top (str "1px solid " (:panel-color COLORS))}]]
-                                    [:td [:li:first-child {:border-top "none" :margin-top "0" :padding-top "0"}]]
-                                    [:a {:color (:link-color COLORS)}]
-                                    [:a:hover {:text-decoration "underline"}]
-                                    ]})
+(def table-style
+  {:border-collapse "collapse"
+   :font-size "12px"
+   :font-family "IBM Plex Sans Condensed"
+   :letter-spacing "-0.01em"
+   :margin "8px 0 0"
+   :min-width "100%"
+   ::stylefy/manual [[:td {:border-top (str "1px solid " (:panel-color COLORS))
+                           :padding "2px"}]
+                     [:tbody {:vertical-align "top"}]
+                     [:th {:text-align "left" :padding "2px 2px"}]
+                     [:tr {:transition "all 0.05s ease"}]
+                     [:td:first-child :th:first-child {:padding-left "8px"}]
+                     [:td:last-child :th-last-child {:padding-right "8px"}]
+                     [:tbody [:tr:hover {:background (opacify (:panel-color HSL-COLORS) 0.15)
+                                         :color (:header-text-color COLORS)}]]
+                     [:td>ul {:padding "0"
+                              :margin "0"
+                              :list-style "none"}]
+                     [:td [:li {:margin "0 0 4px"
+                                :padding-top "4px";
+                                :border-top (str "1px solid " (:panel-color COLORS))}]]
+                     [:td [:li:first-child {:border-top "none" :margin-top "0" :padding-top "0"}]]
+                     [:a {:color (:link-color COLORS)}]
+                     [:a:hover {:text-decoration "underline"}]]})
 
 
-(def footer-style {:margin "8px 0"
-                   ::stylefy/manual [[:a {:color (:link-color COLORS)}]]})
+(def footer-style
+  {:margin "8px 0"
+   ::stylefy/manual [[:a {:color (:link-color COLORS)}]]})
 
 
 (defn table-view
@@ -416,12 +417,12 @@
            :else
            (str result))]
    [:div (use-style footer-style) (when (and (coll? result)
-                    (not (map? result))
-                    (< limit (count result)))
-           [:span (str "Showing " limit " out of " (count result) " rows ")
-            [:a {:on-click increase-limit!
-                 :style {:cursor :pointer}}
-             "load more"]])]])
+                                             (not (map? result))
+                                             (< limit (count result)))
+                                    [:span (str "Showing " limit " out of " (count result) " rows ")
+                                     [:a {:on-click increase-limit!
+                                          :style {:cursor :pointer}}
+                                      "load more"]])]])
 
 
 (defn error-component


### PR DESCRIPTION
More usable database browser results table [Demo](https://shanberg.github.io/athens/cards.html#!/athens.devcards.db_boxes)

<img width="1387" alt="Screen Shot 2020-06-13 at 9 21 12 PM" src="https://user-images.githubusercontent.com/98312/84582582-d018d780-adbb-11ea-9f32-b4dac8e8c9da.png">
