### PR TITLE
auto deploy with CI scripts now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,93 @@
-name: build
+name: test, style, and lint
 
-on: [push
-    , pull_request
-    ]
+on: [push, pull_request]
 
 jobs:
 
-  # scratch:
+   test:
+     runs-on: ubuntu-18.04
+     steps:
+       - name: Git checkout
+         uses: actions/checkout@v1
+         with:
+           fetch-depth: 1
+           submodules: 'true'
+
+       - name: Cache deps
+         uses: actions/cache@v1
+         id: cache-deps
+         with:
+           path: ~/.m2/repository
+           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
+           restore-keys: ${{ runner.os }}-maven-
+
+       - name: Fetch deps
+         if: steps.cache-deps.outputs.cache-hit != 'true'
+         run: lein deps
+
+       - name: Run tests
+         run: script/test/jvm
+
+   lint:
+     runs-on: ubuntu-18.04
+     steps:
+       - name: Git checkout
+         uses: actions/checkout@v1
+         with:
+           fetch-depth: 1
+           submodules: 'true'
+
+       - uses: DeLaGuardo/setup-clj-kondo@v1
+         with:
+           version: '2020.05.09'
+
+       - name: Lint
+         run: script/lint
+
+   style:
+     runs-on: ubuntu-18.04
+     steps:
+       - name: Git checkout
+         uses: actions/checkout@v1
+         with:
+           fetch-depth: 1
+           submodules: 'true'
+
+       - name: Style
+         run: script/style
+
+   carve:
+     runs-on: ubuntu-18.04
+     steps:
+       - name: Git checkout
+         uses: actions/checkout@v1
+         with:
+           fetch-depth: 1
+           submodules: 'true'
+
+       - uses: DeLaGuardo/setup-clojure@2.0
+         with:
+           tools-deps: '1.10.1.469'
+
+       - name: Cache deps
+         uses: actions/cache@v1
+         id: cache-deps
+         with:
+           path: ~/.m2/repository
+           key: ${{ runner.os }}-maven-${{ hashFiles('deps.edn') }}
+           restore-keys: ${{ runner.os }}-maven-
+
+       - name: Fetch deps
+         if: steps.cache-deps.outputs.cache-hit != 'true'
+         run: clojure -A:carve -Stree
+
+       - name: Carve unused vars
+         run: script/carve
+
+
+  ## TODO: Don't build app until we debug why release from `lein prod` doesn't work
+  # build-app:
+  #   needs: [test]
   #   runs-on: ubuntu-18.04
   #   steps:
   #     - name: Git checkout
@@ -14,137 +95,82 @@ jobs:
   #       with:
   #         fetch-depth: 1
   #         submodules: 'true'
-  #
-  #     - name: Scratch
+
+  #     - name: Cache deps
+  #       uses: actions/cache@v1
+  #       id: cache-deps
+  #       with:
+  #         path: ~/.m2/repository
+  #         key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-maven-
+
+  #     - name: Fetch deps
+  #       if: steps.cache-deps.outputs.cache-hit != 'true'
+  #       run: lein deps
+
+  #     - name: Athens version
+  #       id: athens-version
   #       run: |
-  #         echo "Scratch"
-  test:
-    # ubuntu 18.04 comes with lein + java8 installed
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-          submodules: 'true'
+  #         ATHENS_VERSION=$(echo $GITHUB_SHA | head -c 7)
+  #         echo "##[set-output name=version;]${ATHENS_VERSION}"
+  #         echo "##[set-output name=release-name;]athens-app-${ATHENS_VERSION}"
 
-      - name: Cache deps
-        uses: actions/cache@v1
-        id: cache-deps
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
-          restore-keys: |
-                ${{ runner.os }}-maven-
-      - name: Fetch deps
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          lein deps
-      - name: Run tests
-        run: |
-          script/test/jvm
+  #     - name: Release
+  #       run: RELEASE_NAME=${{ steps.athens-version.outputs.release-name }} script/build/athens-app
 
-  lint:
-    # ubuntu 18.04 comes with lein + java8 installed
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-          submodules: 'true'
+  #     - uses: actions/upload-artifact@v1
+  #       with:
+  #         name: app
+  #         path: ${{ steps.athens-version.outputs.release-name }}.tar.gz
 
-      - uses: DeLaGuardo/setup-clj-kondo@v1
-        with:
-          version: '2020.05.09'
 
-      - name: Lint
-        run: |
-          script/lint
-          
-  style:
-    # ubuntu 18.04 comes with lein + java8 installed
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-          submodules: 'true'
-          
-      - name: Style 
-        run: |
-          script/style
-                 
-  carve:
-    # ubuntu 18.04 comes with lein + java8 installed
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-          submodules: 'true'
+   deploy:
+     needs: [test]
+     runs-on: ubuntu-18.04
+     steps:
+       - name: Git checkout
+         uses: actions/checkout@v1
+         with:
+           fetch-depth: 1
+           submodules: 'true'
 
-      - uses: DeLaGuardo/setup-clojure@2.0
-        with:
-          tools-deps: '1.10.1.469'
-                             
-      - name: Cache deps
-        uses: actions/cache@v1
-        id: cache-deps
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('deps.edn') }}
-          restore-keys: |
-                ${{ runner.os }}-maven-    
+       - name: Restore maven
+         uses: actions/cache@v1
+         id: restore-maven
+         with:
+           path: ~/.m2/repository
+           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
+           restore-keys: |
+             ${{ runner.os }}-maven-
 
