### PR TITLE
feat(blocks): first start on (()) and [[]] search

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -123,13 +123,13 @@
 
 (defn get-block-document
   [id]
-  (->> @(pull dsdb '[:db/id :block/uid :block/string :block/open :block/order {:block/children ...}] id)
+  (->> @(pull dsdb '[:db/id :block/uid :block/string :block/open :block/order {:block/children ...} :edit/time] id)
        sort-block-children))
 
 
 (defn get-node-document
   [id]
-  (->> @(pull dsdb '[:db/id :node/title :block/uid :block/string :block/open :block/order {:block/children ...}] id)
+  (->> @(pull dsdb '[:db/id :node/title :block/uid :block/string :block/open :block/order {:block/children ...} :edit/time] id)
        sort-block-children))
 
 
@@ -225,7 +225,7 @@
          @dsdb
          (re-case-insensitive query))
     (map get-root-parent-node)
-    (map #(dissoc % :block/_children))))
+    (mapv #(dissoc % :block/_children))))
 
 
 ;; history

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -65,15 +65,30 @@
 
 
 (defn handle-arrow-key
-  [e uid]
+  [e uid state]
   (let [{:keys [key-code]} (destruct-event e)
-        top-row?    true                                    ;; TODO
-        bottom-row? true]                                   ;; TODO
+        ;; TODO
+        top-row?    true
+        bottom-row? true
+        {:search/keys [query index results]} @state]
+
     (cond
-      (and (= key-code KeyCodes.UP) top-row?)           (dispatch [:up uid])
-      (and (= key-code KeyCodes.LEFT) (block-start? e)) (dispatch [:left uid])
-      (and (= key-code KeyCodes.DOWN) bottom-row?)      (dispatch [:down uid])
-      (and (= key-code KeyCodes.RIGHT) (block-end? e))  (dispatch [:right uid]))))
+      query (cond
+              (= key-code KeyCodes.UP) (do
+                                         (.. e preventDefault)
+                                         (if (= index 0)
+                                           (swap! state assoc :search/index (dec (count results)))
+                                           (swap! state update :search/index dec)))
+              (= key-code KeyCodes.DOWN) (do
+                                           (.. e preventDefault)
+                                           (if (= index (dec (count results)))
+                                             (swap! state assoc :search/index 0)
+                                             (swap! state update :search/index inc))))
+      :else (cond
+              (and (= key-code KeyCodes.UP) top-row?) (dispatch [:up uid])
+              (and (= key-code KeyCodes.LEFT) (block-start? e)) (dispatch [:left uid])
+              (and (= key-code KeyCodes.DOWN) bottom-row?) (dispatch [:down uid])
+              (and (= key-code KeyCodes.RIGHT) (block-end? e)) (dispatch [:right uid])))))
 
 
 (defn handle-tab
@@ -93,21 +108,35 @@
 
 (defn handle-enter
   [e uid state]
-  (let [{:keys [shift meta start head tail value]} (destruct-event e)]
+  (let [{:keys [shift meta start head tail value]} (destruct-event e)
+        {:search/keys [query index results page block]} @state]
+    (.. e preventDefault)
     (cond
+      ;; auto-complete link
+      page (let [{:keys [node/title]} (get results index)
+                 new-str (clojure.string/replace-first value (str query "]]") (str title "]]"))]
+             (swap! state merge {:atom-string  new-str
+                                 :search/query nil
+                                 :search/block  false}))
+      ;; auto-complete block ref
+      block (let [{:keys [block/uid]} (get results index)
+                  new-str (clojure.string/replace-first value (str query "))") (str uid "))"))]
+              (prn "NEW" new-str)
+              (swap! state merge {:atom-string  new-str
+                                  :search/query nil
+                                  :search/block  false}))
+
       ;; shift-enter: add line break to textarea
       shift (swap! state assoc :atom-string (str head "\n" tail))
       ;; cmd-enter: toggle todo/done
-      meta (let [first    (subs value 0 12)
-                 new-tail (subs value 12)
-                 new-head (cond (= first "{{[[TODO]]}}") "{{[[DONE]]}}"
-                                (= first "{{[[DONE]]}}") ""
-                                :else "{{[[TODO]]}} ")
-                 new-str  (str new-head new-tail)]
+      meta (let [first    (subs value 0 13)
+                 new-tail (subs value 13)
+                 new-str (cond (= first "{{[[TODO]]}} ") (str "{{[[DONE]]}} " new-tail)
+                               (= first "{{[[DONE]]}} ") new-tail
+                               :else (str "{{[[TODO]]}} " value))]
              (swap! state assoc :atom-string new-str))
       ;; default: may mutate blocks
-      :else (do (.. e preventDefault)
-                (dispatch [:enter uid value start state])))))
+      :else (dispatch [:enter uid value start]))))
 
 
 ;; todo: do this for ** and __
@@ -226,34 +255,57 @@
       :else (let [head    (subs value 0 (dec start))
                   new-str (str head tail)
                   {:search/keys [query]} @state]
-              (cond
-                ;;(= (get value start) KeyCodes.SLASH)
-                ;;(swap! state update :slash? not)
-                query (swap! state assoc :search/query (subs query 0 (dec (count query)))))
+              (when query
+                (swap! state assoc :search/query (subs query 0 (dec (count query)))))
               (swap! state assoc :atom-string new-str)))))
