### PR TITLE
refactor(blocks): don't create unnecessary spans

### DIFF
--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -161,7 +161,7 @@
          [:> mui-icons/KeyboardArrowDown {:style {:font-size "16px"}}]]
         [:span (use-style block-disclosure-toggle-style)])
       [:a (use-style block-indicator-style {:class (if closed? "closed" "open") :on-click #(navigate-page uid)})]
-      [:span (parse-and-render string)]]
+      [:<> (parse-and-render string)]]
      (when open?
        (for [child (:block/children block)]
          [:div {:style {:margin-left "32px"} :key (:db/id child)}

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -161,7 +161,7 @@
          [:> mui-icons/KeyboardArrowDown {:style {:font-size "16px"}}]]
         [:span (use-style block-disclosure-toggle-style)])
       [:a (use-style block-indicator-style {:class (if closed? "closed" "open") :on-click #(navigate-page uid)})]
-      [:<> (parse-and-render string)]]
+      [parse-and-render string]]
      (when open?
        (for [child (:block/children block)]
          [:div {:style {:margin-left "32px"} :key (:db/id child)}

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -57,5 +57,5 @@
        {:title (pr-str (insta/get-failure result))
         :style {:color "red"}}
        string]
-      [:span
+      [:<>
        (vec (transform result))])))

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -57,5 +57,4 @@
        {:title (pr-str (insta/get-failure result))
         :style {:color "red"}}
        string]
-      [:<>
-       (vec (transform result))])))
+      [vec (transform result)])))


### PR DESCRIPTION
Switch to fragments for spans that don't apply styling or have semantic meaning. Makes for easier markup to navigate, and less work for the browser to do.

[Demo](https://shanberg.github.io/athens/cards.html#!/athens.devcards.blocks)