### PR TITLE
feat(blocks): fancier block editing

### DIFF
--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -297,16 +297,14 @@ no results for pull eid returns nil
                                                    :user-select (when dragging-uid "none")})
                        {:class    "block-contents"
                         :data-uid uid})
-       (if (= editing-uid uid)
          [autosize/textarea {:value       string
-                             :class (when (= editing-uid uid) "isEditing")
+                             :class       (when (= editing-uid uid) "isEditing")
                              :auto-focus  true
                              :on-change   (fn [e]
                                             ;;(prn (.. e -target -value)))
                                             (transact! db/dsdb [[:db/add [:block/uid uid] :block/string (.. e -target -value)]]))
-
                              :on-key-down (fn [e] (on-key-down e [:block/uid uid] order))}]
-         [parse-and-render string])
+         [parse-and-render string]
 
        ;; Drop Indicator
        (when (and (= closest-uid uid)

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -296,15 +296,15 @@ no results for pull eid returns nil
                                                    :user-select (when dragging-uid "none")})
                        {:class    "block-contents"
                         :data-uid uid})
-         [:textarea {:value       string
-                             :style       {:width "100%"}
-                             :auto-focus  true
-                             :on-change   (fn [e]
-                                            (prn (.. e -target -value))
+       [:textarea {:value       string
+                   :style       {:width "100%"}
+                   :auto-focus  true
+                   :on-change   (fn [e]
+                                  (prn (.. e -target -value))
                                             ;;(transact! db/dsdb [[:db/add dbid :block/string (.. e -target -value)]])
-                                            )
-                             :on-key-down (fn [e] (on-key-down e dbid order))}]
-         [parse-and-render string]
+                                  )
+                   :on-key-down (fn [e] (on-key-down e dbid order))}]
+       [parse-and-render string]
 
        ;; Drop Indicator
        (when (and (= closest-uid uid)

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -298,14 +298,14 @@ no results for pull eid returns nil
                                                    :user-select (when dragging-uid "none")})
                        {:class    "block-contents"
                         :data-uid uid})
-         [autosize/textarea {:value       string
-                             :class       (when (= editing-uid uid) "isEditing")
-                             :auto-focus  true
-                             :on-change   (fn [e]
+       [autosize/textarea {:value       string
+                           :class       (when (= editing-uid uid) "isEditing")
+                           :auto-focus  true
+                           :on-change   (fn [e]
                                             ;;(prn (.. e -target -value)))
-                                            (transact! db/dsdb [[:db/add [:block/uid uid] :block/string (.. e -target -value)]]))
-                             :on-key-down (fn [e] (on-key-down e [:block/uid uid] order))}]
-         [parse-and-render string]
+                                          (transact! db/dsdb [[:db/add [:block/uid uid] :block/string (.. e -target -value)]]))
+                           :on-key-down (fn [e] (on-key-down e [:block/uid uid] order))}]
+       [parse-and-render string]
 
        ;; Drop Indicator
        (when (and (= closest-uid uid)

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -9,7 +9,6 @@
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
     [garden.selectors :as selectors]
-    [komponentit.autosize :as autosize]
     [posh.reagent :refer [transact! pull]]
     [re-frame.core :as rf]
     [stylefy.core :as stylefy :refer [use-style]])
@@ -190,23 +189,26 @@
                                  :right "0"
                                  :bottom "0"
                                  :height "100%"
+                                 :width "100%"
                                  :caret-color (color :link-color)
                                  :margin "0"
                                  :font-size "inherit"
                                  :line-height "inherit"
                                  :overflow "visible"
-                                 :border-radius "2px"
+                                 :border-radius "4px"
                                  :transition "all 0.15s ease"
-                                 :box-shadow (str "-2px 0 0 2px " (color :panel-color))
+                                 :box-shadow (str "-4px 0 0 0" (color :panel-color))
                                  :border "0"
                                  :opacity "0"
                                  :font-family "inherit"}]
-                     [:textarea:focus {:outline "none"
-                                       :z-index "10"
-                                       :display "block"
-                                       :opacity "1"}]
-                     [:span [:span :a {:position "relative"
-                                       :z-index "2"}]]]})
+                     [:textarea:focus
+                      :.isEditing {:outline "none"
+                                   :z-index "10"
+                                   :display "block"
+                                   :opacity "1"}]
+                     [:span [:span
+                             :a {:position "relative"
+                                 :z-index "2"}]]]})
 
 
 (def tooltip-style
@@ -297,7 +299,7 @@ no results for pull eid returns nil
                        {:class    "block-contents"
                         :data-uid uid})
        [:textarea {:value       string
-                   :style       {:width "100%"}
+                   :class (when (= editing-uid uid) "isEditing")
                    :auto-focus  true
                    :on-change   (fn [e]
                                   (prn (.. e -target -value))

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -172,20 +172,41 @@
 
 
 (def block-content-style
-  {::stylefy/manual [[:textarea {:-webkit-appearance "none"
+  {:position "relative"
+   :overflow "visible"
+   ::stylefy/manual [[:textarea {:display "none"}]
+                     [:&:hover [:textarea {:display "block"
+                                           :z-index 1}]]
+                     [:textarea {:-webkit-appearance "none"
+                                 :cursor "text"
                                  :resize "none"
+                                 :transform "translate3d(0,0,0)"
                                  :color "inherit"
                                  :padding "0"
+                                 :background (color :panel-color)
+                                 :position "absolute"
+                                 :top "0"
+                                 :left "0"
+                                 :right "0"
+                                 :bottom "0"
+                                 :height "100%"
                                  :caret-color (color :link-color)
                                  :margin "0"
                                  :font-size "inherit"
                                  :line-height "inherit"
-                                 :overflow "hidden"
-                                 :margin-bottom "-10px" ;; FIXME: hack to correct for improper textarea autosizing. 
+                                 :overflow "visible"
+                                 :border-radius "2px"
+                                 :transition "all 0.15s ease"
+                                 :box-shadow (str "-2px 0 0 2px " (color :panel-color))
                                  :border "0"
+                                 :opacity "0"
                                  :font-family "inherit"}]
                      [:textarea:focus {:outline "none"
-                                       :opacity (:opacity-high OPACITIES)}]]})
+                                       :z-index "10"
+                                       :display "block"
+                                       :opacity "1"}]
+                     [:span [:span :a {:position "relative"
+                                       :z-index "2"}]]]})
 
 
 (def tooltip-style
@@ -275,8 +296,7 @@ no results for pull eid returns nil
                                                    :user-select (when dragging-uid "none")})
                        {:class    "block-contents"
                         :data-uid uid})
