### PR TITLE
Refactor opacity

### DIFF
--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -4,11 +4,10 @@
     [athens.devcards.db :refer [new-conn posh-conn! load-real-db-button]]
     [athens.lib.dom.attributes :refer [with-attributes]]
     [athens.router :refer [navigate-page]]
-    [athens.style :as style :refer [base-styles HSL-COLORS COLORS OPACITIES]]
+    [athens.style :as style :refer [base-styles color]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard defcard-rg]]
-    [garden.color :refer [opacify]]
     [garden.core :refer [css]]
     [garden.selectors :as selectors]
     [posh.reagent :refer [transact! pull-many q]]
@@ -55,10 +54,6 @@
     (.toLocaleString  (js/Date. x))))
 
 
-(def table-cell-background-color-hover
-  (opacify (:panel-color HSL-COLORS) (first OPACITIES)))
-
-
 (def tables
   {:width "100%"
    :text-align "left"
@@ -68,7 +63,7 @@
                          :th-title {}
                          :th-body {}
                          :th-date {:text-align "right"}
-                         :td-title {:color (:link-color COLORS)
+                         :td-title {:color (color :link-color)
                                     :width "15vw"
                                     :min-width "10em"
                                     :word-break "break-word"
@@ -89,8 +84,8 @@
                                    :min-width "9em"}}
    ::stylefy/manual [[:tbody {:vertical-align "top"}
                       [:tr
-                       [:td {:border-top (str "1px solid " (:panel-color COLORS))}]
-                       [:&:hover {:background-color table-cell-background-color-hover
+                       [:td {:border-top (str "1px solid " (color :panel-color))}]
+                       [:&:hover {:background-color (color :panel-color :opacity-10)
                                   :border-radius "8px"}
                         [:td [(selectors/& (selectors/first-child)) {:border-radius "8px 0 0 8px"
                                                                      :box-shadow "-16px 0 hsla(30, 11.11%, 93%, 0.1)"}]]

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -4,7 +4,7 @@
     [athens.devcards.db :refer [new-conn posh-conn! load-real-db-button]]
     [athens.lib.dom.attributes :refer [with-attributes]]
     [athens.router :refer [navigate-page]]
-    [athens.style :as style :refer [base-styles color]]
+    [athens.style :as style :refer [base-styles color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard defcard-rg]]
@@ -79,20 +79,20 @@
                                         :-webkit-line-clamp "3"
                                         :-webkit-box-orient "vertical"}
                          :td-date {:text-align "right"
-                                   :opacity "0.75"
+                                   :opacity (:opacity-high OPACITIES)
                                    :font-size "12px"
                                    :min-width "9em"}}
    ::stylefy/manual [[:tbody {:vertical-align "top"}
                       [:tr
                        [:td {:border-top (str "1px solid " (color :panel-color))}]
-                       [:&:hover {:background-color (color :panel-color :opacity-10)
+                       [:&:hover {:background-color (color :panel-color :opacity-lower)
                                   :border-radius "8px"}
                         [:td [(selectors/& (selectors/first-child)) {:border-radius "8px 0 0 8px"
                                                                      :box-shadow "-16px 0 hsla(30, 11.11%, 93%, 0.1)"}]]
                         [:td [(selectors/& (selectors/last-child)) {:border-radius "0 8px 8px 0"
                                                                     :box-shadow "16px 0 hsla(30, 11.11%, 93%, 0.1)"}]]]]]
                      [:td :th {:padding "8px"}]
-                     [:th [:h5 {:opacity "0.5"}]]]})
+                     [:th [:h5 {:opacity (:opacity-med OPACITIES)}]]]})
 
 
 (defn table

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -148,7 +148,7 @@
 
 (def hint-style
   {:color "inherit"
-   :opacity (nth OPACITIES 3)
+   :opacity (:opacity-50 OPACITIES)
    :font-size "14px"
    ::stylefy/manual [[:kbd {:text-transform "uppercase"
                             :font-family "inherit"

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -64,7 +64,7 @@
 (def container-style
   {:width         "784px"
    :border-radius "4px"
-   :box-shadow    [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-10)]]
+   :box-shadow    [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-lower)]]
    :display       "flex"
    :flex-direction "column"
    :background    (color :app-bg-color)
@@ -90,7 +90,7 @@
    :padding "24px"
    :cursor "text"
    ::stylefy/mode {:focus {:outline "none"}
-                   "::placeholder" {:opacity (:opacity-25 OPACITIES)}}})
+                   "::placeholder" {:color (color :body-text-color :opacity-low)}}})
 
 
 (def results-list-style
@@ -106,8 +106,8 @@
    :position "sticky"
    :top "0"
    :justify-content "space-between"
-   :box-shadow [["0 1px 0 0 " (color :body-text-color 0.12)]]
-   :border-top [["1px solid" (color :body-text-color 0.12)]]})
+   :box-shadow [["0 1px 0 0 " (color :body-text-color :opacity-lower)]]
+   :border-top [["1px solid" (color :body-text-color :opacity-lower)]]})
 
 
 (def result-style
@@ -118,7 +118,7 @@
    :padding "8px 32px"
    :background (color :body-text-color 0.02)
    :transition "all .05s ease"
-   :border-top [["1px solid " (color :body-text-color 0.12)]]
+   :border-top [["1px solid " (color :body-text-color :opacity-lower)]]
    ::stylefy/sub-styles {:title {:grid-area "title"
                                  :font-size "16px"
                                  :margin "0"
@@ -132,7 +132,7 @@
                                   ;;  :display "-webkit-box"
                                   ;;  :-webkit-line-clamp "2"
                                   ;;  :-webkit-box-orient "vertical"
-                                   :color (color :body-text-color :opacity-50)}
+                                   :color (color :body-text-color :opacity-med)}
                          :link-leader {:grid-area "icon"
                                        :color "transparent"
                                        :margin "auto auto"}}
