### PR TITLE
fix(Sidebar): readability, usability improvements

### DIFF
--- a/src/cljs/athens/devcards/buttons.cljs
+++ b/src/cljs/athens/devcards/buttons.cljs
@@ -1,14 +1,14 @@
 (ns athens.devcards.buttons
   (:require
-    ["@material-ui/icons" :as mui-icons]
-    [athens.db]
-    [athens.style :refer [color]]
-    [cljsjs.react]
-    [cljsjs.react.dom]
-    [devcards.core :refer-macros [defcard-rg]]
-    [garden.color :refer [darken]]
-    [garden.selectors :as selectors]
-    [stylefy.core :as stylefy :refer [use-style]]))
+   ["@material-ui/icons" :as mui-icons]
+   [athens.db]
+   [athens.style :refer [color]]
+   [cljsjs.react]
+   [cljsjs.react.dom]
+   [devcards.core :refer-macros [defcard-rg]]
+   [garden.color :refer [darken]]
+   [garden.selectors :as selectors]
+   [stylefy.core :as stylefy :refer [use-style]]))
 
 
 ;;; Styles
@@ -58,18 +58,18 @@
 
 
 (defn button
-  [{:keys [disabled label on-click-fn style active]}]
+  [{:keys [disabled label on-click-fn style active class]}]
   [:button (use-style (merge buttons-style style) {:disabled disabled
                                                    :on-click on-click-fn
-                                                   :class (when active "active")})
+                                                   :class [class (when active "active")]})
    label])
 
 
 (defn button-primary
-  [{:keys [disabled label on-click-fn style active]}]
+  [{:keys [disabled label on-click-fn style active class]}]
   [:button (use-style (merge buttons-primary-style style) {:disabled disabled
                                                            :on-click on-click-fn
-                                                           :class (when active "active")})
+                                                           :class [class (when active "active")]})
    label])
 
 

--- a/src/cljs/athens/devcards/buttons.cljs
+++ b/src/cljs/athens/devcards/buttons.cljs
@@ -1,14 +1,14 @@
 (ns athens.devcards.buttons
   (:require
-   ["@material-ui/icons" :as mui-icons]
-   [athens.db]
-   [athens.style :refer [color]]
-   [cljsjs.react]
-   [cljsjs.react.dom]
-   [devcards.core :refer-macros [defcard-rg]]
-   [garden.color :refer [darken]]
-   [garden.selectors :as selectors]
-   [stylefy.core :as stylefy :refer [use-style]]))
+    ["@material-ui/icons" :as mui-icons]
+    [athens.db]
+    [athens.style :refer [color]]
+    [cljsjs.react]
+    [cljsjs.react.dom]
+    [devcards.core :refer-macros [defcard-rg]]
+    [garden.color :refer [darken]]
+    [garden.selectors :as selectors]
+    [stylefy.core :as stylefy :refer [use-style]]))
 
 
 ;;; Styles

