### PR TITLE
fix(parser, blocks): fixed incorrect parser outputs and added non-existent pages auto-create 

### DIFF
--- a/src/cljc/athens/parser.cljc
+++ b/src/cljc/athens/parser.cljc
@@ -17,7 +17,9 @@
    
    <syntax-in-block> = (page-link | block-ref | hashtag | url-image | url-link | bold)
    
-   page-link = <'[['> any-chars <']]'>
+   <any-non-page-link-chars> = #'[^\\[\\]]*'
+   <page-link-content> = (any-non-page-link-chars | page-link)*
+   page-link = <'[['> page-link-content <']]'>
    
    block-ref = <'(('> #'[a-zA-Z0-9_\\-]+' <'))'>
    

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -1,12 +1,12 @@
 (ns athens.parse-renderer
   (:require
-   [athens.db :as db]
-   [athens.parser :as parser]
-   [athens.router :refer [navigate-uid]]
-   [athens.style :refer [color OPACITIES]]
-   [instaparse.core :as insta]
-   [posh.reagent :refer [pull #_q]]
-   [stylefy.core :as stylefy :refer [use-style]]))
+    [athens.db :as db]
+    [athens.parser :as parser]
+    [athens.router :refer [navigate-uid]]
+    [athens.style :refer [color OPACITIES]]
+    [instaparse.core :as insta]
+    [posh.reagent :refer [pull #_q]]
+    [stylefy.core :as stylefy :refer [use-style]]))
 
 
 (declare parse-and-render)

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -54,6 +54,17 @@
                 ::stylefy/mode [[:hover {:background-color (color :highlight-color :opacity-lower)
                                          :cursor "alias"}]]})
 