@@ -148,7 +148,7 @@
 
 (def hint-style
   {:color "inherit"
-   :opacity (:opacity-50 OPACITIES)
+   :opacity (:opacity-med OPACITIES)
    :font-size "14px"
    ::stylefy/manual [[:kbd {:text-transform "uppercase"
                             :font-family "inherit"

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -5,14 +5,13 @@
     [athens.devcards.db :refer [new-conn posh-conn! load-real-db-button]]
     [athens.events]
     [athens.router :refer [navigate-page]]
-    [athens.style :refer [base-styles DEPTH-SHADOWS COLORS HSL-COLORS OPACITIES]]
+    [athens.style :refer [base-styles color DEPTH-SHADOWS OPACITIES]]
     [athens.subs]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as str]
     [datascript.core :as d]
     [devcards.core :refer-macros [defcard-rg]]
-    [garden.color :refer [opacify]]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
@@ -65,10 +64,10 @@
 (def container-style
   {:width         "784px"
    :border-radius "4px"
-   :box-shadow    [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (opacify (:body-text-color HSL-COLORS) (first OPACITIES))]]
+   :box-shadow    [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-10)]]
    :display       "flex"
    :flex-direction "column"
-   :background    (:app-bg-color HSL-COLORS)
+   :background    (color :app-bg-color)
    :position      "fixed"
    :overflow      "hidden"
    :max-height    "60vh"
@@ -87,28 +86,28 @@
    :letter-spacing "-0.03em"
    :border-radius "4px 4px 0 0"
    :color          "#433F38"
-   :caret-color    (:link-color COLORS)
+   :caret-color    (color :link-color)
    :padding "24px"
    :cursor "text"
    ::stylefy/mode {:focus {:outline "none"}
-                   "::placeholder" {:opacity (nth OPACITIES 2)}}})
+                   "::placeholder" {:opacity (:opacity-25 OPACITIES)}}})
 
 
 (def results-list-style
-  {:background    (:app-bg-color HSL-COLORS)
+  {:background    (color :app-bg-color)
    :overflow-y "auto"
    :max-height "100%"})
 
 
 (def results-heading-style
   {:padding "4px 18px"
-   :background (:app-bg-color HSL-COLORS)
+   :background (color :app-bg-color)
    :display "flex"
    :position "sticky"
    :top "0"
    :justify-content "space-between"
-   :box-shadow [["0 1px 0 0 " (opacify (:body-text-color HSL-COLORS) 0.12)]]
-   :border-top [["1px solid" (opacify (:body-text-color HSL-COLORS) 0.12)]]})
+   :box-shadow [["0 1px 0 0 " (color :body-text-color 0.12)]]
+   :border-top [["1px solid" (color :body-text-color 0.12)]]})
 
 
 (def result-style
@@ -117,13 +116,13 @@
    :grid-gap "0 12px"
    :grid-template-columns "1fr auto"
    :padding "8px 32px"
-   :background (opacify (:body-text-color HSL-COLORS) 0.02)
+   :background (color :body-text-color 0.02)
    :transition "all .05s ease"
-   :border-top [["1px solid " (opacify (:body-text-color HSL-COLORS) 0.12)]]
+   :border-top [["1px solid " (color :body-text-color 0.12)]]
    ::stylefy/sub-styles {:title {:grid-area "title"
                                  :font-size "16px"
                                  :margin "0"
-                                 :color (:header-text-color COLORS)
+                                 :color (color :header-text-color)
                                  :font-weight "500"}
                          :preview {:grid-area "preview"
                                    :white-space "wrap"
@@ -133,12 +132,12 @@
                                   ;;  :display "-webkit-box"
                                   ;;  :-webkit-line-clamp "2"
                                   ;;  :-webkit-box-orient "vertical"
-                                   :color (opacify (:body-text-color COLORS) (nth OPACITIES 3))}
+                                   :color (color :body-text-color :opacity-50)}
                          :link-leader {:grid-area "icon"
                                        :color "transparent"
                                        :margin "auto auto"}}
