### PR TITLE
fix(style-guide): remove broken icons link

### DIFF
--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -97,7 +97,3 @@
        [:div (use-style text-item-style)
         [:span t]
         [t {:style {:font-family (last fonts)}} "Welcome to Athens"]]))])
-
-
-(defcard-rg Material-UI-Icons
-  [:a {:href "/cards.html#!/athens.devcards.icons"} "Icons DevCard"])


### PR DESCRIPTION
Removes link from style_guide page to icons page, which worked in local development but not in deployed GH Pages.

[Demo](https://shanberg.github.io/athens/cards.html#!/athens.devcards.style_guide)