### PR TITLE
feat(import): add modal gate for import flow

### DIFF
--- a/src/cljs/athens/devcards/app_toolbar.cljs
+++ b/src/cljs/athens/devcards/app_toolbar.cljs
@@ -70,27 +70,29 @@
                     {:opacity "1"}])
 
 
-(def modal-contents-style {:display "flex"
-                           :padding "1.5rem"
-                           :flex-direction "column"
-                           :align-items "center"
-                           ::stylefy/manual [[:p {:max-width "24rem"
-                                                  :text-align "center"}]
-                                             [:button {:font-size "18px"}]]})
+(def modal-contents-style
+  {:display "flex"
+   :padding "1.5rem"
+   :flex-direction "column"
+   :align-items "center"
+   ::stylefy/manual [[:p {:max-width "24rem"
+                          :text-align "center"}]
+                     [:button {:font-size "18px"}]]})
 
 
-(def features-table-style {:background (color :background-plus-1 :opacity-low)
-                           :border-radius "0.5rem"
-                           :margin "0.5rem auto 1.25rem"
-                           ::stylefy/manual [[:th {:font-weight "normal"
-                                                   :opacity "0.75"
-                                                   :padding-block-start "0.5rem"
-                                                   :text-align "left"}]
-                                             [:th :td {:padding-inline "0.25rem"
-                                                       :padding-block "0.125rem"}]
-                                             [:tr:last-child [:td {:padding-block-end "0.5rem"}]]
-                                             [:th:first-child :td:first-child {:padding-inline-start "1rem"}]
-                                             [:th:last-child :td:last-child {:padding-inline-end "1rem"}]]})
+(def features-table-style
+  {:background (color :background-plus-1 :opacity-low)
+   :border-radius "0.5rem"
+   :margin "0.5rem auto 1.25rem"
+   ::stylefy/manual [[:th {:font-weight "normal"
+                           :opacity "0.75"
+                           :padding-block-start "0.5rem"
+                           :text-align "left"}]
+                     [:th :td {:padding-inline "0.25rem"
+                               :padding-block "0.125rem"}]
+                     [:tr:last-child [:td {:padding-block-end "0.5rem"}]]
+                     [:th:first-child :td:first-child {:padding-inline-start "1rem"}]
+                     [:th:last-child :td:last-child {:padding-inline-end "1rem"}]]})
 
 
 ;;; Components
@@ -101,15 +103,19 @@
   [:hr (use-style separator-style)])
 
 
-(defn feature-yes []
-   [(r/adapt-react-class mui-icons/Check) {:style {:margin "auto"
-                                                   :display "block"
-                                                   :color (color :confirmation-color)}}])
+(defn feature-yes
+  []
+  [(r/adapt-react-class mui-icons/Check) {:style {:margin "auto"
+                                                  :display "block"
+                                                  :color (color :confirmation-color)}}])
 