--- a/src/cljs/athens/devcards/right_sidebar.cljs
+++ b/src/cljs/athens/devcards/right_sidebar.cljs
@@ -201,8 +201,7 @@
     (if (empty? items)
       [empty-message]
       (doall
-        (for [[uid {:keys [open node/title block/string]}] items
-              :let [node-page? (boolean title)]]
+        (for [[uid {:keys [open node/title block/string]}] items]
           ^{:key uid}
           [:article (use-style sidebar-item-style)
            [:header (use-style sidebar-item-heading-style {:class (when open "is-open")})
@@ -221,7 +220,7 @@
                       :label [:> mui-icons/Close]}]]]
            (when open
              [:div (use-style sidebar-item-container-style)
-              (if node-page?
+              (if title
                 [node-page-component [:block/uid uid]]
                 [block-page-component [:block/uid uid]])])])))]
    [button {:style sidebar-toggle-style

--- a/src/cljs/athens/devcards/right_sidebar.cljs
+++ b/src/cljs/athens/devcards/right_sidebar.cljs
@@ -96,6 +96,7 @@
 
 (def sidebar-item-style
   {:display "flex"
+   :flex "0 0 auto"
    :flex-direction "column"
    :border-top [["1px solid" (color :panel-color)]]})
 
@@ -126,6 +127,7 @@
 (def sidebar-item-heading-style
   {:font-size "16px"
    :display "flex"
+   :flex "0 0 auto"
    :align-items "center"
    :padding "4px 16px"
    :position "sticky"

--- a/src/cljs/athens/devcards/right_sidebar.cljs
+++ b/src/cljs/athens/devcards/right_sidebar.cljs
@@ -167,7 +167,23 @@
                      [:&.is-open [:h2 {:font-weight "500"}]]]})
 
 
+(def empty-message-style {:align-self "center"
+                          :display "flex"
+                          :margin "auto auto"
+                          :align-items "center"
+                          :color (color :body-text-color :opacity-med)
+                          :font-size "14px"
+                          :border-radius "8px"
+                          :line-height 1.3
+                          ::stylefy/manual [[:p {:max-width "13em"}]]})
+
+
 ;;; Components
+
+
+(defn empty-message []
+  [:div (use-style empty-message-style)
+   [:p "Hold shift when clicking a page link to view the page in the sidebar."]])
 
 
 (defn right-sidebar-el
@@ -178,30 +194,32 @@
      [:h1 "Pages and Blocks"]
     ;;  [button {:label [:> mui-icons/FilterList]}]
      ]
-    (doall
-      (for [[uid {:keys [open node/title block/string]}] items
-            :let [node-page? (boolean title)]]
-        ^{:key uid}
-        [:article (use-style sidebar-item-style)
-         [:header (use-style sidebar-item-heading-style {:class (when open "is-open")})
-          [button {:style sidebar-item-toggle-style
-                   :on-click-fn #(dispatch [:right-sidebar/toggle-item uid])
-                   :class (when open "is-open")
-                   :label [:> mui-icons/ChevronRight]}]
-          [:h2
-           (if title
-             [:<> [:> mui-icons/Description] title]
-             [:<> [:> mui-icons/FiberManualRecord] string])]
-          [:div {:class "controls"}
+    (if (empty? items)
+      [empty-message]
+      (doall
+       (for [[uid {:keys [open node/title block/string]}] items
+             :let [node-page? (boolean title)]]
+         ^{:key uid}
+         [:article (use-style sidebar-item-style)
+          [:header (use-style sidebar-item-heading-style {:class (when open "is-open")})
+           [button {:style sidebar-item-toggle-style
+                    :on-click-fn #(dispatch [:right-sidebar/toggle-item uid])
+                    :class (when open "is-open")
+                    :label [:> mui-icons/ChevronRight]}]
+           [:h2
+            (if title
+              [:<> [:> mui-icons/Description] title]
+              [:<> [:> mui-icons/FiberManualRecord] string])]
+           [:div {:class "controls"}
         ;;  [button {:label [:> mui-icons/DragIndicator]}]
         ;;  [:hr]
-           [button {:on-click-fn #(dispatch [:right-sidebar/close-item uid])
-                    :label [:> mui-icons/Close]}]]]
-         (when open
-           [:div (use-style sidebar-item-container-style)
-            (if node-page?
-              [node-page-component [:block/uid uid]]
-              [block-page-component [:block/uid uid]])])]))]
+            [button {:on-click-fn #(dispatch [:right-sidebar/close-item uid])
+                     :label [:> mui-icons/Close]}]]]
+          (when open
+            [:div (use-style sidebar-item-container-style)
+             (if node-page?
+               [node-page-component [:block/uid uid]]
+               [block-page-component [:block/uid uid]])])])))]
    [button {:style sidebar-toggle-style
             :class (if open? "is-open" "is-closed")
             :on-click-fn #(dispatch [:right-sidebar/toggle])

--- a/src/cljs/athens/devcards/right_sidebar.cljs
+++ b/src/cljs/athens/devcards/right_sidebar.cljs
@@ -167,21 +167,23 @@
                      [:&.is-open [:h2 {:font-weight "500"}]]]})
 
 
