### PR TITLE
Menu positioning

### DIFF
--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -130,7 +130,6 @@
 (def block-content-style
   {:position "relative"
    :overflow "visible"
-   :z-index "1"
    :flex-grow "1"
    :word-break "break-word"
    ::stylefy/manual [[:textarea {:display "none"}]
@@ -443,34 +442,30 @@
              [:div [:b "db/id"] [:span dbid]]
              [:div [:b "uid"] [:span uid]]
              [:div [:b "order"] [:span order]]])
-          
-          ;; Hacky wraper div to give the slash menu a static-positioned element
-          ;; to hang from. This should be removed when we're able to place tooltips,
-          ;; menus, and popups at arbitrary screen coordinates.
-          [:div {:style {:flex "1 1 100%"}}
-           ;; Actual string contents - two elements, one for reading and one for writing
-           ;; seems hacky, but so far no better way to click into the correct position with one conditional element
-           [:div (use-style (merge block-content-style {:user-select (when dragging-uid "none")})
-                            {:class    "block-contents"
-                             :data-uid uid})
-            [autosize/textarea {:value       (:atom-string @state)
-                                :class       (when (= editing-uid uid) "is-editing")
-                                :auto-focus  true
-                                :id          (str "editable-uid-" uid)
-                                :on-change (fn [_] (db-on-change (:atom-string @state) uid))
-                                :on-key-down (fn [e] (on-key-down e uid state))}]
-            [parse-and-render string]
+
+          ;; Actual string contents - two elements, one for reading and one for writing
+          ;; seems hacky, but so far no better way to click into the correct position with one conditional element
+          [:div (use-style (merge block-content-style {:user-select (when dragging-uid "none")})
+                           {:class    "block-contents"
+                            :data-uid uid})
+           [autosize/textarea {:value       (:atom-string @state)
+                               :class       (when (= editing-uid uid) "is-editing")
+                               :auto-focus  true
+                               :id          (str "editable-uid-" uid)
+                               :on-change (fn [_] (db-on-change (:atom-string @state) uid))
+                               :on-key-down (fn [e] (on-key-down e uid state))}]
+           [parse-and-render string]
+           
+           
+         (when (:slash? @state)
+           [slash-menu-component {:style {:position "absolute"
+                                          :top "100%"
+                                          :left "-0.125em"}}])
 
            ;; Drop Indicator
-            (when (and (= closest-uid uid)
-                       (= closest-kind :child))
-              [:span (use-style drop-area-indicator)])]]
-
-        ;; Slash menu
-          (when (:slash? @state)
-            [slash-menu-component {:style {:position "absolute"
-                                           :top "100%"
-                                           :left "0"}}])]
+           (when (and (= closest-uid uid)
+                      (= closest-kind :child))
+             [:span (use-style drop-area-indicator)])]]
 
          ;; Children
          (when open?

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -457,10 +457,28 @@
            [parse-and-render string]
            
            
+         ;; Slash menu
          (when (:slash? @state)
            [slash-menu-component {:style {:position "absolute"
                                           :top "100%"
                                           :left "-0.125em"}}])
+
+         ;; Page search menu
+         (when (:search/page @state)
+           (let [query (:search/query @state)
+                 results (when (not (str/blank? query))
+                           (db/search-in-node-title query))]
+             [dropdown {:style {:position "absolute"
+                                :top "100%"
+                                :left "-0.125em"}
+                        :content
+                        (if (not query)
+                          [:div "Start Typing!"]
+                          (for [{:keys [node/title block/uid]} results]
+                            ^{:key uid}
+                            [:div {:on-click #(navigate-uid uid)} title]))}]))
+           
+           
 
            ;; Drop Indicator
            (when (and (= closest-uid uid)
@@ -472,17 +490,6 @@
            (for [child children]
              [:div {:style {:margin-left "32px"} :key (:db/id child)}
               [block-el child]]))
-
-         (when (:search/page @state)
-           (let [query (:search/query @state)
-                 results (when (not (str/blank? query))
-                           (db/search-in-node-title query))]
-             [dropdown {:content
-                        (if (not query)
-                          [:div "Start Typing!"]
-                          (for [{:keys [node/title block/uid]} results]
-                            ^{:key uid}
-                            [:div {:on-click #(navigate-uid uid)} title]))}]))
 
          ;; TODO: block search. will be pretty much same as page search
          ;;(when (:search/block @state)

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -443,33 +443,40 @@
              [:div [:b "db/id"] [:span dbid]]
              [:div [:b "uid"] [:span uid]]
              [:div [:b "order"] [:span order]]])
-
-          ;; Actual string contents - two elements, one for reading and one for writing
-          ;; seems hacky, but so far no better way to click into the correct position with one conditional element
-          [:div (use-style (merge block-content-style {:user-select (when dragging-uid "none")})
-                           {:class    "block-contents"
-                            :data-uid uid})
-           [autosize/textarea {:value       (:atom-string @state)
-                               :class       (when (= editing-uid uid) "is-editing")
-                               :auto-focus  true
-                               :id          (str "editable-uid-" uid)
-                               :on-change (fn [_] (db-on-change (:atom-string @state) uid))
-                               :on-key-down (fn [e] (on-key-down e uid state))}]
-           [parse-and-render string]
+          
+          ;; Hacky wraper div to give the slash menu a static-positioned element
+          ;; to hang from. This should be removed when we're able to place tooltips,
+          ;; menus, and popups at arbitrary screen coordinates.
+          [:div {:style {:flex "1 1 100%"}}
+           ;; Actual string contents - two elements, one for reading and one for writing
+           ;; seems hacky, but so far no better way to click into the correct position with one conditional element
+           [:div (use-style (merge block-content-style {:user-select (when dragging-uid "none")})
+                            {:class    "block-contents"
+                             :data-uid uid})
+            [autosize/textarea {:value       (:atom-string @state)
+                                :class       (when (= editing-uid uid) "is-editing")
+                                :auto-focus  true
+                                :id          (str "editable-uid-" uid)
+                                :on-change (fn [_] (db-on-change (:atom-string @state) uid))
+                                :on-key-down (fn [e] (on-key-down e uid state))}]
+            [parse-and-render string]
 
            ;; Drop Indicator
-           (when (and (= closest-uid uid)
-                      (= closest-kind :child))
-             [:span (use-style drop-area-indicator)])]]
+            (when (and (= closest-uid uid)
+                       (= closest-kind :child))
+              [:span (use-style drop-area-indicator)])]]
+
+        ;; Slash menu
+          (when (:slash? @state)
+            [slash-menu-component {:style {:position "absolute"
+                                           :top "100%"
+                                           :left "0"}}])]
 
          ;; Children
          (when open?
            (for [child children]
              [:div {:style {:margin-left "32px"} :key (:db/id child)}
               [block-el child]]))
-
-         (when (:slash? @state)
-           [slash-menu-component])
 
          (when (:search/page @state)
            (let [query (:search/query @state)

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -5,7 +5,6 @@
     [athens.style :refer [color DEPTH-SHADOWS]]
     [athens.views.buttons :refer [button]]
     [athens.views.filters :refer [filters-el]]
-    [athens.views.textinput :refer [textinput]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [garden.selectors :as selectors]
@@ -137,16 +136,16 @@
 (defn slash-menu-component
   [{:keys [style]}]
   [dropdown {:style style :content
-              [menu {:style {:max-height "8em"} :content
-                     [:<>
-                      [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Description] [:span "Page Reference"] [kbd "[["]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Link] [:span "Block Reference"] [kbd "(("]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Timer] [:span "Current Time"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]}])
+             [menu {:style {:max-height "8em"} :content
+                    [:<>
+                     [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Description] [:span "Page Reference"] [kbd "[["]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Link] [:span "Block Reference"] [kbd "(("]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Timer] [:span "Current Time"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
+                     [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]}])
 
 
 (defn block-context-menu-component

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -26,6 +26,7 @@
    :border-radius "6px"
    :min-height "2em"
    :min-width "2em"
+   :background (color :app-bg-color)
    :box-shadow [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px rgba(0, 0, 0, 0.05)"]]
    :flex-direction "column"})
 
@@ -134,10 +135,8 @@
 
 
 (defn slash-menu-component
-  []
-  [dropdown {:content
-             [:<>
-              [textinput {:placeholder "Type to filter commands"}]
+  [{:keys [style]}]
+  [dropdown {:style style :content
               [menu {:style {:max-height "8em"} :content
                      [:<>
                       [menu-item {:label [:<> [:> mui-icons/Done] [:span "Add Todo"] [kbd "cmd-enter"]]}]
@@ -147,12 +146,12 @@
                       [menu-item {:label [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]}]
                       [menu-item {:label [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]}]
                       [menu-item {:label [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]}]
-                      [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]]}])
+                      [menu-item {:label [:<> [:> mui-icons/Today] [:span "Today"]]}]]}]}])
 
 
 (defn block-context-menu-component
-  []
-  [dropdown {:content
+  [style]
+  [dropdown {:style style :content
              [menu {:content
                     [:<>
                      ;;  [menu-heading "Modify Block 'Day of Datomic On-Prem 2016'"]

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -15,16 +15,21 @@
 
 
 (stylefy/keyframes "dropdown-appear"
-                   [:from {:opacity 0}]
-                   [:to {:opacity 1}])
+                   [:from {:opacity 0
+                           :transform "translateY(-10%)"}]
+                   [:to {:opacity 1
+                         :transform "translateY(0)"}])
 
 
 (def dropdown-style
   {:display "inline-flex"
+   :z-index "1000"
    :padding "4px"
    :border-radius "6px"
    :min-height "2em"
    :min-width "2em"
+   :animation "dropdown-appear 0.125s"
+   :animation-fill-mode "both"
    :background (color :app-bg-color)
    :box-shadow [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px rgba(0, 0, 0, 0.05)"]]
    :flex-direction "column"})


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/#/pages)

Slash menu should appear at the bottom-left corner of the textarea in the block being edited. This should be improved later by making it appear at the caret position.