-(defn feature-no []
-   [(r/adapt-react-class mui-icons/Close) {:style {:margin "auto"
-                                                   :display "block"
-                                                   :color (color :warning-color)}}])
+
+(defn feature-no
+  []
+  [(r/adapt-react-class mui-icons/Close) {:style {:margin "auto"
+                                                  :display "block"
+                                                  :color (color :warning-color)}}])
+
 
 (defn features-table
   []
@@ -183,9 +189,9 @@
        (when @import-modal-open?
          [:div (use-style modal-style)
           [modal/modal
-           {:title [:div.modal__title [:> mui-icons/Publish][:h4 "Import to Athens"] [button
-                                                  {:on-click-fn #(reset! import-modal-open? false)
-                                                   :label [:> mui-icons/Close]}]]
+           {:title [:div.modal__title [:> mui-icons/Publish] [:h4 "Import to Athens"] [button
+                                                                                       {:on-click-fn #(reset! import-modal-open? false)
+                                                                                        :label [:> mui-icons/Close]}]]
             :content [:div (use-style modal-contents-style)
                       ;; TODO: Write intro copy
                       [:p "Some helpful framing about what Athens does and what users should expect. Athens is not Roam."]

--- a/src/cljs/athens/devcards/app_toolbar.cljs
+++ b/src/cljs/athens/devcards/app_toolbar.cljs
@@ -4,8 +4,11 @@
     [athens.router :refer [navigate]]
     [athens.style :refer [color]]
     [athens.subs]
-    [athens.views.buttons :refer [button]]
+    [athens.views.buttons :refer [button button-primary]]
+    [athens.views.modal :refer [modal-style]]
+    [komponentit.modal :as modal]
     [re-frame.core :refer [subscribe dispatch]]
+    [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style]]))
 
 
@@ -60,6 +63,36 @@
    :block-size "auto"})
 
 
+(stylefy/keyframes "fade-in"
+                   [:from
+                    {:opacity "0"}]
+                   [:to
+                    {:opacity "1"}])
+
+
+(def modal-contents-style {:display "flex"
+                           :padding "1.5rem"
+                           :flex-direction "column"
+                           :align-items "center"
+                           ::stylefy/manual [[:p {:max-width "24rem"
+                                                  :text-align "center"}]
+                                             [:button {:font-size "18px"}]]})
+
+
+(def features-table-style {:background (color :background-plus-1 :opacity-low)
+                           :border-radius "0.5rem"
+                           :margin "0.5rem auto 1.25rem"
+                           ::stylefy/manual [[:th {:font-weight "normal"
+                                                   :opacity "0.75"
+                                                   :padding-block-start "0.5rem"
+                                                   :text-align "left"}]
+                                             [:th :td {:padding-inline "0.25rem"
+                                                       :padding-block "0.125rem"}]
+                                             [:tr:last-child [:td {:padding-block-end "0.5rem"}]]
+                                             [:th:first-child :td:first-child {:padding-inline-start "1rem"}]
+                                             [:th:last-child :td:last-child {:padding-inline-end "1rem"}]]})
+
+
 ;;; Components
 
 
@@ -68,42 +101,96 @@
   [:hr (use-style separator-style)])
 
 
+(defn feature-yes []
+   [(r/adapt-react-class mui-icons/Check) {:style {:margin "auto"
+                                                   :display "block"
+                                                   :color (color :confirmation-color)}}])
+
+(defn feature-no []
+   [(r/adapt-react-class mui-icons/Close) {:style {:margin "auto"
+                                                   :display "block"
+                                                   :color (color :warning-color)}}])
+
+(defn features-table
+  []
+  [:table (use-style features-table-style)
+   [:thead
+    [:th]
+    [:th "Athens"]
+    [:th "Roam"]]
+   [:tbody
+    [:tr
+     [:td "Text Editing"]
+     [:td [feature-yes]]
+     [:td [feature-yes]]]
+    [:tr
+     [:td "Bidirectional Links"]
+     [:td [feature-yes]]
+     [:td [feature-yes]]]
+    [:tr
+     [:td "Timeline (Daily Notes)"]
+     [:td [feature-yes]]
+     [:td [feature-yes]]]
+    [:tr
+     [:td "Bookmarked Pages"]
+     [:td [feature-yes]]
+     [:td [feature-yes]]]
+    [:tr
+     [:td "Todos, Kanban, etc."]
+     [:td [feature-no]]
+     [:td [feature-yes]]]]])
+
+
 (defn app-toolbar
   []
   (let [left-open? (subscribe [:left-sidebar/open])
         right-open? (subscribe [:right-sidebar/open])
         current-route (subscribe [:current-route])
+        import-modal-open? (r/atom false)
         route-name (-> @current-route :data :name)]
 
-    [:header (use-style app-header-style)
-     [:div (use-style app-header-control-section-style)
-      [button {:active @left-open?
-               :label [:> mui-icons/Menu] :on-click-fn #(dispatch [:left-sidebar/toggle])}]
+    (fn []
+      [:<>
+       [:header (use-style app-header-style)
+        [:div (use-style app-header-control-section-style)
+         [button {:active @left-open?
+                  :label [:> mui-icons/Menu] :on-click-fn #(dispatch [:left-sidebar/toggle])}]
       ;; [separator] // for Electron implementation
       ;; [button {:on-click-fn #(navigate :home)
       ;;          :label [:> mui-icons/ChevronLeft]}]
       ;; [button {:on-click-fn #(navigate :home)
       ;;          :label [:> mui-icons/ChevronRight]}]
-      [separator]
-      [button {:on-click-fn #(navigate :home)
-               :active (when (= route-name :home) true)
-               :label [:> mui-icons/Today]}]
-      [button {:on-click-fn #(navigate :pages)
-               :active (when (= route-name :pages) true)
-               :label [:> mui-icons/FileCopy]}]
-      [button {:on-click-fn #(dispatch [:athena/toggle])
-               :style {:width "14rem" :margin-left "1rem" :background (color :background-minus-1)}
-               :active (when @(subscribe [:athena/open]) true)
-               :label [:<> [:> mui-icons/Search] [:span "Find or Create a Page"]]}]]
+         [separator]
+         [button {:on-click-fn #(navigate :home)
+                  :active (when (= route-name :home) true)
+                  :label [:> mui-icons/Today]}]
+         [button {:on-click-fn #(navigate :pages)
+                  :active (when (= route-name :pages) true)
+                  :label [:> mui-icons/FileCopy]}]
+         [button {:on-click-fn #(dispatch [:athena/toggle])
+                  :style {:width "14rem" :margin-left "1rem" :background (color :background-minus-1)}
+                  :active (when @(subscribe [:athena/open]) true)
+                  :label [:<> [:> mui-icons/Search] [:span "Find or Create a Page"]]}]]
 
-     [:div (use-style app-header-secondary-controls-style)
-      [button {:label [:> mui-icons/Settings]}]
-      [separator]
-      [button {:label [:> mui-icons/VerticalSplit {:style {:transform "scaleX(-1)"}}]
-               :active @right-open?
-               :on-click-fn #(dispatch [:right-sidebar/toggle])}]]]))
+        [:div (use-style app-header-secondary-controls-style)
+         [button {:on-click-fn #(reset! import-modal-open? true)
+                  :label [:> mui-icons/Publish]}]
+         [separator]
+         [button {:label [:> mui-icons/VerticalSplit {:style {:transform "scaleX(-1)"}}]
+                  :active @right-open?
+                  :on-click-fn #(dispatch [:right-sidebar/toggle])}]]]
 
-
-;;; Devcards
-
+       (when @import-modal-open?
+         [:div (use-style modal-style)
+          [modal/modal
+           {:title [:div.modal__title [:> mui-icons/Publish][:h4 "Import to Athens"] [button
+                                                  {:on-click-fn #(reset! import-modal-open? false)
+                                                   :label [:> mui-icons/Close]}]]
+            :content [:div (use-style modal-contents-style)
+                      ;; TODO: Write intro copy
+                      [:p "Some helpful framing about what Athens does and what users should expect. Athens is not Roam."]
+                      [features-table]
+                      ;; TODO: Create browser file dialog and actually import stuff
+                      [:div [button-primary {:label "Add Files"}]]]
+            :on-close #(reset! import-modal-open? false)}]])])))
 

--- a/src/cljs/athens/views/modal.cljs
+++ b/src/cljs/athens/views/modal.cljs
@@ -10,36 +10,37 @@
 
 ;;; Styles
 
-(def modal-style {:z-index (:zindex-modal ZINDICES)
-                  :animation "fade-in 0.2s"
-                  ::stylefy/manual [[:.modal {:position "fixed"
-                                              :top "50vh"
-                                              :left "50vw"
-                                              :transform "translate(-50%, -50%)"
-                                              :border-radius "0.5rem"
-                                              :display "flex"
-                                              :flex-direction "column"
-                                              :background (color :background-plus-2)
-                                              :box-shadow [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-lower)]]}]
-                                    [:modal__header {:display "contents"}] ;; Deactivate layout on the default header
-                                    [(selectors/> :.modal__header :button) {:display "none"}] ;; Hide default close button
-                                    [:.modal__title :.modal__footer {:flex "0 0 auto"
-                                                                     :padding "0.25rem 1rem"
-                                                                     :display "flex"
-                                                                     :align-items "center"}
-                                     [:&:empty {:display "none"}]]
-                                    [:.modal__title {:border-bottom [["1px solid " (color :border-color)]]}
-                                     [:button {:margin-inline-start "auto"
-                                               :align-self "flex-start"
-                                               :margin-block "0.5rem"}]]
-                                    [:.modal__content {:flex "1 1 100%"
-                                                       :overflow-y "auto"
-                                                       :border-top [["1px solid " (color :border-color)]]}]
-                                    [:.modal__footer {:display "flex"}]
-                                    [:.modal__backdrop {:position "fixed"
-                                                        :top 0
-                                                        :left 0
-                                                        :background "rgba(0,0,0,0.1)"
-                                                        :z-index -1
-                                                        :width "100vw"
-                                                        :height "100vh"}]]})
+(def modal-style
+  {:z-index (:zindex-modal ZINDICES)
+   :animation "fade-in 0.2s"
+   ::stylefy/manual [[:.modal {:position "fixed"
+                               :top "50vh"
+                               :left "50vw"
+                               :transform "translate(-50%, -50%)"
+                               :border-radius "0.5rem"
+                               :display "flex"
+                               :flex-direction "column"
+                               :background (color :background-plus-2)
+                               :box-shadow [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-lower)]]}]
+                     [:modal__header {:display "contents"}] ;; Deactivate layout on the default header
+                     [(selectors/> :.modal__header :button) {:display "none"}] ;; Hide default close button
+                     [:.modal__title :.modal__footer {:flex "0 0 auto"
+                                                      :padding "0.25rem 1rem"
+                                                      :display "flex"
+                                                      :align-items "center"}
+                      [:&:empty {:display "none"}]]
+                     [:.modal__title {:border-bottom [["1px solid " (color :border-color)]]}
+                      [:button {:margin-inline-start "auto"
+                                :align-self "flex-start"
+                                :margin-block "0.5rem"}]]
+                     [:.modal__content {:flex "1 1 100%"
+                                        :overflow-y "auto"
+                                        :border-top [["1px solid " (color :border-color)]]}]
+                     [:.modal__footer {:display "flex"}]
+                     [:.modal__backdrop {:position "fixed"
+                                         :top 0
+                                         :left 0
+                                         :background "rgba(0,0,0,0.1)"
+                                         :z-index -1
+                                         :width "100vw"
+                                         :height "100vh"}]]})

--- a/src/cljs/athens/views/modal.cljs
+++ b/src/cljs/athens/views/modal.cljs
@@ -1,0 +1,45 @@
+(ns athens.views.modal
+  (:require
+    [athens.db]
+    [athens.style :refer [color ZINDICES DEPTH-SHADOWS]]
+    [cljsjs.react]
+    [cljsjs.react.dom]
+    [garden.selectors :as selectors]
+    [stylefy.core :as stylefy]))
+
+
+;;; Styles
+
+(def modal-style {:z-index (:zindex-modal ZINDICES)
+                  :animation "fade-in 0.2s"
+                  ::stylefy/manual [[:.modal {:position "fixed"
+                                              :top "50vh"
+                                              :left "50vw"
+                                              :transform "translate(-50%, -50%)"
+                                              :border-radius "0.5rem"
+                                              :display "flex"
+                                              :flex-direction "column"
+                                              :background (color :background-plus-2)
+                                              :box-shadow [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-lower)]]}]
+                                    [:modal__header {:display "contents"}] ;; Deactivate layout on the default header
+                                    [(selectors/> :.modal__header :button) {:display "none"}] ;; Hide default close button
+                                    [:.modal__title :.modal__footer {:flex "0 0 auto"
+                                                                     :padding "0.25rem 1rem"
+                                                                     :display "flex"
+                                                                     :align-items "center"}
+                                     [:&:empty {:display "none"}]]
+                                    [:.modal__title {:border-bottom [["1px solid " (color :border-color)]]}
+                                     [:button {:margin-inline-start "auto"
+                                               :align-self "flex-start"
+                                               :margin-block "0.5rem"}]]
+                                    [:.modal__content {:flex "1 1 100%"
+                                                       :overflow-y "auto"
+                                                       :border-top [["1px solid " (color :border-color)]]}]
+                                    [:.modal__footer {:display "flex"}]
+                                    [:.modal__backdrop {:position "fixed"
+                                                        :top 0
+                                                        :left 0
+                                                        :background "rgba(0,0,0,0.1)"
+                                                        :z-index -1
+                                                        :width "100vw"
+                                                        :height "100vh"}]]})


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens/)

<img width="1158" alt="Screen Shot 2020-07-16 at 10 29 36 PM" src="https://user-images.githubusercontent.com/98312/87742012-d7b10f00-c7b3-11ea-849f-47359223b48b.png">

Adds modal, attached to the 'import' toolbar button to show some intro/help text before users add data to Athens from elsewhere.