### PR TITLE
Refactor zindex

### DIFF
--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -27,7 +27,7 @@
                                              :right "-0.2em"
                                              :left "-0.2em"
                                              :bottom "-1px"
-                                             :z-index "-1"
+                                             :z-index -1
                                              :opacity "0"
                                              :border-radius "4px"
                                              :transition "all 0.05s ease"

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -34,6 +34,17 @@
    :opacity-higher 0.85})
 
 
+;; Based on Bootstrap's excellent Z-index set
+(def ZINDICES
+  {:zindex-dropdown          1000
+   :zindex-sticky            1020
+   :zindex-fixed             1030
+   :zindex-modal-backdrop    1040
+   :zindex-modal             1050
+   :zindex-popover           1060
+   :zindex-tooltip           1070})
+
+
 ;; Color
 ;; Provide color keyword
 ;; (optional) Provide alpha value, either keyword or 0-1

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -3,7 +3,7 @@
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db :refer [search-in-block-content search-exact-node-title search-in-node-title re-case-insensitive]]
     [athens.router :refer [navigate-uid]]
-    [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+    [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
     [athens.subs]
     [athens.util :refer [gen-block-uid]]
     [athens.views.buttons :refer [button-primary]]
@@ -32,10 +32,10 @@
    :position      "fixed"
    :overflow      "hidden"
    :max-height    "60vh"
+   :z-index       (:zindex-modal ZINDICES)
    :top           "50%"
    :left          "50%"
-   :transform     "translate(-50%, -50%)"
-   :z-index       2})
+   :transform     "translate(-50%, -50%)"})
 
 
 (def athena-input-style

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -60,7 +60,7 @@
                                  :font-family "inherit"}]
                      [:textarea:focus
                       :.is-editing {:outline "none"
-                                    :z-index "10"
+                                    :z-index 3
                                     :display "block"
                                     :opacity "1"}]
                      [(selectors/+ :.is-editing :span) {:opacity 0}]]})

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -4,7 +4,7 @@
     [athens.db :as db]
     [athens.parse-renderer :refer [parse-and-render]]
     [athens.router :refer [navigate-uid]]
-    [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
+    [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
     [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
     [cljsjs.react]
     [cljsjs.react.dom]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -4,7 +4,7 @@
     [athens.db :as db]
     [athens.parse-renderer :refer [parse-and-render]]
     [athens.router :refer [navigate-uid]]
-    [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+    [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
     [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -86,7 +86,7 @@
                      [:&.closed [(selectors/& (selectors/before)) {:content "none"}]]
                      [:&.closed [(selectors/& (selectors/before)) {:content "none"}]]
                      [:&:hover:after {:transform "translate(-50%, -50%) scale(1.3)"}]
-                     [:&.dragging {:z-index "1000"
+                     [:&.dragging {:z-index 1
                                    :cursor "grabbing"
                                    :color (color :body-text-color)}]
                      [:&.selected {}]]})
@@ -113,7 +113,7 @@
    :color (color :body-text-color)
    :position "relative"
    :transform-origin "left"
-   :z-index "1000"
+   :z-index 3
    :width "100%"
    :animation "drop-area-appear .5s ease"
    ::stylefy/manual [[:&:after {:position "absolute"
@@ -130,7 +130,7 @@
 (def block-content-style
   {:position "relative"
    :overflow "visible"
-   :z-index "1"
+   :z-index 1
    :flex-grow "1"
    :word-break "break-word"
    ::stylefy/manual [[:textarea {:display "none"}]
@@ -161,12 +161,12 @@
                                  :font-family "inherit"}]
                      [:textarea:focus
                       :.is-editing {:outline "none"
-                                    :z-index "10"
+                                    :z-index 3
                                     :display "block"
                                     :opacity "1"}]
                      [:span [:span
                              :a {:position "relative"
-                                 :z-index "2"}]]]})
+                                 :z-index 2}]]]})
 
 
 (stylefy/keyframes "tooltip-appear"

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db]
-    [athens.style :refer [color DEPTH-SHADOWS]]
+    [athens.style :refer [color DEPTH-SHADOWS ZINDICES]]
     [athens.views.buttons :refer [button]]
     [athens.views.filters :refer [filters-el]]
     [athens.views.textinput :refer [textinput]]
@@ -22,6 +22,7 @@
 
 (def dropdown-style
   {:display "inline-flex"
+   :z-index (:zindex-dropdown ZINDICES)
    :padding "4px"
    :border-radius "6px"
    :min-height "2em"

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -67,7 +67,7 @@
                                  :font-family "inherit"}]
                      [:textarea:focus
                       :.is-editing {:outline "none"
-                                    :z-index "10"
+                                    :z-index 3
                                     :display "block"
                                     :opacity "1"}]
                      [(selectors/+ :.is-editing :span) {:opacity 0}]]})

--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -62,7 +62,7 @@
    :align-items "flex-start"
    :padding "80px 4px 0"
    :position "relative"
-   :z-index "10"
+   :z-index 3
    :box-shadow [["inset 1px 0 0 " (color :panel-color)]]
    ::stylefy/manual [[:& {:transition-duration "0.15s"}]
                      [:&:hover {:background (lighten (color :panel-color) 5)}]
@@ -119,7 +119,7 @@
    :line-height "24px"
    :font-size "15px"
    :position "relative"
-   :z-index "1"
+   :z-index 1
    :width sidebar-width})
 
 
@@ -131,7 +131,7 @@
    :padding "4px 16px"
    :position "sticky"
    :backdrop-filter "blur(12px)"
-   :z-index "10"
+   :z-index 2
    :background "#FBFAFA" ;; FIXME: Replace with weighted-mix color function
    :top "0"
    :bottom "0"


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/#/page/OaSVyM_nr)

Refactor all our uses of z-index to either be a small numeric value, essentially a "relative" z-index, or a semantic value like ":zindex-modal" or ":zindex-dropdown", drawn from `athens.style`.

Fixes #230 