### PR TITLE
Minor polish

### DIFF
--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -131,6 +131,14 @@
                            :text-transform "uppercase"}]
                      [:.MuiSvgIcon-root {:font-size "24px"}]
                      [:input {:font-family "inherit"}]
+                     [:kbd {:text-transform "uppercase"
+                            :font-family "inherit"
+                            :font-size "0.85em"
+                            :letter-spacing "0.05em"
+                            :font-weight 600
+                            :background (color :body-text-color :opacity-lower)
+                            :border-radius "4px"
+                            :padding "0 4px"}]
                      [:img {:max-width "100%"
                             :height "auto"}]]})
 

--- a/src/cljs/athens/views/all_pages.cljs
+++ b/src/cljs/athens/views/all_pages.cljs
@@ -25,7 +25,7 @@
 
 (def table-style
   {:flex "1 1 100%"
-   :margin "0 1rem"
+   :margin "0 2rem"
    :text-align "left"
    :border-collapse "collapse"
    ::stylefy/sub-styles {:th-date {:text-align "right"}

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -107,14 +107,7 @@
 (def hint-style
   {:color "inherit"
    :opacity (:opacity-med OPACITIES)
-   :font-size "14px"
-   ::stylefy/manual [[:kbd {:text-transform "uppercase"
-                            :font-family "inherit"
-                            :font-size "12px"
-                            :font-weight 600
-                            :background (color :body-text-color :opacity-lower)
-                            :border-radius "4px"
-                            :padding "0 4px"}]]})
+   :font-size "14px"})
 
 
 ;;; Utilities

--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -37,7 +37,8 @@
                                   :grid-gap "4px"}
                          :small-icon {:font-size "16px"}
                          :large-icon {:font-size "22px"}}
