### PR TITLE
Debug datascript

### DIFF
--- a/src/cljs/athens/devcards/daily_notes.cljs
+++ b/src/cljs/athens/devcards/daily_notes.cljs
@@ -87,8 +87,8 @@
       (let [eids (q '[:find [?e ...]
                       :in $ [?uid ...]
                       :where [?e :block/uid ?uid]]
-                   db/dsdb
-                   @note-refs)]
+                    db/dsdb
+                    @note-refs)]
         (when (not-empty @eids)
           (let [notes (pull-many db/dsdb '[*] @eids)]
             [:div#daily-notes (use-style daily-notes-scroll-area-style)

--- a/src/cljs/athens/devcards/daily_notes.cljs
+++ b/src/cljs/athens/devcards/daily_notes.cljs
@@ -7,7 +7,7 @@
     [cljsjs.react.dom]
     [devcards.core :refer-macros [defcard-rg]]
     [goog.functions :refer [debounce]]
-    [posh.reagent :refer [pull-many]]
+    [posh.reagent :refer [q pull-many]]
     [re-frame.core :refer [dispatch subscribe]]
     [stylefy.core :refer [use-style]]
     [tick.alpha.api :as t]
@@ -81,21 +81,25 @@
 (defn daily-notes-panel
   []
   (let [note-refs (subscribe [:daily-notes])]
-    (when (empty? @note-refs)
-      (dispatch [:next-daily-note (get-day)]))
     (fn []
-      (let [notes (pull-many db/dsdb
-                             '[*]
-                             (map (fn [x] [:block/uid x]) @note-refs))]
-        [:div#daily-notes (use-style daily-notes-scroll-area-style)
-         (doall
-           (for [{:keys [block/uid]} @notes]
-             ^{:key uid}
-             [:<>
-              [:div (use-style daily-notes-page-style)
-               [node-page-component [:block/uid uid]]]]))
-         [:div (use-style daily-notes-notional-page-style)
-          [:h1 "Earlier"]]]))))
+      (when (empty? @note-refs)
+        (dispatch [:next-daily-note (get-day)]))
+      (let [eids (q '[:find [?e ...]
+                      :in $ [?uid ...]
+                      :where [?e :block/uid ?uid]]
+                   db/dsdb
+                   @note-refs)]
+        (when (not-empty @eids)
+          (let [notes (pull-many db/dsdb '[*] @eids)]
+            [:div#daily-notes (use-style daily-notes-scroll-area-style)
+             (doall
+               (for [{:keys [block/uid]} @notes]
+                 ^{:key uid}
+                 [:<>
+                  [:div (use-style daily-notes-page-style)
+                   [node-page-component [:block/uid uid]]]]))
+             [:div (use-style daily-notes-notional-page-style)
+              [:h1 "Earlier"]]]))))))
 
 
 ;;; Devcards

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -32,8 +32,8 @@
 
 (reg-fx
   :set-local-storage-db
-  (fn [_]
-    (js/localStorage.setItem "datascript/DB" (dt/write-transit-str @db/dsdb))))
+  (fn [db]
+    (js/localStorage.setItem "datascript/DB" (dt/write-transit-str db))))
 
 
 (reg-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -199,7 +199,6 @@
     (assoc db :daily-notes [])))
 
 
-
 (reg-event-fx
   :transact-event
   (fn [_ [_ datoms]]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -84,8 +84,7 @@
     (update db :right-sidebar/items dissoc uid)))
 
 
-;; TODO: toggle open right sidebar if not open
-;; FIXME: what happens when item is already in sidebar? all indices increment, which is not right
+;; TODO: change right sidebar items from map to datascript
 (reg-event-fx
   :right-sidebar/open-item
   (fn-traced [{:keys [db]} [_ uid]]
@@ -114,6 +113,12 @@
   :clear-errors
   (fn-traced [db]
              (assoc-in db [:errors] {})))
+
+
+(reg-event-db
+  :set-loading
+  (fn-traced [db]
+    (assoc-in db [:loading] true)))
 
 
 (reg-event-db
@@ -161,14 +166,20 @@
             :on-failure [:alert-failure]}}))
 
 