+
+
+(defn is-character-key?
+  "Closure returns true even when using modifier keys. We do not make that assumption."
+  [e]
+  (let [{:keys [meta ctrl alt key-code]} (destruct-event e)]
+    (and (not meta) (not ctrl) (not alt)
+         (isCharacterKey key-code))))
+
+
+(defn write-char
+  [e _ state]
+  (let [{:keys [head tail key key-code]} (destruct-event e)
+        new-str (str head key tail)
+        {:search/keys [page block query]} @state
+        new-query (str query key)]
+    (cond
+      ;; FIXME: must press slash twice to close
+      (= key-code KeyCodes.SLASH) (swap! state update :slash? not)
+
+      ;; when in-line search dropdown is open
+      block (let [results (db/search-in-block-content query)]
+              (swap! state assoc :search/query new-query)
+              (swap! state assoc :search/results results))
+
+    ;; when in-line search dropdown is open
+      page (let [results (db/search-in-node-title query)]
+             (swap! state assoc :search/query new-query)
+             (swap! state assoc :search/results results)))
+
+    (swap! state merge {:atom-string new-str})))
 
 
 ;; XXX: what happens here when we have multi-block selection? In this case we pass in `uids` instead of `uid`
 (defn block-key-down
   [e uid state]
-  (let [{:keys [meta ctrl alt key key-code head tail]} (destruct-event e)]
+  (let [{:keys [meta key-code]} (destruct-event e)]
     (cond
-      (arrow-key? e) (handle-arrow-key e uid)
+      (arrow-key? e) (handle-arrow-key e uid state)
       (pair-char? e) (handle-pair-char e uid state)
       (= key-code KeyCodes.TAB) (handle-tab e uid)
       (= key-code KeyCodes.ENTER) (handle-enter e uid state)
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
       meta (handle-system-shortcuts e uid state)
-      ;; -- Default: Add new character -----------------------------------------
-      (and (not meta) (not ctrl) (not alt) (isCharacterKey key-code))
-      (let [new-str (str head key tail)]
-        (cond
-          (= key-code KeyCodes.SLASH)
-          (swap! state assoc :slash? true)
 
-          (or (:search/page @state) (:search/block @state))
-          (swap! state assoc :search/query (str (:search/query @state) key)))
-        (swap! state assoc :atom-string new-str)))))
+      ;; -- Default: Add new character -----------------------------------------
+      (is-character-key? e) (write-char e uid state))))
+
 
 ;;:else (prn "non-event" key key-code))))
 

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -117,14 +117,14 @@
                  new-str (clojure.string/replace-first value (str query "]]") (str title "]]"))]
              (swap! state merge {:atom-string  new-str
                                  :search/query nil
-                                 :search/block  false}))
+                                 :search/page  false}))
       ;; auto-complete block ref
       block (let [{:keys [block/uid]} (get results index)
                   new-str (clojure.string/replace-first value (str query "))") (str uid "))"))]
               (prn "NEW" new-str)
               (swap! state merge {:atom-string  new-str
                                   :search/query nil
-                                  :search/block  false}))
+                                  :search/block false}))
 
       ;; shift-enter: add line break to textarea
       shift (swap! state assoc :atom-string (str head "\n" tail))

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -13,15 +13,15 @@
 
 ;; -- Turn read block or header into editable on mouse down --------------
 
