### PR TITLE
feat(blocks): esc to close menus and stop editing

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -179,13 +179,6 @@
 
 
 (reg-event-db
-  :stop-editing
-  (fn-traced [db [_ uid]]
-             (js/setTimeout (focus-el (str "editable-uid-" uid)) 300)
-             (dissoc db :editing/uid uid)))
-
-
-(reg-event-db
   :tooltip/uid
   (fn [db [_ uid]]
     (assoc db :tooltip/uid uid)))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -179,7 +179,7 @@
 
 
 (reg-event-db
-  :un-editing
+  :stop-editing
   (fn-traced [db [_ uid]]
              (js/setTimeout (focus-el (str "editable-uid-" uid)) 300)
              (dissoc db :editing/uid uid)))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -179,6 +179,13 @@
 
 
 (reg-event-db
+  :un-editing
+  (fn-traced [db [_ uid]]
+             (js/setTimeout (focus-el (str "editable-uid-" uid)) 300)
+             (dissoc db :editing/uid uid)))
+
+
+(reg-event-db
   :tooltip/uid
   (fn [db [_ uid]]
     (assoc db :tooltip/uid uid)))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -129,14 +129,20 @@
         block-zero? (zero? (:block/order (db/get-block [:block/uid uid])))]
     (cond
       shift (dispatch [:unindent uid])
-      :else (when-not block-zero?
+      :else (when-not block-zero? 
               (dispatch [:indent uid])))))
 
 
 (defn handle-escape
-  [e uid]
+  [e state]
   (.. e preventDefault)
-  (dispatch [:stop-editing uid]))
+  (prn @state)
+  (prn state)
+  (cond
+    (:slash? @state) (swap! state assoc :slash? false)
+    (:search/page @state) (swap! state assoc :search/page false)
+    (:search/block @state) (swap! state assoc :search/block false)
+    :else (dispatch [:editing/uid nil])))
 
 
 ;;(defn cycle-todo
@@ -337,7 +343,7 @@
       (= key-code KeyCodes.TAB) (handle-tab e uid)
       (= key-code KeyCodes.ENTER) (handle-enter e uid state)
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
-      (= key-code KeyCodes.ESC) (handle-escape e uid)
+      (= key-code KeyCodes.ESC) (handle-escape e state)
       meta (handle-system-shortcuts e uid state)
 
       ;; -- Default: Add new character -----------------------------------------

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -136,7 +136,7 @@
 (defn handle-escape
   [e uid]
   (.. e preventDefault)
-  (dispatch [:un-editing uid]))
+  (dispatch [:stop-editing uid]))
 
 
 ;;(defn cycle-todo

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -133,6 +133,12 @@
               (dispatch [:indent uid])))))
 
 
+(defn handle-escape
+  [e uid]
+  (.. e preventDefault)
+  (dispatch [:un-editing uid]))
+
+
 ;;(defn cycle-todo
 ;;  [])
 
@@ -331,6 +337,7 @@
       (= key-code KeyCodes.TAB) (handle-tab e uid)
       (= key-code KeyCodes.ENTER) (handle-enter e uid state)
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
+      (= key-code KeyCodes.ESC) (handle-escape e uid)
       meta (handle-system-shortcuts e uid state)
 
       ;; -- Default: Add new character -----------------------------------------

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -129,7 +129,7 @@
         block-zero? (zero? (:block/order (db/get-block [:block/uid uid])))]
     (cond
       shift (dispatch [:unindent uid])
-      :else (when-not block-zero? 
+      :else (when-not block-zero?
               (dispatch [:indent uid])))))
 
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -154,8 +154,7 @@
                                  :border "0"
                                  :opacity "0"
                                  :font-family "inherit"}]
-                     [:textarea:focus
-                      :.is-editing {:outline "none"
+                     [:.is-editing {:outline "none"
                                     :z-index 3
                                     :display "block"
                                     :opacity "1"}]


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/)

- Pressing escape closes slash menus, block/page search menus, and ends block editing, in that order.