-      - name: Fetch deps
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          clojure -A:carve -Stree
+       - name: Fetch maven
+         if: steps.restore-maven.outputs.cache-hit != 'true'
+         run: lein deps
 
-      - name: Carving unused vars 
-        run: |
-          script/carve
-          
+       - name: Get yarn cache directory path
+         id: yarn-cache-dir-path
+         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-  build-app:
-    needs: [test]
-    # ubuntu 18.04 comes with lein + java8 installed
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-          submodules: 'true'
+       - name: Restore yarn
+         uses: actions/cache@v1
+         id: restore-yarn
+         with:
+           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+           restore-keys: |
+             ${{ runner.os }}-yarn-
 
-      - name: Cache deps
-        uses: actions/cache@v1
-        id: cache-deps
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('project.clj') }}
-          restore-keys: |
-                ${{ runner.os }}-maven-
-      - name: Fetch deps
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          lein deps
+       - name: Fetch yarn
+         run: yarn install --frozen-lockfile
 
-      - name: Athens version
-        id: athens-version
-        run: |
-          ATHENS_VERSION=$(echo $GITHUB_SHA | head -c 7)
-          echo "##[set-output name=version;]${ATHENS_VERSION}"
-          echo "##[set-output name=release-name;]athens-app-${ATHENS_VERSION}"
+       - name: Compile app and devcards
+         if: github.event_name == 'push'
+         run: COMMIT_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}" script/deploy
 
-      - name: Release
-        run: |
-          RELEASE_NAME=${{ steps.athens-version.outputs.release-name }} script/build/athens-app
-
-      - uses: actions/upload-artifact@v1
-        with:
-          name: app
-          path: ${{ steps.athens-version.outputs.release-name }}.tar.gz
+       - name: Deploy
+         if: github.event_name == 'push'
+         uses: peaceiris/actions-gh-pages@v3
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: ./resources/public

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: test, style, and lint
+name: Test, Lint, Style. Deploy on push
 
 on: [push, pull_request]
 
@@ -125,8 +125,10 @@ jobs:
   #         path: ${{ steps.athens-version.outputs.release-name }}.tar.gz
 
 
+   # Only deploy if a commit is pushed. This lets the previous jobs run on PRs. This also runs when a PR is merged, because a merge is a push.
    deploy:
      needs: [test]
+     if: github.event_name == 'push'
      runs-on: ubuntu-18.04
      steps:
        - name: Git checkout
@@ -165,11 +167,9 @@ jobs:
          run: yarn install --frozen-lockfile
 
        - name: Compile app and devcards
-         if: github.event_name == 'push'
          run: COMMIT_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}" script/deploy
 
        - name: Deploy
-         if: github.event_name == 'push'
          uses: peaceiris/actions-gh-pages@v3
          with:
            github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/project.clj
+++ b/project.clj
@@ -49,7 +49,8 @@
             "devcards"     ["with-profile" "dev" "do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "watch" "devcards"]]
             "compile"      ["with-profile" "dev" "do"
-                            ["run" "-m" "shadow.cljs.devtools.cli" "compile" "app"]]
+                            ["run" "-m" "shadow.cljs.devtools.cli" "compile" "app"]
+                            ["run" "-m" "shadow.cljs.devtools.cli" "compile" "devcards"]]
             "prod"         ["with-profile" "prod" "do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "release" "app"]]
             "build-report" ["with-profile" "prod" "do"

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Compile App and Devcard bundles
+# Using shadow-cljs directly is faster than lein
+./node_modules/shadow-cljs/cli/runner.js compile app --config-merge "{:closure-defines {athens.devcards/spinner/COMMIT_URL \"${COMMIT_URL}\"}}"
+./node_modules/shadow-cljs/cli/runner.js compile devcards --config-merge "{:closure-defines {athens.devcards/spinner/COMMIT_URL \"${COMMIT_URL}\"}}"

--- a/src/cljs/athens/devcards/spinner.cljs
+++ b/src/cljs/athens/devcards/spinner.cljs
@@ -64,8 +64,12 @@
 
 
 (def initial-spinner-container
-  {:margin-top "50vh"
-   :transform "translateY(-50%)"})
+  {:margin-top      "50vh"
+   :transform       "translateY(-50%)"
+   :display         "flex"
+   :flex-direction  "column"
+   :justify-content "center"
+   :align-items     "center"})
 
 
 ;;; Components
@@ -78,9 +82,14 @@
    [:span (use-style spinner-message-style) (or message "Loading...")]])
 
 
+(goog-define COMMIT_URL false)
+
+
 (defn ^:export initial-spinner-component
   []
   [:div (use-style initial-spinner-container)
+   (when COMMIT_URL
+     [:a {:href COMMIT_URL} COMMIT_URL])
    [spinner-component]])
 
 


### PR DESCRIPTION
- makes single `run:` commands one-liners
- deploy to GH pages (TODO: document how to configure for local)
- compiles with `shadow-cljs` because faster
- `prn`s the commit version
