### PR TITLE
feat(blocks): start on slash commands, inline-search, hot keys. refactor devcards and athena

### DIFF
--- a/src/cljs/athens/devcards/dropdown.cljs
+++ b/src/cljs/athens/devcards/dropdown.cljs
@@ -1,71 +1,18 @@
 (ns athens.devcards.dropdown
   (:require
     ["@material-ui/icons" :as mui-icons]
-    [athens.views.dropdown :refer [dropdown menu-item menu kbd submenu-indicator menu-separator menu-heading]]
-    [athens.views.filters :refer [filters-el]]
+    [athens.views.dropdown :refer [slash-menu-component block-context-menu-component filter-dropdown-component]]
     [athens.views.textinput :refer [textinput]]
     [devcards.core :refer-macros [defcard-rg]]))
 
 
 (defcard-rg Slash-Menu
-  [dropdown {:content
-             [:<>
-              [textinput {:placeholder "Type to filter commands"}]
-              [menu {:style {:max-height "8em"} :content
-                     [:<>
-                      [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Description] [:span "Page Reference"] [kbd "[["]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Link] [:span "Block Reference"] [kbd "(("]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Timer] [:span "Current Time"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]]}])
+  [slash-menu-component])
 
 
-(defcard-rg Block-Dropdown-Menu
-  [dropdown {:content
-             [menu {:content
-                    [:<>
-                    ;;  [menu-heading "Modify Block 'Day of Datomic On-Prem 2016'"]
-                    ;;  [textinput {:icon [:> mui-icons/Face] :placeholder "Type to filter"}]
-                     [menu-item {:label [:<> [:> mui-icons/Link] [:span "Copy Page Reference"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/Star] [:span "Add to Shortcuts"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/Face] [:span "Add Reaction"] [submenu-indicator]]}]
-                     [menu-separator]
-                     [menu-item {:label [:<> [:> mui-icons/LastPage] [:span "Open in Sidebar"] [kbd "shift-click"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/Launch] [:span "Open in New Window"] [kbd "ctrl-o"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/UnfoldMore] [:span "Expand All"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/UnfoldLess] [:span "Collapse All"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/Slideshow] [:span "View As"]  [submenu-indicator]]}]
-                     [menu-separator]
-                     [menu-item {:label [:<> [:> mui-icons/FileCopy] [:span "Duplicate and Break Links"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/LibraryAdd] [:span "Save as Template"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/History] [:span "Browse Versions"]]}]
-                     [menu-item {:label [:<> [:> mui-icons/CloudDownload] [:span "Export As"]]}]]}]}])
+(defcard-rg Block-Context-Menu
+  [block-context-menu-component])
 
 
-(def items
-  {"Amet"   {:count 6 :state :added}
-   "At"     {:count 130 :state :excluded}
-   "Diam"   {:count 6}
-   "Donec"  {:count 6}
-   "Elit"   {:count 30}
-   "Elitudomin mesucen defibocutruon"  {:count 1}
-   "Erat"   {:count 11}
-   "Est"    {:count 2}
-   "Eu"     {:count 2}
-   "Ipsum"  {:count 2 :state :excluded}
-   "Magnis" {:count 10 :state :added}
-   "Metus"  {:count 29}
-   "Mi"     {:count 7 :state :added}
-   "Quam"   {:count 1}
-   "Turpis" {:count 97}
-   "Vitae"  {:count 1}})
-
-
-(defcard-rg With-Filters-and-custom-style-accommodations
-  [dropdown {:style {:width "20em" :height "20em"}
-             :content [:<>
-                       [menu-heading "Filters"]
-                       [filters-el "((some-uid))" items]]}])
+(defcard-rg Filter-Dropdown
+  [filter-dropdown-component])