-   ::stylefy/mode {:hover {:background (:link-color HSL-COLORS)
-                           :color (:app-bg-color COLORS)}}
+   ::stylefy/mode {:hover {:background (color :link-color)
+                           :color (color :app-bg-color)}}
    ::stylefy/manual [[:&:hover [:.title :.preview :.link-leader :.result-highlight {:color "inherit"}]]]})
 
 

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -3,7 +3,7 @@
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
     [athens.router :refer [navigate-page]]
-    [athens.style :refer [base-styles COLORS]]
+    [athens.style :refer [base-styles color]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [datascript.core :as d]
@@ -96,7 +96,7 @@
    :justify-content "center"
    :padding "0"
    :-webkit-appearance "none"
-   ::stylefy/mode [[:hover {:color (:link-color COLORS)}]
+   ::stylefy/mode [[:hover {:color (color :link-color)}]
                    [":is(button)" {:cursor "pointer"}]]
    ::stylefy/manual [[:&.closed [:svg {:transform "rotate(-90deg)"}]]]})
 
@@ -108,7 +108,7 @@
    :margin-right "4px"
    :transition "all 0.05s ease"
    :height "32px"
-   :color (:panel-color COLORS)
+   :color (color :panel-color)
    ::stylefy/mode [[:after {:content "''"
                             :background "currentColor"
                             :transition "all 0.05s ease"
@@ -119,7 +119,7 @@
                             :transform "translate(-50%, -50%)"
                             :height "5px"
                             :width "5px"}]
-                   [:hover {:color (:link-color COLORS)}]
+                   [:hover {:color (color :link-color)}]
                    [:before {:content "''"
                              :position "absolute"
                              :top "24px"
@@ -127,10 +127,10 @@
                              :pointer-events "none"
                              :left "22px"
                              :width "1px"
-                             :background (:panel-color COLORS)}]]
+                             :background (color :panel-color)}]]
    ::stylefy/manual [[:&.open {}]
                      [:&.closed {}]
-                     [:&.closed [(selectors/& (selectors/after)) {:box-shadow (str "0 0 0 2px " (:body-text-color COLORS))
+                     [:&.closed [(selectors/& (selectors/after)) {:box-shadow (str "0 0 0 2px " (color :body-text-color))
                                                                   :opacity "0.5"}]]
                      [:&.closed [(selectors/& (selectors/before)) {:content "none"}]]
                      [:&.closed [(selectors/& (selectors/before)) {:content "none"}]]

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -3,7 +3,7 @@
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
     [athens.router :refer [navigate-page]]
-    [athens.style :refer [base-styles color]]
+    [athens.style :refer [base-styles color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [datascript.core :as d]
@@ -131,7 +131,7 @@
    ::stylefy/manual [[:&.open {}]
                      [:&.closed {}]
                      [:&.closed [(selectors/& (selectors/after)) {:box-shadow (str "0 0 0 2px " (color :body-text-color))
-                                                                  :opacity "0.5"}]]
+                                                                  :opacity (:opacity-med OPACITIES)}]]
                      [:&.closed [(selectors/& (selectors/before)) {:content "none"}]]
                      [:&.closed [(selectors/& (selectors/before)) {:content "none"}]]
                      [:&.selected {}]]})

--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db]
-    [athens.style :refer [COLORS OPACITIES]]
+    [athens.style :refer [color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -29,13 +29,13 @@
 (defcard-rg Styling-icons
   "Color, opacity, and other properties can be applied to icons by placing them in an element with those styles applied."
   [:div
-   [:span {:style {:color (:link-color COLORS)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:color (:highlight-color COLORS)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:color (:warning-color COLORS)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:color (:confirmation-color COLORS)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:color (:body-text-color COLORS)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (nth OPACITIES 0)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (nth OPACITIES 1)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (nth OPACITIES 2)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (nth OPACITIES 3)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:color (:body-text-color COLORS)}} (r/create-element mui-icons/Face)]])
+   [:span {:style {:color (color :link-color)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:color (color :highlight-color)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:color (color :warning-color)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:color (color :confirmation-color)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:color (color :body-text-color)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-10 OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-25 OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-50 OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-75 OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:color (color :body-text-color)}} (r/create-element mui-icons/Face)]])

