### PR TITLE
All pages date format

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "shadow-cljs": "2.8.83"
   },
   "dependencies": {
+    "@js-joda/core": "1.12.0",
+    "@js-joda/locale_en-us": "3.1.1",
+    "@js-joda/timezone": "2.2.0",
     "@material-ui/core": "^4.10.1",
     "@material-ui/icons": "^4.9.1",
     "create-react-class": "^15.6.3",

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,8 @@
                  [devcards "0.2.6"]
                  [borkdude/sci "0.0.13-alpha.22"]
                  [garden "1.3.10"]
-                 [stylefy "2.2.0"]]
+                 [stylefy "2.2.0"]
+                 [tick "0.4.26-alpha"]]
 
   :plugins [[lein-shell "0.5.0"]]
 

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -12,7 +12,9 @@
     [garden.core :refer [css]]
     [garden.selectors :as selectors]
     [posh.reagent :refer [transact! pull-many q]]
-    [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
+    [stylefy.core :as stylefy :refer [use-style use-sub-style]]
+    [tick.alpha.api :as t]
+    [tick.locale-en-us]))
 
 
 ;;; Styles
@@ -61,7 +63,7 @@
   [x]
   (if (< x 1)
     [:span "(unknown date)"]
-    (.toLocaleString  (js/Date. x))))
+    (t/format (t/formatter "LLLL MM, yyyy h':'ma") (t/date-time (t/instant (js/Date. x))))))
 
 
 (defn table

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -63,7 +63,7 @@
   [x]
   (if (< x 1)
     [:span "(unknown date)"]
-    (t/format (t/formatter "LLLL MM, yyyy h':'ma") (t/date-time (t/instant (js/Date. x))))))
+    (clojure.string/replace (clojure.string/replace (t/format (t/formatter "LLLL MM, yyyy h':'ma") (t/date-time (t/instant (js/Date. x)))) #"AM" "am") #"PM" "pm")))
 
 
 (defn table

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -8,6 +8,7 @@
     [athens.style :as style :refer [color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
+    [clojure.string :as str]
     [devcards.core :refer [defcard defcard-rg]]
     [garden.core :refer [css]]
     [garden.selectors :as selectors]
@@ -63,7 +64,7 @@
   [x]
   (if (< x 1)
     [:span "(unknown date)"]
-    (clojure.string/replace (clojure.string/replace (t/format (t/formatter "LLLL MM, yyyy h':'ma") (t/date-time (t/instant (js/Date. x)))) #"AM" "am") #"PM" "pm")))
+    (str/replace (str/replace (t/format (t/formatter "LLLL MM, yyyy h':'ma") (t/date-time (t/instant (js/Date. x)))) #"AM" "am") #"PM" "pm")))
 
 
 (defn table
@@ -94,7 +95,7 @@
                   {:on-click #(navigate-page uid)})
             title]
            [:td
-            [:div (use-sub-style table-style :body-preview) (clojure.string/join " " (map #(str "• " (:block/string %)) children))]]
+            [:div (use-sub-style table-style :body-preview) (str/join " ") (map #(str "• " (:block/string %)) children)]]
            [:td (use-sub-style table-style :td-date) (date-string modified)]
            [:td (use-sub-style table-style :td-date) (date-string created)]]))]]))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,21 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@js-joda/core@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-1.12.0.tgz#f310b0f89382adb54cf6d636dc38f295736d7835"
+  integrity sha512-XfqsWzY2jRUcVesKJ/vbZPDzfBZo2jHBWofabPozJQFguSQ0XEaUbdFPBeUICUmfeRsQn/Z+/SPTHSboT0XO3A==
+
+"@js-joda/locale_en-us@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@js-joda/locale_en-us/-/locale_en-us-3.1.1.tgz#c2eab2561aa048f5366046edd313ce94108263c6"
+  integrity sha512-EYrs4h0Um/9LqcEwDb0kGTHGaGkJgEO2cj78KKICPz7hsdvJHPOADIkDtjesYInZ1YkNrtE3HopnfETLDBvnWg==
+
+"@js-joda/timezone@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@js-joda/timezone/-/timezone-2.2.0.tgz#6085937d83791cd0bda0b43b533273f2f76b678b"
+  integrity sha512-Ks1F35VAEhQjlXQd9iqkbCkYGOUmCtMPfrjurgdoAGFqy4Q83Ob/p865E6N+mFAhlpWW1iFpwsznhdrVmtSZ2w==
+
 "@material-ui/core@^4.10.1":
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.10.1.tgz#e3db4ca55d2af6cc23a1159ef5c32ad97c43c39c"


### PR DESCRIPTION
This is my first PR to improve datetime format for `Created` and `Modified` columns, based on the UI showed in #100.
It uses `juxt/tick`, the chosen date library as discussed in the issue.

Some choices I made:
- The am/pm marker is simply put to lower case but this [SO answer](https://stackoverflow.com/questions/13581608/displaying-am-and-pm-in-lower-case-after-date-formatting/13581910#13581910), although not the accepted best answer, says that it is not the correct way to do it in Java with the old `SimpleDateFormat`. I went with it anyway because:
1. Athens runs in the browser so the date input is always AM/PM and thus it doesn't have the problem mentioned in the following SO comment:
> [...] some phones display AM/PM, others display a.m./p.m. 
2. I couldn't find the equivalent of `DateFormatSymbols` for Java 8 `DateTimeFormatter`

- Localization: the previous code had a JS call to Date's [`toLocaleString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) which according to the docs says that the default locale and the default time zone are en-US locale with time zone America/Los_Angeles. So localization was not implemented for Athens. Can someone correct me if I'm wrong? And it is not in the specs per se but is localization needed?

I am a Clojure beginner here to learn so comments are more than welcome!