-(defn edit-block
-  [e]
-  ;; Consider refactor if we add more editable targets
-  (let [closest-block (.. e -target (closest ".block-contents"))
-        closest-block-header (.. e -target (closest ".block-header"))
-        closest-page-header (.. e -target (closest ".page-header"))
-        closest (or closest-block closest-block-header closest-page-header)]
-    (when closest
-      (dispatch [:editing/uid (.. closest -dataset -uid)]))))
+;; (defn edit-block
+;;   [e]
+;;   ;; Consider refactor if we add more editable targets
+;;   (let [closest-block (.. e -target (closest ".block-content"))
+;;         closest-block-header (.. e -target (closest ".block-header"))
+;;         closest-page-header (.. e -target (closest ".page-header"))
+;;         closest (or closest-block closest-block-header closest-page-header)]
+;;     (when closest
+;;       (dispatch [:editing/uid (.. closest -dataset -uid)]))))
 
 
 ;; -- Close Athena -------------------------------------------------------
@@ -66,7 +66,7 @@
 
 (defn init
   []
-  (events/listen js/window EventType.MOUSEDOWN edit-block)
+  ;; (events/listen js/window EventType.MOUSEDOWN edit-block)
   (events/listen js/window EventType.MOUSEDOWN mouse-down-outside-athena)
   (events/listen js/window EventType.KEYDOWN key-down))
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -4,8 +4,9 @@
     [athens.db :as db]
     [athens.keybindings :refer [block-key-down]]
     [athens.parse-renderer :refer [parse-and-render]]