--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -34,8 +34,8 @@
    [:span {:style {:color (color :warning-color)}} (r/create-element mui-icons/Face)]
    [:span {:style {:color (color :confirmation-color)}} (r/create-element mui-icons/Face)]
    [:span {:style {:color (color :body-text-color)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (:opacity-10 OPACITIES)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (:opacity-25 OPACITIES)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (:opacity-50 OPACITIES)}} (r/create-element mui-icons/Face)]
-   [:span {:style {:opacity (:opacity-75 OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-lower OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-low OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-med OPACITIES)}} (r/create-element mui-icons/Face)]
+   [:span {:style {:opacity (:opacity-high OPACITIES)}} (r/create-element mui-icons/Face)]
    [:span {:style {:color (color :body-text-color)}} (r/create-element mui-icons/Face)]])

--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -5,7 +5,7 @@
     [athens.devcards.buttons :refer [button button-primary]]
     [athens.devcards.db :refer [new-conn posh-conn!]]
     [athens.router :refer [navigate navigate-page]]
-    [athens.style :refer [base-styles COLORS]]
+    [athens.style :refer [base-styles color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard-rg]]
@@ -43,7 +43,7 @@
    :display "flex"
    :flex-direction "column"
    :padding "32px 32px 16px 32px"
-   :box-shadow (str "1px 0 " (:panel-color COLORS))
+   :box-shadow (str "1px 0 " (color :panel-color))
    ::stylefy/manual [[]]
    ::stylefy/sub-styles {:top-line {:margin-bottom "40px"
                                     :display "flex"
@@ -104,7 +104,7 @@
 
 
 (def shortcut-style
-  {:color (:link-color COLORS)
+  {:color (color :link-color)
    :cursor "pointer"
    :display "flex"
    :flex "0 0 auto"
@@ -122,9 +122,9 @@
    :text-decoration "none"
    :justify-self "flex-start"
    :align-self "center"
-   :color "#000"
+   :color (color :headings-text-color)
    :transition "all 0.05s ease"
-   ::stylefy/mode [[:hover {:opacity "0.8"}]]})
+   ::stylefy/mode [[:hover {:opacity (:opacity-75 OPACITIES)}]]})
 
 
 (def q-shortcuts

--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -97,7 +97,7 @@
    :margin "0 0 32px"
    :overflow-y "auto"
    ::stylefy/sub-styles {:heading {:flex "0 0 auto"
-                                   :opacity "0.5"
+                                   :opacity (:opacity-med OPACITIES)
                                    :line-height "1"
                                    :margin "0 0 4px"
                                    :font-size "inherit"}}})
@@ -110,21 +110,21 @@
    :flex "0 0 auto"
    :padding "4px 0"
    :transition "all 0.05s ease"