-(def empty-message-style {:align-self "center"
-                          :display "flex"
-                          :margin "auto auto"
-                          :align-items "center"
-                          :color (color :body-text-color :opacity-med)
-                          :font-size "14px"
-                          :border-radius "8px"
-                          :line-height 1.3
-                          ::stylefy/manual [[:p {:max-width "13em"}]]})
+(def empty-message-style
+  {:align-self "center"
+   :display "flex"
+   :margin "auto auto"
+   :align-items "center"
+   :color (color :body-text-color :opacity-med)
+   :font-size "14px"
+   :border-radius "8px"
+   :line-height 1.3
+   ::stylefy/manual [[:p {:max-width "13em"}]]})
 
 
 ;;; Components
 
 
-(defn empty-message []
+(defn empty-message
+  []
   [:div (use-style empty-message-style)
    [:p "Hold shift when clicking a page link to view the page in the sidebar."]])
 
@@ -197,29 +199,29 @@
     (if (empty? items)
       [empty-message]
       (doall
-       (for [[uid {:keys [open node/title block/string]}] items
-             :let [node-page? (boolean title)]]
-         ^{:key uid}
-         [:article (use-style sidebar-item-style)
-          [:header (use-style sidebar-item-heading-style {:class (when open "is-open")})
-           [button {:style sidebar-item-toggle-style
-                    :on-click-fn #(dispatch [:right-sidebar/toggle-item uid])
-                    :class (when open "is-open")
-                    :label [:> mui-icons/ChevronRight]}]
-           [:h2
-            (if title
-              [:<> [:> mui-icons/Description] title]
-              [:<> [:> mui-icons/FiberManualRecord] string])]
-           [:div {:class "controls"}
+        (for [[uid {:keys [open node/title block/string]}] items
+              :let [node-page? (boolean title)]]
+          ^{:key uid}
+          [:article (use-style sidebar-item-style)
+           [:header (use-style sidebar-item-heading-style {:class (when open "is-open")})
+            [button {:style sidebar-item-toggle-style
+                     :on-click-fn #(dispatch [:right-sidebar/toggle-item uid])
+                     :class (when open "is-open")
+                     :label [:> mui-icons/ChevronRight]}]
+            [:h2
+             (if title
+               [:<> [:> mui-icons/Description] title]
+               [:<> [:> mui-icons/FiberManualRecord] string])]
+            [:div {:class "controls"}
         ;;  [button {:label [:> mui-icons/DragIndicator]}]
         ;;  [:hr]
-            [button {:on-click-fn #(dispatch [:right-sidebar/close-item uid])
-                     :label [:> mui-icons/Close]}]]]
-          (when open
-            [:div (use-style sidebar-item-container-style)
-             (if node-page?
-               [node-page-component [:block/uid uid]]
-               [block-page-component [:block/uid uid]])])])))]
+             [button {:on-click-fn #(dispatch [:right-sidebar/close-item uid])
+                      :label [:> mui-icons/Close]}]]]
+           (when open
+             [:div (use-style sidebar-item-container-style)
+              (if node-page?
+                [node-page-component [:block/uid uid]]
+                [block-page-component [:block/uid uid]])])])))]
    [button {:style sidebar-toggle-style
             :class (if open? "is-open" "is-closed")
             :on-click-fn #(dispatch [:right-sidebar/toggle])


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/#/page/AVOHMK6bK)

- Show a nice message when the sidebar is empty
- Sidebar item collapse toggle should rotate when items are open. Fixes #200 
- Sidebar items shouldn't collapse into each other