### PR TITLE
Revert "refactor(style): use global styles instead of base styles"

### DIFF
--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -5,7 +5,7 @@
     [athens.devcards.db :refer [load-real-db-button]]
     [athens.lib.dom.attributes :refer [with-attributes]]
     [athens.router :refer [navigate-page]]
-    [athens.style :as style :refer [color OPACITIES]]
+    [athens.style :as style :refer [base-styles color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard defcard-rg]]
@@ -104,7 +104,9 @@
 
 
 (defcard-rg Import-Styles
-  [:style (css [:.com-rigsomelight-devcards-container {:width "90%"}])])
+  [:<>
+   [base-styles]
+   [:style (css [:.com-rigsomelight-devcards-container {:width "90%"}])]])
 
 
 (defcard-rg Create-Page

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -6,7 +6,7 @@
     [athens.devcards.db :refer [load-real-db-button]]
     [athens.events]
     [athens.router :refer [navigate-page]]
-    [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+    [athens.style :refer [base-styles color DEPTH-SHADOWS OPACITIES]]
     [athens.subs]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -233,6 +233,10 @@
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Create-Page

--- a/src/cljs/athens/devcards/block_page.cljs
+++ b/src/cljs/athens/devcards/block_page.cljs
@@ -3,6 +3,7 @@
     [athens.db :as db]
     [athens.devcards.blocks :refer [block-el]]
     [athens.router :refer [navigate-page]]
+    [athens.style :refer [base-styles]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -93,6 +94,10 @@
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Block-Page

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -4,7 +4,7 @@
     [athens.db :as db]
     [athens.parse-renderer :refer [parse-and-render]]
     [athens.router :refer [navigate-page]]
-    [athens.style :refer [color OPACITIES]]
+    [athens.style :refer [base-styles color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -175,6 +175,10 @@ no results for pull eid returns nil
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Block

--- a/src/cljs/athens/devcards/buttons.cljs
+++ b/src/cljs/athens/devcards/buttons.cljs
@@ -2,6 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db]
+    [athens.style :refer [base-styles]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -69,6 +70,10 @@
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Default-Button

--- a/src/cljs/athens/devcards/db_boxes.cljs
+++ b/src/cljs/athens/devcards/db_boxes.cljs
@@ -1,7 +1,7 @@
 (ns athens.devcards.db-boxes
   (:require
     [athens.db :as db]
-    [athens.style :refer [COLORS HSL-COLORS]]
+    [athens.style :refer [base-styles COLORS HSL-COLORS]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [<!]]
     [cljsjs.react]
@@ -22,6 +22,10 @@
   {8   :backspace
    9   :tab
    13  :return})
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard "

--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -5,7 +5,7 @@
     [athens.devcards.athena :refer [athena-prompt]]
     [athens.devcards.buttons :refer [button button-primary]]
     [athens.router :refer [navigate navigate-page]]
-    [athens.style :refer [color OPACITIES]]
+    [athens.style :refer [base-styles color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer [defcard-rg]]
@@ -169,6 +169,10 @@
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Create-Shortcut

--- a/src/cljs/athens/devcards/node_page.cljs
+++ b/src/cljs/athens/devcards/node_page.cljs
@@ -3,6 +3,7 @@
     [athens.db :as db]
     [athens.devcards.blocks :as blocks]
     [athens.patterns :as patterns]
+    [athens.style :refer [base-styles]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -413,6 +414,10 @@
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Node-Page

--- a/src/cljs/athens/devcards/parser.cljs
+++ b/src/cljs/athens/devcards/parser.cljs
@@ -3,6 +3,7 @@
     [athens.devcards.blocks :refer [block-el]]
     #_[athens.parse-renderer :refer [parse-and-render]]
     #_[athens.parser :refer [parse-to-ast combine-adjacent-strings]]
+    [athens.style :refer [base-styles]]
     #_[cljs.test :refer [is testing are async]]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -23,6 +24,10 @@
    "This is a **very** important block"
    "This is an [external link](https://github.com/athensresearch/athens/)"
    "This is an image: ![alt](https://raw.githubusercontent.com/athensresearch/athens/master/doc/athens-puk-patrick-unsplash.jpg)"])
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Parse

--- a/src/cljs/athens/devcards/style_guide.cljs
+++ b/src/cljs/athens/devcards/style_guide.cljs
@@ -1,7 +1,7 @@
 (ns athens.devcards.style-guide
   (:require
     [athens.db]
-    [athens.style :refer [color COLORS OPACITIES]]
+    [athens.style :refer [base-styles color COLORS OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
@@ -48,6 +48,10 @@
 
 
 ;;; Devcards
+
+
+(defcard-rg Import-Styles
+  [base-styles])
 
 
 (defcard-rg Colors

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,7 +1,7 @@
 (ns athens.style
   (:require
     [garden.color :refer [opacify hex->hsl]]
-    [stylefy.core :as stylefy]))
+    [garden.core :refer [css]]))
 
 
 (def COLORS
@@ -57,41 +57,44 @@
 
 ;; Base Styles
 
-(stylefy/tag "body" {:background-color (color :app-bg-color)
-                     :font-family "IBM Plex Sans, Sans-Serif"
-                     :color (color :body-text-color)
-                     :font-size "16px"
-                     :line-height "1.5"
-                     ::stylefy/manual [[:a {:color (color :link-color)}]
-                                       [:h1 :h2 :h3 :h4 :h5 :h6 {:margin "0.2em 0"
-                                                                 :color (color :header-text-color)}]
-                                       [:h1 {:font-size "50px"
-                                             :font-weight 600
-                                             :line-height "65px"
-                                             :letter-spacing "-0.03em"}]
-                                       [:h2 {:font-size "38px"
-                                             :font-weight 500
-                                             :line-height "49px"
-                                             :letter-spacing "-0.03em"}]
-                                       [:h3 {:font-size "28px"
-                                             :font-weight 500
-                                             :line-height "36px"
-                                             :letter-spacing "-0.02em"}]
-                                       [:h4 {:font-size "21px"
-                                             :line-height "27px"}]
-                                       [:h5 {:font-size "12px"
-                                             :font-weight 500
-                                             :line-height "16px"
-                                             :letter-spacing "0.08em"
-                                             :text-transform "uppercase"}]
-                                       [:.MuiSvgIcon-root {:font-size "24px"}]
-                                       [:input {:font-family "inherit"}]
-                                       [:span
-                                        [:&.block-ref {:border-bottom [["1px" "solid" (color :highlight-color)]]}
-                                         [:&:hover {:background-color (color :highlight-color :opacity-lower)
-                                                    :cursor "alias"}]]]
-                                       [:img {:max-width "100%"
-                                              :height "auto"}]]})
-
-
-(stylefy/tag "*" {:box-sizing "border-box"})
+(defn base-styles
+  []
+  [:style (css
+            [:body {:margin 0
+                    :font-family "IBM Plex Sans, Sans-Serif"
+                    :color (color :body-text-color)
+                    :font-size "16px"}]
+            [:* {:box-sizing "border-box"}]
+            [:h1 :h2 :h3 :h4 :h5 :h6 {:margin "0.2em 0"
+                                      :color (color :header-text-color)}]
+            [:h1 {:font-size "50px"
+                  :font-weight 600
+                  :line-height "65px"
+                  :letter-spacing "-0.03em"}]
+            [:h2 {:font-size "38px"
+                  :font-weight 500
+                  :line-height "49px"
+                  :letter-spacing "-0.03em"}]
+            [:h3 {:font-size "28px"
+                  :font-weight 500
+                  :line-height "36px"
+                  :letter-spacing "-0.02em"}]
+            [:h4 {:font-size "21px"
+                  :line-height "27px"}]
+            [:h5 {:font-size "12px"
+                  :font-weight 500
+                  :line-height "16px"
+                  :letter-spacing "0.08em"
+                  :text-transform "uppercase"}]
+            [:.MuiSvgIcon-root {:font-size "24px"}]
+            [:input {:font-family "inherit"}]
+            [:span
+             [:&.block-ref {:border-bottom [["1px" "solid" (color :highlight-color)]]}
+              [:&:hover {:background-color (color :highlight-color :opacity-lower)
+                         :cursor           "alias"}]]]
+            [:.athena-result {:display "flex"
+                              :padding "12px 32px 12px 32px"
+                              :border-top "1px solid rgba(67, 63, 56, 0.2)"}
+             [:&:hover {:background-color (color :link-color) :cursor "pointer"}
+              [:h4 {:color "rgba(255, 255, 255, 1)"}]
+              [:span {:color "rgba(255, 255, 255, .9)"}]]])])

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -106,11 +106,13 @@
         loading (subscribe [:loading])]
     (fn []
       [:<>
+       [style/base-styles]
        [alert]
        [athena db/dsdb]
        (if @loading
          [:h1 (use-style loading-message-style) "Loading Athens 😈"]
          [:div (use-style app-wrapper-style)
+          [style/base-styles]
           [left-sidebar db/dsdb]
           [:div (use-style main-content-style)
            [match-panel (-> @current-route :data :name)]]])])))


### PR DESCRIPTION
Reverts athensresearch/athens#160

Pretty nasty conflicts while trying to rebase onto the tangjeff0/athens komponentit branch at: https://github.com/tangjeff0/athens/commit/cf0a87e6e78e5303b6e962474e8fa129128ee748

Will merge the komponentit branch in even though buggy so we can have a clean starting point for new branches

![image](https://user-images.githubusercontent.com/8952138/85203276-9d4e7200-b2da-11ea-8901-6d096cdf46c8.png)
