### PR TITLE
Fix incorrect date time format

### DIFF
--- a/src/cljs/athens/views/all_pages.cljs
+++ b/src/cljs/athens/views/all_pages.cljs
@@ -67,7 +67,7 @@
 ;;; Components
 
 
-(def date-col-format (t/formatter "LLLL MM, yyyy h':'mma"))
+(def date-col-format (t/formatter "LLLL dd, yyyy h':'mma"))
 
 
 (defn date-string


### PR DESCRIPTION
`date-col-format` in `all_pages.cljs` had the format - `"LLLL MM, yyyy h':'mma"` which would yield July 07, 2020 for all dates in July.

This format has been fixed to be `"LLLL dd, yyyy h':'mma"`.