-   ::stylefy/mode [[:hover {:opacity "0.8"}]]})
+   ::stylefy/mode [[:hover {:opacity (:opacity-high OPACITIES)}]]})
 
 
 (def notional-logotype
   {:font-family "IBM Plex Serif"
    :font-size "18px"
-   :opacity "0.5"
+   :opacity (:opacity-med OPACITIES)
    :letter-spacing "-0.05em"
    :font-weight "bold"
    :text-decoration "none"
    :justify-self "flex-start"
    :align-self "center"
-   :color (color :headings-text-color)
+   :color (color :header-text-color)
    :transition "all 0.05s ease"
-   ::stylefy/mode [[:hover {:opacity (:opacity-75 OPACITIES)}]]})
+   ::stylefy/mode [[:hover {:opacity (:opacity-high OPACITIES)}]]})
 
 
 (def q-shortcuts

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -38,7 +38,7 @@
 
 
 (defcard-rg Colors
-  [:div (use-style (merge color-group-style {:background (color :body-text-color 0.15)}))
+  [:div (use-style (merge color-group-style {:background (color :body-text-color :opacity-low)}))
    (doall
      (for [c (keys COLORS)]
        ^{:key c}

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -1,7 +1,7 @@
 (ns athens.devcards.style-guide
   (:require
     [athens.db]
-    [athens.style :refer [base-styles COLORS OPACITIES]]
+    [athens.style :refer [base-styles color COLORS OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -26,7 +26,7 @@
   {:display "grid"
    :grid-gap "0.25rem"
    ::stylefy/manual [[:div {:border-radius "1000px"
-                            :background (:link-color COLORS)
+                            :background (color :link-color)
                             :height "4rem"
                             :margin "auto"
                             :width "4rem"}]]})
@@ -38,13 +38,13 @@
 
 
 (defcard-rg Colors
-  [:div (use-style (merge color-group-style {:background "#e5e5e5"}))
+  [:div (use-style (merge color-group-style {:background (color :body-text-color 0.15)}))
    (for [c (keys COLORS)]
      ^{:key c}
      [:div (use-style color-item-style)
-      [:div {:style {:background (c COLORS) :box-shadow "0 0 0 1px rgba(0,0,0,0.15)"}}]
+      [:div {:style {:background (color c) :box-shadow "0 0 0 1px rgba(0,0,0,0.15)"}}]
       [:span c]
-      [:span {:style {:color (c COLORS)}} (c COLORS)]])]
+      [:span {:style {:color (color c)}} (color c)]])]
   {}
   {:padding false})
 
@@ -55,7 +55,8 @@
      ^{:key o}
      [:div (use-style color-item-style)
       [:div {:style {:opacity o}}]
-      [:span o]])])
+      [:span o]])
+   ])
 
 
 (def types [:h1 :h2 :h3 :h4 :h5 :span :span.block-ref])

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -39,23 +39,25 @@
 
 (defcard-rg Colors
   [:div (use-style (merge color-group-style {:background (color :body-text-color 0.15)}))
-   (for [c (keys COLORS)]
-     ^{:key c}
-     [:div (use-style color-item-style)
-      [:div {:style {:background (color c) :box-shadow "0 0 0 1px rgba(0,0,0,0.15)"}}]
-      [:span c]
-      [:span {:style {:color (color c)}} (color c)]])]
+   (doall
+     (for [c (keys COLORS)]
+       ^{:key c}
+       [:div (use-style color-item-style)
+        [:div {:style {:background (color c) :box-shadow "0 0 0 1px rgba(0,0,0,0.15)"}}]
+        [:span c]
+        [:span {:style {:color (color c)}} (color c)]]))]
   {}
   {:padding false})
 
 
 (defcard-rg Opacities
   [:div (use-style color-group-style)
-   (for [o OPACITIES]
-     ^{:key o}
-     [:div (use-style color-item-style)
-      [:div {:style {:opacity o}}]
-      [:span o]])])
+   (doall
+     (for [o (keys OPACITIES)]
+       ^{:key o}
+       [:div (use-style color-item-style)
+        [:div {:style {:opacity (o OPACITIES)}}]
+        [:span o]]))])
 
 
 (def types [:h1 :h2 :h3 :h4 :h5 :span :span.block-ref])