-;; FIXME? I reset db/dsdb and store its value in localStorage in the same step. How do we ensure the order of operations is correct?
 (reg-event-fx
   :parse-datoms
   (fn [_ [_ json-str]]
     (let [datoms (db/str-to-db-tx json-str)
           new-db (d/db-with (d/empty-db db/schema) datoms)]
       {:reset-conn new-db
-       :set-local-storage-db nil})))
+       :set-local-storage-db new-db
+       :db (assoc db/rfdb :loading false)})))
+
+
+(reg-event-fx
+  :reset-dsdb
+  (fn []
+    {:reset-conn (d/empty-db db/schema)}))
 
 
 (reg-event-fx
@@ -176,8 +187,17 @@
   (fn [{:keys [db]}]
     (if-let [stored (js/localStorage.getItem "datascript/DB")]
       {:reset-conn (dt/read-transit-str stored)
-       :db         (assoc db :loading false)}
-      {:dispatch [:get-datoms]})))
+       ;;:db         (assoc (assoc db/rfdb :loading false) :current-route (:current-route db))
+       :db         (merge db/rfdb {:loading false :current-route (:current-route db)})}
+      {:dispatch [:get-datoms]
+       :db       db/rfdb})))
+
+
+(reg-event-db
+  :daily-notes/reset
+  (fn [db _]
+    (assoc db :daily-notes [])))
+
 
 
 (reg-event-fx

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -85,8 +85,8 @@
 
 
 (defn match-panel
-  [name]
-  [(case name
+  [route-name]
+  [(case route-name
      :about about-panel
      :home daily-notes-panel
      :pages pages-panel
@@ -99,16 +99,17 @@
   (let [current-route (subscribe [:current-route])
         loading (subscribe [:loading])]
     (fn []
-      [:<>
-       [alert]
-       [athena-component]
-       (if @loading
-         [initial-spinner-component]
-         [:div (use-style app-wrapper-style)
-          [left-sidebar]
-          [:div (use-style main-content-style
-                           {:on-scroll (when (= (-> @current-route :data :name) :home)
-                                         db-scroll-daily-notes)})
-           [match-panel (-> @current-route :data :name)]]
-          [right-sidebar-component]
-          [devtool-component]])])))
+      (let [route-name (-> @current-route :data :name)]
+        [:<>
+         [alert]
+         [athena-component]
+         (if @loading
+           [initial-spinner-component]
+           [:div (use-style app-wrapper-style)
+            [left-sidebar]
+            [:div (use-style main-content-style
+                    {:on-scroll (when (= route-name :home)
+                                  db-scroll-daily-notes)})
+             [match-panel route-name]]
+            [right-sidebar-component]
+            [devtool-component]])]))))

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -108,8 +108,8 @@
            [:div (use-style app-wrapper-style)
             [left-sidebar]
             [:div (use-style main-content-style
-                    {:on-scroll (when (= route-name :home)
-                                  db-scroll-daily-notes)})
+                             {:on-scroll (when (= route-name :home)
+                                           db-scroll-daily-notes)})
              [match-panel route-name]]
             [right-sidebar-component]
             [devtool-component]])]))))


### PR DESCRIPTION
https://github.com/tonsky/datascript/issues/315

Many issues here, mainly to do with asynchronous `dispatch`es, routing, and resetting the datascript and re-frame dbs. Not a normal bug, as it's probably rare to reset these two database in an app. My poorly written code elsewhere probably didn't help, namely with routing and me not realizing that resetting app-db would reset the routing as well. But the stack trace for the pull API was incredibly difficult to go through, and the resetting of the DB might've had non-deterministic behavior due to the nature of dispatches? Not sure here, maybe I'm just trying to blame other people.

The code that led to the problem mainly:

```

(defn daily-notes-panel
  []
  (let [note-refs (subscribe [:daily-notes])]
    (fn []
      (when (empty? @note-refs)
        (dispatch [:next-daily-note (get-day)]))
      (let [eids (q '[:find [?e ...]
                      :in $ [?uid ...]
                      :where [?e :block/uid ?uid]]
                   db/dsdb
                   @note-refs)]
        (prn "EIDS" @eids)
        (when (not-empty @eids)
          (prn "REFS" @note-refs)
          (let [notes (pull-many db/dsdb
                        '[*]
                        (map (fn [x] [:block/uid x]) @note-refs))] ;; <----
            (prn "notes" @notes)
            [:div#daily-notes (use-style daily-notes-scroll-area-style)
             (doall
               (for [{:keys [block/uid]} @notes]
                 ^{:key uid}
                 [:<>
                  [:div (use-style daily-notes-page-style)
                   [node-page-component [:block/uid uid]]]]))
             [:div (use-style daily-notes-notional-page-style)
              [:h1 "Earlier"]]]))))))

```