### PR TITLE
feat(localStorage): persist db now, no longer need to request GH each

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
                  [reagent "0.9.1"]
                  [re-frame "0.11.0"]
                  [datascript "0.18.10"]
+                 [datascript-transit "0.3.0"]
                  [denistakeda/posh "0.5.8"]
                  [cljs-http "0.1.46"]
                  [day8.re-frame/async-flow-fx "0.1.0"]

--- a/src/cljs/athens/coeffects.cljs
+++ b/src/cljs/athens/coeffects.cljs
@@ -1,14 +1,4 @@
-(ns athens.coeffects
-  #_(:require
-    [athens.db :as db]
-    [cljs-http.client :as http]
-    [cljs.core.async :refer [go <!]]
-    [datascript.core :as d]
-    [datascript.transit :as dt]
-    [day8.re-frame.async-flow-fx]
-    [day8.re-frame.tracing :refer-macros [fn-traced]]
-    [posh.reagent :refer [transact! pull #_q #_pull-many]]
-    [re-frame.core :refer [dispatch reg-fx reg-event-db reg-event-fx]]))
+(ns athens.coeffects)
 
 
 ;;; Coeffects

--- a/src/cljs/athens/coeffects.cljs
+++ b/src/cljs/athens/coeffects.cljs
@@ -1,0 +1,20 @@
+(ns athens.coeffects
+  #_(:require
+    [athens.db :as db]
+    [cljs-http.client :as http]
+    [cljs.core.async :refer [go <!]]
+    [datascript.core :as d]
+    [datascript.transit :as dt]
+    [day8.re-frame.async-flow-fx]
+    [day8.re-frame.tracing :refer-macros [fn-traced]]
+    [posh.reagent :refer [transact! pull #_q #_pull-many]]
+    [re-frame.core :refer [dispatch reg-fx reg-event-db reg-event-fx]]))
+
+
+;;; Coeffects
+
+;;
+;;(r/reg-cofx
+;;  :ds
+;;  (fn [coeffects _]
+;;    (assoc coeffects :ds @@store)))

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -1,6 +1,8 @@
 (ns athens.core
   (:require
+    [athens.coeffects]
     [athens.config :as config]
+    [athens.effects]
     [athens.events]
     [athens.listeners :as listeners]
     [athens.router :as router]
@@ -29,10 +31,6 @@
   []
   (stylefy/init)
   (listeners/init)
-  (rf/dispatch-sync [:init-rfdb])
-  ;; when dev, download datoms directly
-  ;; FIXME without this dispatch nothing works, so enabling it for now
-  (when true #_config/debug?
-        (rf/dispatch [:boot]))
+  (rf/dispatch-sync [:boot])
   (dev-setup)
   (mount-root))

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -18,9 +18,6 @@
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
 
 
-(dispatch [:init-rfdb])
-
-
 ;;; Styles
 
 

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -18,9 +18,6 @@
       KeyCodes)))
 
 
-(rf/dispatch [:init-rfdb])
-
-
 (def datoms
   [{:db/id          2381
     :block/uid      "OaSVyM_nr"

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -19,7 +19,8 @@
     (transact! db/dsdb datoms)))
 
 
-(reg-fx :reset-conn
+(reg-fx
+  :reset-conn
   (fn [new-db]
     (d/reset-conn! db/dsdb new-db)))
 

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -1,0 +1,55 @@
+(ns athens.effects
+  (:require
+    [athens.db :as db]
+    [cljs-http.client :as http]
+    [cljs.core.async :refer [go <!]]
+    [datascript.core :as d]
+    [datascript.transit :as dt]
+    [day8.re-frame.async-flow-fx]
+    [posh.reagent :refer [transact!]]
+    [re-frame.core :refer [dispatch reg-fx]]))
+
+
+;;; Effects
+
+
+(reg-fx
+  :transact
+  (fn [datoms]
+    (transact! db/dsdb datoms)))
+
+
+(reg-fx :reset-conn
+  (fn [new-db]
+    (d/reset-conn! db/dsdb new-db)))
+
+
+(reg-fx
+  :set-local-storage-db
+  (fn [_]
+    (js/localStorage.setItem "datascript/DB" (dt/write-transit-str @db/dsdb))))
+
+
+(reg-fx
+  :http
+  (fn [{:keys [url method opts on-success on-failure]}]
+    (go
+      (let [http-fn (case method
+                      :post http/post :get http/get
+                      :put http/put :delete http/delete)
+            res     (<! (http-fn url opts))
+            {:keys [success body] :as all} res]
+        (if success
+          (dispatch (conj on-success body))
+          (dispatch (conj on-failure all)))))))
+
+
+(reg-fx
+  :timeout
+  (let [timers (atom {})]
+    (fn [{:keys [action id event wait]}]
+      (case action
+        :start (swap! timers assoc id (js/setTimeout #(dispatch event) wait))
+        :clear (do (js/clearTimeout (get @timers id))
+                   (swap! timers dissoc id))))))
+


### PR DESCRIPTION
load

- refactor event into coeffects and effects files
- get ride of initial re-frame dispatches in athena and blocks

coeffects is just a stub right now. Can probably make `localStore` its own `cofx` as in https://day8.github.io/re-frame/Coeffects/ once we begin to utilize it more

also, db will eventually maybe want to be stored in IndexedDB down the line