@@ -69,29 +71,32 @@
 
 (defcard-rg Sans-Types
   [:div
-   (for [t types]
-     ^{:key t}
-     [:div (use-style text-item-style)
-      [:span t]
-      [t {:style {:font-family (second fonts)}} "Welcome to Athens"]])])
+   (doall
+     (for [t types]
+       ^{:key t}
+       [:div (use-style text-item-style)
+        [:span t]
+        [t {:style {:font-family (second fonts)}} "Welcome to Athens"]]))])
 
 
 (defcard-rg Serif-Types
   [:div
-   (for [t types]
-     ^{:key t}
-     [:div (use-style text-item-style)
-      [:span t]
-      [t {:style {:font-family (first fonts)}} "Welcome to Athens"]])])
+   (doall
+     (for [t types]
+       ^{:key t}
+       [:div (use-style text-item-style)
+        [:span t]
+        [t {:style {:font-family (first fonts)}} "Welcome to Athens"]]))])
 
 
 (defcard-rg Monospace-Types
   [:div
-   (for [t types]
-     ^{:key t}
-     [:div (use-style text-item-style)
-      [:span t]
-      [t {:style {:font-family (last fonts)}} "Welcome to Athens"]])])
+   (doall
+     (for [t types]
+       ^{:key t}
+       [:div (use-style text-item-style)
+        [:span t]
+        [t {:style {:font-family (last fonts)}} "Welcome to Athens"]]))])
 
 
 (defcard-rg Material-UI-Icons

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -55,8 +55,7 @@
      ^{:key o}
      [:div (use-style color-item-style)
       [:div {:style {:opacity o}}]
-      [:span o]])
-   ])
+      [:span o]])])
 
 
 (def types [:h1 :h2 :h3 :h4 :h5 :span :span.block-ref])

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -34,7 +34,6 @@
    :opacity-100 1})
 
 
-
 ;; (color :link-color)
 ;; (color :link-color 0.5)
 ;; (color :link-color :opacity-50)
@@ -43,13 +42,17 @@
 ;; Pass in color keyword
 ;; Optionally pass in alpha value, which may be keyword or 0-1
 