-    [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+    [athens.util :refer [now-ts]]
+    [athens.views.all-pages :refer [date-string]]
     [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -220,10 +221,11 @@
 
 (defn on-change
   [value uid]
-  (dispatch [:transact [[:db/add [:block/uid uid] :block/string value]]]))
+  ;; (prn "ONCHANGE" value)
+  (dispatch [:transact [{:db/id [:block/uid uid] :block/string value :edit/time (now-ts)}]]))
 
 
-(def db-on-change (debounce on-change 500))
+(def db-on-change (debounce on-change 1000))
 
 
 (defn toggle
@@ -245,7 +247,7 @@
 
 ;; FIXME: fix flicker from on-mouse-enter on-mouse-leave
 (defn tooltip-el
-  [{:block/keys [uid order] dbid :db/id} state]
+  [{:block/keys [uid order] dbid :db/id edit-time :edit/time} state]
   (let [{:keys [dragging tooltip]} @state]
     (when (and tooltip (not dragging))
       [:div (use-style tooltip-style
@@ -253,7 +255,8 @@
                         :on-mouse-leave #(swap! state assoc :tooltip false)})
        [:div [:b "db/id"] [:span dbid]]
        [:div [:b "uid"] [:span uid]]
-       [:div [:b "order"] [:span order]]])))
+       [:div [:b "order"] [:span order]]
+       [:div [:b "last edit"] [:span (date-string edit-time)]]])))
 
 
 (defn bullet-el
@@ -264,8 +267,9 @@
                             :draggable     true
                             :on-mouse-over #(swap! state assoc :tooltip true)
                             :on-mouse-out  (fn [e]
-                                             (when-not (contains (.. e -relatedTarget) "tooltip")
-                                               (swap! state assoc :tooltip false)))
+                                             (let [related (.. e -relatedTarget)]
+                                               (when-not (and related (contains related "tooltip"))
+                                                 (swap! state assoc :tooltip false))))
                             :on-drag-end   (fn [_] (swap! state assoc :dragging false))
                             :on-drag-start (fn [e]
                                              (.. e stopPropagation)
@@ -278,15 +282,11 @@
 ;; Actual string contents - two elements, one for reading and one for writing
 ;; seems hacky, but so far no better way to click into the correct position with one conditional element
 (defn block-content-el
-  [{:block/keys [string uid children]} state]
-  (let [editing-uid @(subscribe [:editing/uid])]
-
-    (when (and (not (= editing-uid uid))
-               (< (count (:atom-string @state)) (count string)))
-      (swap! state assoc :atom-string string))
-
+  [block state is-editing]
+  (let [{:block/keys [string uid children]} block]
     [:div (use-style block-content-style
                      {:class         "block-content"
+                      :on-click      (fn [_] (dispatch [:editing/uid uid]))
                       :on-drag-enter (fn [e]
                                        (.. e stopPropagation)
                                        (swap! state assoc :drag-target :child))
@@ -312,13 +312,13 @@
                                            (dispatch [:drop-bullet source-uid uid :child]))))})
 
      [autosize/textarea {:value       (:atom-string @state)
-                         :class       [(when (= editing-uid uid) "is-editing") "textarea"]
+                         :class       [(when is-editing "is-editing") "textarea"]
                          :auto-focus  true
                          :id          (str "editable-uid-" uid)
-                         :on-change   (fn [_]
-                                        (when (not= string (:atom-string @state))
-                                          (db-on-change (:atom-string @state) uid)))
-                         :on-key-down (fn [e] (block-key-down e uid state))}]
+                         ;; never actually use on change. rather, use :string-listener to update datascript. necessary to make react happy
+                         :on-change   (fn [_])
+                         :on-key-down (fn [e]
+                                        (block-key-down e uid state))}]
      [parse-and-render string]
      ;; don't show drop indicator when dragging to its children
      (when (and (empty? children) (not (:dragging @state)))
@@ -327,20 +327,28 @@
 
 ;; flipped around
 
+(def inline-selected-search-option
+  {:background-color (color :link-color)
+   :color            (color :app-bg-color)})
+
+
 (defn page-search-el
   [_block state]
-  (when (:search/page @state)
-    (let [query   (:search/query @state)
-          results (when (not (clojure.string/blank? query))
-                    (db/search-in-node-title query))]
+  (let [{:search/keys [page block query results index]} @state]
+    (when (or block page)
       [dropdown {:style   {:position "absolute"
                            :top      "100%"
                            :left     "-0.125em"}
-                 :content (if (or (not query) (clojure.string/blank? query))
+                 :content (if (clojure.string/blank? query)
                             [:div "Start Typing!"]
-                            (for [{:keys [node/title block/uid]} results]
-                              ^{:key uid}
-                              [:div {:on-click #(navigate-uid uid)} title]))}])))
+                            (doall
+                              [:<>
+                               (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
+                                 ^{:key (str "inline-search-item" uid)}
+                                 [:div (use-style
+                                         (merge {} (when (= index i) inline-selected-search-option))
+                                         {:on-click #(prn "expand")})
+                                  (or title string)])]))}])))
 
 
 ;;TODO: more clarity on open? and closed? predicates, why we use `cond` in one case and `if` in another case)
@@ -352,17 +360,31 @@
                        :search/page false
                        :search/query nil
                        :search/block false
+                       :search/index 0
                        :dragging false
-                       :drag-target nil})]
+                       :drag-target nil
+                       :edit/time (:edit/time block)})]
+    (add-watch state :string-listener
+               (fn [_context _atom old new]
+                 (let [{:keys [atom-string]} new]
+                   (when (not= (:atom-string old) atom-string)
+                     (db-on-change atom-string (:block/uid block))))))
+
     (fn [block]
-      (let [{:block/keys [uid #_string open children order]} block
-            {dragging :dragging drag-target :drag-target} @state
+      (let [{:block/keys [uid string open children order] edit-time :edit/time} block
+            {dragging :dragging drag-target :drag-target state-edit-time :edit/time} @state
             parent (db/get-parent [:block/uid uid])
-            last-child? (= order (dec (count (:block/children parent))))]
+            last-child? (= order (dec (count (:block/children parent))))
+            editing-uid @(subscribe [:editing/uid])
+            is-editing (= (:block/uid block) editing-uid)]
 
-        ;; xxx: bad vibes - if not editing-uid, allow ratom to be appended by joining two blocks (deleting at start)
+        ;;(prn uid state-edit-time edit-time)
 
-        ;;(prn "target" uid drag-target)
+        ;; if block is updated in datascript, update local block state
+        (when (< state-edit-time edit-time)
+          (let [new-state {:edit/time edit-time :atom-string string}]
+            (swap! state merge new-state)))
+
 
         [:<>
 
@@ -404,7 +426,7 @@
            [toggle-el block]
            [bullet-el block state]
            [tooltip-el block state]
-           [block-content-el block state]]
+           [block-content-el block state is-editing]]
 
           (when (:slash? @state)
             [slash-menu-component {:style {:position "absolute" :top "100%" :left "-0.125em"}}])


### PR DESCRIPTION
- no longer have "bad vibes" `swap!`s
- use atom listener instead of `on-change` for reagent updates
- use :edit/time for datascript updates