-       (if (= editing-uid uid)
-         [autosize/textarea {:value       string
+         [:textarea {:value       string
                              :style       {:width "100%"}
                              :auto-focus  true
                              :on-change   (fn [e]
@@ -284,7 +304,7 @@ no results for pull eid returns nil
                                             ;;(transact! db/dsdb [[:db/add dbid :block/string (.. e -target -value)]])
                                             )
                              :on-key-down (fn [e] (on-key-down e dbid order))}]
-         [parse-and-render string])
+         [parse-and-render string]
 
        ;; Drop Indicator
        (when (and (= closest-uid uid)

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -9,6 +9,7 @@
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
     [garden.selectors :as selectors]
+    [komponentit.autosize :as autosize]
     [posh.reagent :refer [transact! pull]]
     [re-frame.core :as rf]
     [stylefy.core :as stylefy :refer [use-style]])
@@ -187,16 +188,14 @@
                                  :top "0"
                                  :left "0"
                                  :right "0"
-                                 :bottom "0"
-                                 :height "100%"
                                  :width "100%"
+                                 :min-height "100%"
                                  :caret-color (color :link-color)
                                  :margin "0"
                                  :font-size "inherit"
                                  :line-height "inherit"
-                                 :overflow "visible"
                                  :border-radius "4px"
-                                 :transition "all 0.15s ease"
+                                 :transition "opacity 0.15s ease"
                                  :box-shadow (str "-4px 0 0 0" (color :panel-color))
                                  :border "0"
                                  :opacity "0"
@@ -298,7 +297,7 @@ no results for pull eid returns nil
                                                    :user-select (when dragging-uid "none")})
                        {:class    "block-contents"
                         :data-uid uid})
-       [:textarea {:value       string
+       [autosize/textarea {:value       string
                    :class (when (= editing-uid uid) "isEditing")
                    :auto-focus  true
                    :on-change   (fn [e]

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -298,13 +298,13 @@ no results for pull eid returns nil
                        {:class    "block-contents"
                         :data-uid uid})
        [autosize/textarea {:value       string
-                   :class (when (= editing-uid uid) "isEditing")
-                   :auto-focus  true
-                   :on-change   (fn [e]
-                                  (prn (.. e -target -value))
+                           :class (when (= editing-uid uid) "isEditing")
+                           :auto-focus  true
+                           :on-change   (fn [e]
+                                          (prn (.. e -target -value))
                                             ;;(transact! db/dsdb [[:db/add dbid :block/string (.. e -target -value)]])
-                                  )
-                   :on-key-down (fn [e] (on-key-down e dbid order))}]
+                                          )
+                           :on-key-down (fn [e] (on-key-down e dbid order))}]
        [parse-and-render string]
 
        ;; Drop Indicator

--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -174,6 +174,7 @@
 (def block-content-style
   {:position "relative"
    :overflow "visible"
+   :word-break "break-word"
    ::stylefy/manual [[:textarea {:display "none"}]
                      [:&:hover [:textarea {:display "block"
                                            :z-index 1}]]

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -19,7 +19,7 @@
                   (concat [:span {:class "block"}] contents))
      :page-link (fn [title]
                   (let [node (pull db/dsdb '[*] [:node/title title])]
-                    [:span {:class "page-link"}
+                    [:span {:class "page-link" :style {:cursor "pointer"}}
                      [:span {:style {:color "gray"}} "[["]
                      [:span {:on-click #(navigate-uid (:block/uid @node))
                              :style    {:text-decoration "none" :color "dodgerblue"}} title]


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/)

This one scares me a little because of how much is happening at the highest levels of UI code. This is probably being far too clever and brittle, but I haven't found any actual or theoretical problems yet.

**How it works:**
- Textareas are absolutely positioned over their respective blocks.
- Textareas are invisible and display: none by default.
- Hovering a block enables the textarea so that it can be clicked.
- Interactible elements in blocks are z-indexed above the textarea so they can be clicked.
- Regular text in a block is behind the textarea, so is never clicked.
- Clicks are passed through directly to the textarea so the textarea captures the click location.
- Focusing a textarea makes it opaque and in front, and textareas are also triggered by `editing-uid`

**Issues**
- Actual text editing isn't working, but that was true before these changes.
- The textarea of the block you're currently editing can be taller than the block space, so it overlaps following blocks.
- `editing-uid` isn't toggled off when you click outside the textarea. Clicking outside the textarea blurs it, but editing state remains. This leaves room for some weird stuff like parsed block text appearing over a focused textarea.
- Clicking on block contents triggers some state, which may or may not be interrupting the :focus behavior of an already-editing textarea.