-(defn- return-color [c]
+(defn- return-color
+  [c]
   (c COLORS))
 
-(defn- return-color-with-alpha [c a]
+
+(defn- return-color-with-alpha
+  [c a]
   (if (keyword? a)
     (opacify (c HSL-COLORS) (a OPACITIES))
     (opacify (c HSL-COLORS) a)))
+
 
 (defn color
   ([c] (return-color c))

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -34,13 +34,9 @@
    :opacity-100 1})
 
 
-;; (color :link-color)
-;; (color :link-color 0.5)
-;; (color :link-color :opacity-50)
-
-;; Import (color) from style
-;; Pass in color keyword
-;; Optionally pass in alpha value, which may be keyword or 0-1
+;; Color
+;; Provide color keyword
+;; (optional) Provide alpha value, either keyword or 0-1
 
 (defn- return-color
   [c]

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -27,11 +27,11 @@
 
 
 (def OPACITIES
-  {:opacity-10 0.1
-   :opacity-25 0.25
-   :opacity-50 0.50
-   :opacity-75 0.75
-   :opacity-100 1})
+  {:opacity-lower  0.10
+   :opacity-low    0.25
+   :opacity-med    0.50
+   :opacity-high   0.75
+   :opacity-higher 0.85})
 
 
 ;; Color
@@ -90,7 +90,7 @@
             [:input {:font-family "inherit"}]
             [:span
              [:.block-ref {:border-bottom [["1px" "solid" (color :highlight-color)]]}
-              [:&:hover {:background-color (color :highlight-color :opacity-10)
+              [:&:hover {:background-color (color :highlight-color :opacity-lower)
                          :cursor           "alias"}]]]
             [:.athena-result {:display "flex"
                               :padding "12px 32px 12px 32px"

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -15,6 +15,10 @@
    :app-bg-color       "#FFFFFF"})
 
 
+(def HSL-COLORS
+  (reduce-kv #(assoc %1 %2 (hex->hsl %3)) {} COLORS))
+
+
 (def DEPTH-SHADOWS
   {:4                  "0px 1.6px 3.6px rgba(0, 0, 0, 0.13), 0px 0.3px 0.9px rgba(0, 0, 0, 0.1)"
    :8                  "0px 3.2px 7.2px rgba(0, 0, 0, 0.13), 0px 0.6px 1.8px rgba(0, 0, 0, 0.1)"
@@ -22,11 +26,34 @@
    :64                 "0px 24px 60px rgba(0, 0, 0, 0.15), 0px 5px 12px rgba(0, 0, 0, 0.1)"})
 
 
-(def HSL-COLORS
-  (reduce-kv #(assoc %1 %2 (hex->hsl %3)) {} COLORS))
+(def OPACITIES
+  {:opacity-10 0.1
+   :opacity-25 0.25
+   :opacity-50 0.50
+   :opacity-75 0.75
+   :opacity-100 1})
 
 
-(def OPACITIES [0.1 0.25 0.5 0.75 1])
+
+;; (color :link-color)
+;; (color :link-color 0.5)
+;; (color :link-color :opacity-50)
+
+;; Import (color) from style
+;; Pass in color keyword
+;; Optionally pass in alpha value, which may be keyword or 0-1
+
+(defn- return-color [c]
+  (c COLORS))
+
+(defn- return-color-with-alpha [c a]
+  (if (keyword? a)
+    (opacify (c HSL-COLORS) (a OPACITIES))
+    (opacify (c HSL-COLORS) a)))
+
+(defn color
+  ([c] (return-color c))
+  ([c a] (return-color-with-alpha c a)))
 
 
 ;; Base Styles
@@ -36,11 +63,11 @@
   [:style (css
             [:body {:margin 0
                     :font-family "IBM Plex Sans, Sans-Serif"
-                    :color (:body-text-color COLORS)
+                    :color (color :body-text-color)
                     :font-size "16px"}]
             [:* {:box-sizing "border-box"}]
             [:h1 :h2 :h3 :h4 :h5 :h6 {:margin "0.2em 0"
-                                      :color (:header-text-color COLORS)}]
+                                      :color (color :header-text-color)}]
             [:h1 {:font-size "50px"
                   :font-weight 600
                   :line-height "65px"
@@ -63,12 +90,12 @@
             [:.MuiSvgIcon-root {:font-size "24px"}]
             [:input {:font-family "inherit"}]
             [:span
-             [:.block-ref {:border-bottom [["1px" "solid" (:highlight-color COLORS)]]}
-              [:&:hover {:background-color (opacify (:highlight-color HSL-COLORS) (first OPACITIES))
+             [:.block-ref {:border-bottom [["1px" "solid" (color :highlight-color)]]}
+              [:&:hover {:background-color (color :highlight-color :opacity-10)
                          :cursor           "alias"}]]]
             [:.athena-result {:display "flex"
                               :padding "12px 32px 12px 32px"
                               :border-top "1px solid rgba(67, 63, 56, 0.2)"}
-             [:&:hover {:background-color (:link-color COLORS) :cursor "pointer"}
+             [:&:hover {:background-color (color :link-color) :cursor "pointer"}
               [:h4 {:color "rgba(255, 255, 255, 1)"}]
               [:span {:color "rgba(255, 255, 255, .9)"}]]])])

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -16,7 +16,7 @@
 (def loading-message-style
   {:margin-top "50vh"
    :text-align "center"
-   :opacity (:opacity-high OPACITIES))})
+   :opacity (:opacity-high OPACITIES)})
 
 
 (def app-wrapper-style

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -5,7 +5,7 @@
     [athens.devcards.athena :refer [athena]]
     [athens.devcards.left-sidebar :refer [left-sidebar]]
     [athens.page :as page]
-    [athens.style :as style]
+    [athens.style :as style :refer [OPACITIES]]
     [athens.subs]
     [re-frame.core :as rf :refer [subscribe dispatch]]
     [stylefy.core :as stylefy :refer [use-style]]))
@@ -16,7 +16,7 @@
 (def loading-message-style
   {:margin-top "50vh"
    :text-align "center"
-   :opacity "0.9"})
+   :opacity (:opacity-high OPACITIES))})
 
 
 (def app-wrapper-style


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/cards.html#!/athens.devcards.style_guide)

- New opacity scale `lower low med high higher`
- New function `(color)` to handle colors and opacities without having to think about hex vs. HSL etc.
- Replace all uses of color and opacity with new function and consistent values

TODO: documentation