--- a/src/cljs/athens/devcards/dropdown.cljs
+++ b/src/cljs/athens/devcards/dropdown.cljs
@@ -1,8 +1,6 @@
 (ns athens.devcards.dropdown
   (:require
-    ["@material-ui/icons" :as mui-icons]
     [athens.views.dropdown :refer [slash-menu-component block-context-menu-component filter-dropdown-component]]
-    [athens.views.textinput :refer [textinput]]
     [devcards.core :refer-macros [defcard-rg]]))
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -393,7 +393,7 @@
       :else {:dispatch-later [{:ms 0 :dispatch [:transact [[:db/retractEntity [:block/uid uid]]
                                                            [:db/add [:block/uid prev-block-uid-] :block/string (str prev-block-string value)]
                                                            {:db/id (:db/id parent) :block/children reindex}]]}
-                              {:ms 1 :dispatch [:editing/uid prev-block-uid-]}]})))
+                              {:ms 10 :dispatch [:editing/uid prev-block-uid-]}]})))
 
 
 (reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -390,10 +390,10 @@
     (cond
       (and (:node/title parent) (zero? (:block/order block))) nil
       (:block/children block) nil
-      :else {:dispatch-n [[:transact [[:db/retractEntity [:block/uid uid]]
-                                      [:db/add [:block/uid prev-block-uid-] :block/string (str prev-block-string value)]
-                                      {:db/id (:db/id parent) :block/children reindex}]]
-                          [:editing/uid prev-block-uid-]]})))
+      :else {:dispatch-later [{:ms 0 :dispatch [:transact [[:db/retractEntity [:block/uid uid]]
+                                                           [:db/add [:block/uid prev-block-uid-] :block/string (str prev-block-string value)]
+                                                           {:db/id (:db/id parent) :block/children reindex}]]}
+                              {:ms 1 :dispatch [:editing/uid prev-block-uid-]}]})))
 
 
 (reg-event-fx

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -64,7 +64,7 @@
   [tree]
   (insta/transform
     {:block     (fn [& contents]
-                  (concat [:span {:class "block"}] contents))
+                  (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
      :page-link (fn [title]
                   (let [node (pull db/dsdb '[*] [:node/title title])]
                     [:span (use-style page-link {:class "page-link"})

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -5,6 +5,7 @@
     [athens.parse-renderer :refer [parse-and-render]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+    [athens.views.dropdown :refer [slash-menu-component]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :refer [join]]
@@ -278,7 +279,8 @@
 (defn block-el
   "Two checks to make sure block is open or not: children exist and :block/open bool"
   [block]
-  (let [state (r/atom {:atom-string   (:block/string block)})]
+  (let [state (r/atom {:atom-string (:block/string block)
+                       :slash? false})]
     (fn [block]
       (let [{:block/keys [uid string open order children] dbid :db/id} block
             open?       (and (seq children) open)
@@ -356,6 +358,9 @@
            (for [child children]
              [:div {:style {:margin-left "32px"} :key (:db/id child)}
               [block-el child]]))
+
+         (when (:slash? @state)
+           [slash-menu-component])
 
          ;; Drop Indicator
          (when (and (= closest-uid uid) (= closest-kind :sibling))

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -4,6 +4,8 @@
     [athens.db]
     [athens.style :refer [color DEPTH-SHADOWS]]
     [athens.views.buttons :refer [button]]
+    [athens.views.filters :refer [filters-el]]
+    [athens.views.textinput :refer [textinput]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [garden.selectors :as selectors]
@@ -88,7 +90,7 @@
    ::stylefy/manual [[:&:last-child {:padding-inline-end "0"}]]})
 
 
-;;; Components
+;;; Primitives
 
 
 (defn dropdown
@@ -126,3 +128,73 @@
 (defn menu-heading
   [heading]
   [:header (use-style menu-heading-style) [:span heading]])
+
+
+;;; Components
+
+
+(defn slash-menu-component
+  []
+  [dropdown {:content
+             [:<>
+              [textinput {:placeholder "Type to filter commands"}]
+              [menu {:style {:max-height "8em"} :content
+                            [:<>
+                             [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
+                             [menu-item {:label [:<> [:> mui-icons/Description] [:span "Page Reference"] [kbd "[["]]}]
+                             [menu-item {:label [:<> [:> mui-icons/Link] [:span "Block Reference"] [kbd "(("]]}]
+                             [menu-item {:label [:<> [:> mui-icons/Timer] [:span "Current Time"]]}]
+                             [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
+                             [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
+                             [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
+                             [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]]}])
+
+
+(defn block-context-menu-component
+  []
+  [dropdown {:content
+             [menu {:content
+                    [:<>
+                     ;;  [menu-heading "Modify Block 'Day of Datomic On-Prem 2016'"]
+                     ;;  [textinput {:icon [:> mui-icons/Face] :placeholder "Type to filter"}]
+                     [menu-item {:label [:<> [:> mui-icons/Link] [:span "Copy Page Reference"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Star] [:span "Add to Shortcuts"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Face] [:span "Add Reaction"] [submenu-indicator]]}]
+                     [menu-separator]
+                     [menu-item {:label [:<> [:> mui-icons/LastPage] [:span "Open in Sidebar"] [kbd "shift-click"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Launch] [:span "Open in New Window"] [kbd "ctrl-o"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/UnfoldMore] [:span "Expand All"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/UnfoldLess] [:span "Collapse All"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Slideshow] [:span "View As"] [submenu-indicator]]}]
+                     [menu-separator]
+                     [menu-item {:label [:<> [:> mui-icons/FileCopy] [:span "Duplicate and Break Links"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/LibraryAdd] [:span "Save as Template"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/History] [:span "Browse Versions"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/CloudDownload] [:span "Export As"]]}]]}]}])
+
+
+(def items
+  {"Amet"   {:count 6 :state :added}
+   "At"     {:count 130 :state :excluded}
+   "Diam"   {:count 6}
+   "Donec"  {:count 6}
+   "Elit"   {:count 30}
+   "Elitudomin mesucen defibocutruon"  {:count 1}
+   "Erat"   {:count 11}
+   "Est"    {:count 2}
+   "Eu"     {:count 2}
+   "Ipsum"  {:count 2 :state :excluded}
+   "Magnis" {:count 10 :state :added}
+   "Metus"  {:count 29}
+   "Mi"     {:count 7 :state :added}
+   "Quam"   {:count 1}
+   "Turpis" {:count 97}
+   "Vitae"  {:count 1}})
+
+
+(defn filter-dropdown-component
+  []
+  [dropdown {:style   {:width "20em" :height "20em"}
+             :content [:<>
+                       [menu-heading "Filters"]
+                       [filters-el "((some-uid))" items]]}])

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -139,15 +139,15 @@
              [:<>
               [textinput {:placeholder "Type to filter commands"}]
               [menu {:style {:max-height "8em"} :content
-                            [:<>
-                             [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
-                             [menu-item {:label [:<> [:> mui-icons/Description] [:span "Page Reference"] [kbd "[["]]}]
-                             [menu-item {:label [:<> [:> mui-icons/Link] [:span "Block Reference"] [kbd "(("]]}]
-                             [menu-item {:label [:<> [:> mui-icons/Timer] [:span "Current Time"]]}]
-                             [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
-                             [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
-                             [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
-                             [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]]}])
+                     [:<>
+                      [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
+                      [menu-item {:label [:<> [:> mui-icons/Description] [:span "Page Reference"] [kbd "[["]]}]
+                      [menu-item {:label [:<> [:> mui-icons/Link] [:span "Block Reference"] [kbd "(("]]}]
+                      [menu-item {:label [:<> [:> mui-icons/Timer] [:span "Current Time"]]}]
+                      [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
+                      [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
+                      [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
+                      [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]]}])
 
 
 (defn block-context-menu-component


### PR DESCRIPTION
No longer use `:on-change` for editing text. Instead, capture each `:on-key-down` and let `:on-change` dispatch to re-frame. Slight bugs, but this makes more sense long term because we're going to have custom keybindings.

Lots left to do, but a lot less uncertainty. Much clearer path forward for #97 