+;;; Helper functions for recursive link rendering
+(defn render-page-link
+  "Renders a page link given the title of the page."
+  [title]
+  (let [node (pull db/dsdb '[*] [:node/title title])]
+    [:span (use-style page-link {:class "page-link"})
+     [:span {:class "formatting"} "[["]
+     ;; TODO: Add recursive rendering for nested link based on the AST
+     [:span {:on-click (fn [e] (navigate-uid (:block/uid @node) e))} title]
+     [:span {:class "formatting"} "]]"]]))
+
 
 ;;; Components
 
@@ -65,13 +76,7 @@
   (insta/transform
     {:block     (fn [& contents]
                   (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
-     :page-link (fn [title]
-                  (let [node (pull db/dsdb '[*] [:node/title title])]
-                    [:span (use-style page-link {:class "page-link"})
-                     [:span {:class "formatting"} "[["]
-                     ;; TODO: Add recursive rendering for nested link based on the AST
-                     [:span {:on-click (fn [e] (navigate-uid (:block/uid @node) e))} title]
-                     [:span {:class "formatting"} "]]"]]))
+     :page-link (fn [title] (render-page-link title))
      :block-ref (fn [uid]
                   (let [block (pull db/dsdb '[*] [:block/uid uid])]
                     [:span (use-style block-ref {:class "block-ref"})

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -1,12 +1,12 @@
 (ns athens.parse-renderer
   (:require
-    [athens.db :as db]
-    [athens.parser :as parser]
-    [athens.router :refer [navigate-uid]]
-    [athens.style :refer [color OPACITIES]]
-    [instaparse.core :as insta]
-    [posh.reagent :refer [pull #_q]]
-    [stylefy.core :as stylefy :refer [use-style]]))
+   [athens.db :as db]
+   [athens.parser :as parser]
+   [athens.router :refer [navigate-uid]]
+   [athens.style :refer [color OPACITIES]]
+   [instaparse.core :as insta]
+   [posh.reagent :refer [pull #_q]]
+   [stylefy.core :as stylefy :refer [use-style]]))
 
 
 (declare parse-and-render)
@@ -74,30 +74,30 @@
   "Transforms Instaparse output to Hiccup."
   [tree]
   (insta/transform
-    {:block     (fn [& contents]
-                  (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
-     :page-link (fn [title] (render-page-link title))
-     :block-ref (fn [uid]
-                  (let [block (pull db/dsdb '[*] [:block/uid uid])]
-                    [:span (use-style block-ref {:class "block-ref"})
-                     [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block))]]))
-     :hashtag   (fn [tag-name]
-                  (let [node (pull db/dsdb '[*] [:node/title tag-name])]
-                    [:span (use-style hashtag) {:class    "hashtag"
-                                                :on-click #(navigate-uid (:block/uid @node))}
-                     [:span {:class "formatting"} "#"]
-                     [:span {:class "contents"} tag-name]]))
-     :url-image (fn [{url :url alt :alt}]
-                  [:img (use-style image {:class "url-image"
-                                          :alt   alt
-                                          :src   url})])
-     :url-link  (fn [{url :url} text]
-                  [:a (use-style url-link {:class "url-link"
-                                           :href  url})
-                   text])
-     :bold      (fn [text]
-                  [:strong {:class "contents bold"} text])}
-    tree))
+   {:block     (fn [& contents]
+                 (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
+    :page-link (fn [title] (render-page-link title))
+    :block-ref (fn [uid]
+                 (let [block (pull db/dsdb '[*] [:block/uid uid])]
+                   [:span (use-style block-ref {:class "block-ref"})
+                    [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block))]]))
+    :hashtag   (fn [tag-name]
+                 (let [node (pull db/dsdb '[*] [:node/title tag-name])]
+                   [:span (use-style hashtag) {:class    "hashtag"
+                                               :on-click #(navigate-uid (:block/uid @node))}
+                    [:span {:class "formatting"} "#"]
+                    [:span {:class "contents"} tag-name]]))
+    :url-image (fn [{url :url alt :alt}]
+                 [:img (use-style image {:class "url-image"
+                                         :alt   alt
+                                         :src   url})])
+    :url-link  (fn [{url :url} text]
+                 [:a (use-style url-link {:class "url-link"
+                                          :href  url})
+                  text])
+    :bold      (fn [text]
+                 [:strong {:class "contents bold"} text])}
+   tree))
 
 
 (defn parse-and-render

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -69,6 +69,7 @@
                   (let [node (pull db/dsdb '[*] [:node/title title])]
                     [:span (use-style page-link {:class "page-link"})
                      [:span {:class "formatting"} "[["]
+                     ;; TODO: Add recursive rendering for nested link based on the AST
                      [:span {:on-click (fn [e] (navigate-uid (:block/uid @node) e))} title]
                      [:span {:class "formatting"} "]]"]]))
      :block-ref (fn [uid]

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -74,29 +74,29 @@
   "Transforms Instaparse output to Hiccup."
   [tree]
   (insta/transform
-   {:block     (fn [& contents]
-                 (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
-    :page-link (fn [title] (render-page-link title))
-    :block-ref (fn [uid]
-                 (let [block (pull db/dsdb '[*] [:block/uid uid])]
-                   [:span (use-style block-ref {:class "block-ref"})
-                    [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block))]]))
-    :hashtag   (fn [tag-name]
-                 (let [node (pull db/dsdb '[*] [:node/title tag-name])]
-                   [:span (use-style hashtag) {:class    "hashtag"
-                                               :on-click #(navigate-uid (:block/uid @node))}
-                    [:span {:class "formatting"} "#"]
-                    [:span {:class "contents"} tag-name]]))
-    :url-image (fn [{url :url alt :alt}]
-                 [:img (use-style image {:class "url-image"
-                                         :alt   alt
-                                         :src   url})])
-    :url-link  (fn [{url :url} text]
-                 [:a (use-style url-link {:class "url-link"
-                                          :href  url})
-                  text])
-    :bold      (fn [text]
-                 [:strong {:class "contents bold"} text])}
+    {:block     (fn [& contents]
+                  (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
+     :page-link (fn [title] (render-page-link title))
+     :block-ref (fn [uid]
+                  (let [block (pull db/dsdb '[*] [:block/uid uid])]
+                    [:span (use-style block-ref {:class "block-ref"})
+                     [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block))]]))
+     :hashtag   (fn [tag-name]
+                  (let [node (pull db/dsdb '[*] [:node/title tag-name])]
+                    [:span (use-style hashtag) {:class    "hashtag"
+                                                :on-click #(navigate-uid (:block/uid @node))}
+                     [:span {:class "formatting"} "#"]
+                     [:span {:class "contents"} tag-name]]))
+     :url-image (fn [{url :url alt :alt}]
+                  [:img (use-style image {:class "url-image"
+                                          :alt   alt
+                                          :src   url})])
+     :url-link  (fn [{url :url} text]
+                  [:a (use-style url-link {:class "url-link"
+                                           :href  url})
+                   text])
+     :bold      (fn [text]
+                  [:strong {:class "contents bold"} text])}
    tree))
 
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -227,14 +227,15 @@
   ;; automatically add non-existent pages
   ;; TODO: delete pages that are no longer connected to anything else
   (parse/transform {:page-link (fn [& title]
-                                 (if (nil? (db/search-exact-node-title (apply + title)))
-                                   (let [uid (gen-block-uid)]
-                                     (dispatch [:transact [{:node/title     (apply + title)
-                                                            :block/uid      (str uid)
-                                                            :edit/time      (now-ts)
-                                                            :create/time    (now-ts)}]]))
-                                   nil)
-                                 (str "[[" (apply + title) "]]"))} (parser/parse-to-ast value)))
+                                 (let [inner-title (apply + title)]
+                                   (when (nil? (db/search-exact-node-title inner-title))
+                                     (let [now (now-ts)
+                                           uid (gen-block-uid)]
+                                       (dispatch [:transact [{:node/title     inner-title
+                                                              :block/uid      uid
+                                                              :edit/time      now
+                                                              :create/time    now}]])))
+                                   (str "[[" inner-title "]]")))} (parser/parse-to-ast value)))
 
 
 (def db-on-change (debounce on-change 1000))

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -1,26 +1,26 @@
 (ns athens.views.blocks
   (:require
-   ["@material-ui/icons" :as mui-icons]
-   [athens.db :as db]
-   [athens.keybindings :refer [block-key-down]]
-   [athens.parse-renderer :refer [parse-and-render]]
-   [athens.parser :as parser]
-   [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
-   [athens.util :refer [now-ts gen-block-uid]]
-   [athens.views.all-pages :refer [date-string]]
-   [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
-   [cljsjs.react]
-   [cljsjs.react.dom]
-   [datascript.core :as d]
-   [garden.selectors :as selectors]
-   [goog.dom :refer [getAncestorByClass]]
-   [goog.dom.classlist :refer [contains]]
-   [goog.functions :refer [debounce]]
-   [instaparse.core :as parse]
-   [komponentit.autosize :as autosize]
-   [re-frame.core :refer [dispatch subscribe]]
-   [reagent.core :as r]
-   [stylefy.core :as stylefy :refer [use-style]]))
+    ["@material-ui/icons" :as mui-icons]
+    [athens.db :as db]
+    [athens.keybindings :refer [block-key-down]]
+    [athens.parse-renderer :refer [parse-and-render]]
+    [athens.parser :as parser]
+    [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+    [athens.util :refer [now-ts gen-block-uid]]
+    [athens.views.all-pages :refer [date-string]]
+    [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
+    [cljsjs.react]
+    [cljsjs.react.dom]
+    [datascript.core :as d]
+    [garden.selectors :as selectors]
+    [goog.dom :refer [getAncestorByClass]]
+    [goog.dom.classlist :refer [contains]]
+    [goog.functions :refer [debounce]]
+    [instaparse.core :as parse]
+    [komponentit.autosize :as autosize]
+    [re-frame.core :refer [dispatch subscribe]]
+    [reagent.core :as r]
+    [stylefy.core :as stylefy :refer [use-style]]))
 
 
 ;;; Styles
@@ -353,13 +353,13 @@
                  :content (if (clojure.string/blank? query)
                             [:div "Start Typing!"]
                             (doall
-                             [:<>
-                              (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
-                                ^{:key (str "inline-search-item" uid)}
-                                [:div (use-style
-                                       (merge {} (when (= index i) inline-selected-search-option))
-                                       {:on-click #(prn "expand")})
-                                 (or title string)])]))}])))
+                              [:<>
+                               (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
+                                 ^{:key (str "inline-search-item" uid)}
+                                 [:div (use-style
+                                         (merge {} (when (= index i) inline-selected-search-option))
+                                         {:on-click #(prn "expand")})
+                                  (or title string)])]))}])))
 
 
 ;;TODO: more clarity on open? and closed? predicates, why we use `cond` in one case and `if` in another case)

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -1,26 +1,26 @@
 (ns athens.views.blocks
   (:require
-    ["@material-ui/icons" :as mui-icons]
-    [athens.db :as db]
-    [athens.keybindings :refer [block-key-down]]
-    [athens.parse-renderer :refer [parse-and-render]]
-    [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
-    [athens.util :refer [now-ts gen-block-uid]]
-    [athens.views.all-pages :refer [date-string]]
-    [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
-    [cljsjs.react]
-    [cljsjs.react.dom]
-    [datascript.core :as d]
-    [garden.selectors :as selectors]
-    [goog.dom :refer [getAncestorByClass]]
-    [goog.dom.classlist :refer [contains]]
-    [goog.functions :refer [debounce]]
-    [komponentit.autosize :as autosize]
-    [re-frame.core :refer [dispatch subscribe]]
-    [reagent.core :as r]
-    [stylefy.core :as stylefy :refer [use-style]]
-    [athens.parser :as parser]
-    [instaparse.core :as parse]))
+   ["@material-ui/icons" :as mui-icons]
+   [athens.db :as db]
+   [athens.keybindings :refer [block-key-down]]
+   [athens.parse-renderer :refer [parse-and-render]]
+   [athens.parser :as parser]
+   [athens.style :refer [color DEPTH-SHADOWS OPACITIES]]
+   [athens.util :refer [now-ts gen-block-uid]]
+   [athens.views.all-pages :refer [date-string]]
+   [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
+   [cljsjs.react]
+   [cljsjs.react.dom]
+   [datascript.core :as d]
+   [garden.selectors :as selectors]
+   [goog.dom :refer [getAncestorByClass]]
+   [goog.dom.classlist :refer [contains]]
+   [goog.functions :refer [debounce]]
+   [instaparse.core :as parse]
+   [komponentit.autosize :as autosize]
+   [re-frame.core :refer [dispatch subscribe]]
+   [reagent.core :as r]
+   [stylefy.core :as stylefy :refer [use-style]]))
 
 
 ;;; Styles
@@ -228,14 +228,12 @@
   ;; automatically add non-existent pages
   ;; TODO: delete pages that are no longer connected to anything else
   (parse/transform {:page-link (fn [& title]
-                                            (if-not (db/search-exact-node-title (apply + title)) (let [uid (gen-block-uid)]
-                                                                                     (d/transact! db/dsdb [{:node/title     (str apply + title)
-                                                                                                             :block/uid      (str uid)
-                                                                                                             :edit/time      (now-ts)
-                                                                                                             :create/time    (now-ts)
-                                                                                                          }])) nil)
-                                            (str "[[" (apply + title) "]]")
-                                            )} (parser/parse-to-ast value)))
+                                 (if-not (db/search-exact-node-title (apply + title)) (let [uid (gen-block-uid)]
+                                                                                        (d/transact! db/dsdb [{:node/title     (str apply + title)
+                                                                                                               :block/uid      (str uid)
+                                                                                                               :edit/time      (now-ts)
+                                                                                                               :create/time    (now-ts)}])) nil)
+                                 (str "[[" (apply + title) "]]"))} (parser/parse-to-ast value)))
 
 
 (def db-on-change (debounce on-change 1000))
@@ -355,13 +353,13 @@
                  :content (if (clojure.string/blank? query)
                             [:div "Start Typing!"]
                             (doall
-                              [:<>
-                               (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
-                                 ^{:key (str "inline-search-item" uid)}
-                                 [:div (use-style
-                                         (merge {} (when (= index i) inline-selected-search-option))
-                                         {:on-click #(prn "expand")})
-                                  (or title string)])]))}])))
+                             [:<>
+                              (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
+                                ^{:key (str "inline-search-item" uid)}
+                                [:div (use-style
+                                       (merge {} (when (= index i) inline-selected-search-option))
+                                       {:on-click #(prn "expand")})
+                                 (or title string)])]))}])))
 
 
 ;;TODO: more clarity on open? and closed? predicates, why we use `cond` in one case and `if` in another case)

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -11,7 +11,6 @@
     [athens.views.dropdown :refer [slash-menu-component #_menu dropdown]]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [datascript.core :as d]
     [garden.selectors :as selectors]
     [goog.dom :refer [getAncestorByClass]]
     [goog.dom.classlist :refer [contains]]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -228,11 +228,13 @@
   ;; automatically add non-existent pages
   ;; TODO: delete pages that are no longer connected to anything else
   (parse/transform {:page-link (fn [& title]
-                                 (if (nil? (db/search-exact-node-title (apply + title))) (let [uid (gen-block-uid)]
-                                                                                           (dispatch [:transact [{:node/title     (apply + title)
-                                                                                                                  :block/uid      (str uid)
-                                                                                                                  :edit/time      (now-ts)
-                                                                                                                  :create/time    (now-ts)}]])) nil)
+                                 (if (nil? (db/search-exact-node-title (apply + title)))
+                                   (let [uid (gen-block-uid)]
+                                     (dispatch [:transact [{:node/title     (apply + title)
+                                                            :block/uid      (str uid)
+                                                            :edit/time      (now-ts)
+                                                            :create/time    (now-ts)}]]))
+                                   nil)
                                  (str "[[" (apply + title) "]]"))} (parser/parse-to-ast value)))
 
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -228,11 +228,11 @@
   ;; automatically add non-existent pages
   ;; TODO: delete pages that are no longer connected to anything else
   (parse/transform {:page-link (fn [& title]
-                                 (if-not (db/search-exact-node-title (apply + title)) (let [uid (gen-block-uid)]
-                                                                                        (d/transact! db/dsdb [{:node/title     (str apply + title)
-                                                                                                               :block/uid      (str uid)
-                                                                                                               :edit/time      (now-ts)
-                                                                                                               :create/time    (now-ts)}])) nil)
+                                 (if (nil? (db/search-exact-node-title (apply + title))) (let [uid (gen-block-uid)]
+                                                                                           (dispatch [:transact [{:node/title     (apply + title)
+                                                                                                                  :block/uid      (str uid)
+                                                                                                                  :edit/time      (now-ts)
+                                                                                                                  :create/time    (now-ts)}]])) nil)
                                  (str "[[" (apply + title) "]]"))} (parser/parse-to-ast value)))
 
 


### PR DESCRIPTION
(This is my first pull request, so if I'm doing anything wrong style-wise don't hesitate to let me know!)
# Changes in this pull request: 
* the parser now correctly identifies nested page links and multiple page links in one block. For example:
```
user=> (athens.parser/parse-to-ast "[[Hello [[Bruh]] ]] [[World]]")
[:block [:page-link "Hello " [:page-link "Bruh"] " "] " " [:page-link "World"]]
```
* non-existent pages linked in blocks would now be automatically created (including multiple nested pages!).

Partially fixes #5 

# Next steps:
* nested page rendering currenty doesn't work. We need to fix the front-end to make it look like Roam.
* if the user deletes the references to empty pages, these pages won't disappear automatically. We can survey the database and delete anything without references and without block content (i.e. orphan pages).

(Edit: fixed markdown formatting for this thread.)