-   ::stylefy/manual [[:&.is-open {:width "288px"}]]})
+   ::stylefy/manual [[:&.is-open {:width "288px"}]
+                     [:&.is-closed {:width "0"}]]})
 
 
 (def left-sidebar-content-style
@@ -48,7 +49,8 @@
    :padding "120px 0 16px"
    :transition "opacity 0.5s ease"
    :opacity 0
-   ::stylefy/manual [[:&.is-open {:opacity 1}]]})
+   ::stylefy/manual [[:&.is-open {:opacity 1}]
+                     [:&.is-closed {:opacity 0}]]})
 
 
 (def shortcuts-list-style

--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -149,19 +149,19 @@
     ;; (when @open?
 
       ;; IF EXPANDED
-      [:div (use-style left-sidebar-style {:class (if @open? "is-open" "is-closed")})
-       [:div (use-style left-sidebar-content-style {:class (if @open? "is-open" "is-closed")})
+    [:div (use-style left-sidebar-style {:class (if @open? "is-open" "is-closed")})
+     [:div (use-style left-sidebar-content-style {:class (if @open? "is-open" "is-closed")})
 
        ;; SHORTCUTS
-       [:ol (use-style shortcuts-list-style)
-        [:h2 (use-sub-style shortcuts-list-style :heading) "Shortcuts"]
-        (doall
-          (for [sh shortcuts]
-            ^{:key (str "left-sidebar-" (second sh))}
-            [shortcut-component sh]))]
+      [:ol (use-style shortcuts-list-style)
+       [:h2 (use-sub-style shortcuts-list-style :heading) "Shortcuts"]
+       (doall
+         (for [sh shortcuts]
+           ^{:key (str "left-sidebar-" (second sh))}
+           [shortcut-component sh]))]
 
        ;; LOGO + BOTTOM BUTTONS
-       [:footer (use-sub-style left-sidebar-style :footer)
-        [:a (use-style notional-logotype-style {:href "https://github.com/athensresearch/athens" :target "_blank"}) "Athens"]
-        [button-primary {:label "Load Test Data"
-                         :on-click-fn #(dispatch [:get-db/init])}]]]]))
+      [:footer (use-sub-style left-sidebar-style :footer)
+       [:a (use-style notional-logotype-style {:href "https://github.com/athensresearch/athens" :target "_blank"}) "Athens"]
+       [button-primary {:label "Load Test Data"
+                        :on-click-fn #(dispatch [:get-db/init])}]]]]))

--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -17,26 +17,38 @@
 
 
 (def left-sidebar-style
-  {:flex "0 0 288px"
+  {:width 0
    :grid-area "left-sidebar"
-   :width "288px"
    :height "100%"
    :display "flex"
    :flex-direction "column"
-   :padding "120px 32px 16px 32px"
+   :overflow-y "auto"
+   :transition "width 0.5s ease"
    ::stylefy/sub-styles {:top-line {:margin-bottom "40px"
                                     :display "flex"
                                     :flex "0 0 auto"
                                     :justify-content "space-between"}
-                         :footer {:margin-top "auto"
-                                  :flex "0 0 auto"
+                         :footer {:flex "0 0 auto"
+                                  :margin "auto 32px 0"
                                   :align-self "stretch"
                                   :display "grid"
                                   :grid-auto-flow "column"
                                   :grid-template-columns "1fr auto auto"
                                   :grid-gap "4px"}
                          :small-icon {:font-size "16px"}
-                         :large-icon {:font-size "22px"}}})
+                         :large-icon {:font-size "22px"}}
+   ::stylefy/manual [[:&.is-open {:width "288px"}]]})
+
+
+(def left-sidebar-content-style
+  {:width "288px"
+   :height "100%"
+   :display "flex"
+   :flex-direction "column"
+   :padding "120px 0 16px"
+   :transition "opacity 0.5s ease"
+   :opacity 0
+   ::stylefy/manual [[:&.is-open {:opacity 1}]]})
 
 
 (def shortcuts-list-style
@@ -44,7 +56,7 @@
    :display "flex"
    :list-style "none"
    :flex-direction "column"
-   :padding "0"
+   :padding "0 32px"
    :margin "0 0 32px"
    :overflow-y "auto"
    ::stylefy/sub-styles {:heading {:flex "0 0 auto"
@@ -132,10 +144,11 @@
                              [?e :block/uid ?uid]] db/dsdb)
                        seq
                        (sort-by first))]
-    (when @open?
+    ;; (when @open?
 
       ;; IF EXPANDED
-      [:div (use-style left-sidebar-style)
+      [:div (use-style left-sidebar-style {:class (if @open? "is-open" "is-closed")})
+       [:div (use-style left-sidebar-content-style {:class (if @open? "is-open" "is-closed")})
 
        ;; SHORTCUTS
        [:ol (use-style shortcuts-list-style)
@@ -149,4 +162,4 @@
        [:footer (use-sub-style left-sidebar-style :footer)
         [:a (use-style notional-logotype-style {:href "https://github.com/athensresearch/athens" :target "_blank"}) "Athens"]
         [button-primary {:label "Load Test Data"
-                         :on-click-fn #(dispatch [:get-db/init])}]]])))
+                         :on-click-fn #(dispatch [:get-db/init])}]]]]))

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -36,7 +36,7 @@
   {:position "relative"
    :overflow "visible"
    :flex-grow "1"
-   :margin "0.2em 0"
+   :margin "0.2em 0 0.2em 1rem"
    :letter-spacing "-0.03em"
    :word-break "break-word"
    ::stylefy/manual [[:textarea {:display "none"}]

--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -138,11 +138,12 @@
    :flex-direction "column"
    :margin "auto auto"
    :align-items "center"
+   :text-align "center"
    :color (color :body-text-color :opacity-med)
    :font-size "14px"
    :border-radius "8px"
    :line-height 1.3
-   ::stylefy/manual [[:svg {:opacity (:opacity-med OPACITIES)
+   ::stylefy/manual [[:svg {:opacity (:opacity-low OPACITIES)
                             :font-size "80px"}]
                      [:p {:max-width "13em"}]]})
 
@@ -154,7 +155,8 @@
   []
   [:div (use-style empty-message-style)
    [:> mui-icons/VerticalSplit]
-   [:p "Hold shift when clicking a page link to view the page in the sidebar."]])
+   [:p
+    "Hold " [:kbd "shift"] " when clicking a page link to view the page in the sidebar."]])
 
 
 (defn right-sidebar-el


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/)

Minor polish around a few corners of the app, just sweeping up little stuff.

- Left sidebar toggles smoothly
- Unified `kbd` element style
- Improved style for help text in empty right sidebar
- Improved node page title alignment
- Improved spacing around all-pages table