### PR TITLE
feat(athena): scroll search results with arrow keys

### DIFF
--- a/src/cljc/athens/util.cljc
+++ b/src/cljc/athens/util.cljc
@@ -43,3 +43,13 @@
     (-> (- (.. rect -bottom)
            (.. rect -top))
         (/ 2))))
+
+
+(defn is-beyond-rect?
+  "Checks if any part of the element is above or below the container's bounding rect"
+  [element container]
+  (let [el-box (.. element getBoundingClientRect)
+        cont-box (.. container getBoundingClientRect)]
+    (or
+      (> (.. el-box -bottom) (.. cont-box -bottom))
+      (< (.. el-box -top) (.. cont-box -top)))))

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -176,7 +176,6 @@
         shift (.. e -shiftKey)
         {:keys [index query results]} @state
         item (get results index)]
-
     (cond
       ;; FIXME: why does this only work in Devcards?
       (= key KeyCodes.ESC)
@@ -205,10 +204,30 @@
       ;; TODO: change scroll as user reaches top or bottom
       ;; TODO: what happens when user goes to -1? or past end of list?
       (= key KeyCodes.UP)
-      (swap! state update :index dec)
+      (when (> index 0)
+        (do
+          (swap! state update :index dec)
+          (let [select-el (first (array-seq (. js/document getElementsByClassName "selected")))
+                next-el (.. select-el -previousElementSibling)
+                athena-el (first (array-seq (. js/document getElementsByClassName "athena")))
+                result-el (nth (array-seq (.. athena-el -children)) 2)
+                result-box (.. result-el getBoundingClientRect)
+                next-box (.. next-el getBoundingClientRect)]
+            (if (< (.. next-box -top) (.. result-box -top))
+              (.. next-el (scrollIntoView true {:behavior "auto"}))))))
 
       (= key KeyCodes.DOWN)
-      (swap! state update :index inc)
+      (when (< index (dec (count results)))
+        (do
+          (swap! state update :index inc)
+          (let [select-el (first (array-seq (. js/document getElementsByClassName "selected")))
+                next-el (.. select-el -nextElementSibling)
+                athena-el (first (array-seq (. js/document getElementsByClassName "athena")))
+                result-el (nth (array-seq (.. athena-el -children)) 2)
+                result-box (.. result-el getBoundingClientRect)
+                next-box (.. next-el getBoundingClientRect)]
+            (if (> (.. next-box -bottom) (.. result-box -bottom))
+              (.. next-el (scrollIntoView false {:behavior "auto"}))))))
 
       :else nil)))
 

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -169,14 +169,15 @@
                                            (take 20 (search-in-block-content query)))
                                    vec)}))))
 
+
 (defn is-beyond-rect?
   "Checks if any part of the element is above or below the container's bounding rect"
   [element container]
   (let [el-box (.. element getBoundingClientRect)
         cont-box (.. container getBoundingClientRect)]
     (or
-     (> (.. el-box -bottom) (.. cont-box -bottom))
-     (< (.. el-box -top) (.. cont-box -top)))))
+      (> (.. el-box -bottom) (.. cont-box -bottom))
+      (< (.. el-box -top) (.. cont-box -top)))))
 
 
 (defn key-down-handler
@@ -215,26 +216,22 @@
       (= key KeyCodes.UP)
       (do
         (swap! state update :index #(dec (if (zero? index) (count results) index)))
-        (let [cur-index (get @state :index)
+        (let [cur-index (:index @state)
               input-el (.. e -target)
               result-el (.. (. input-el closest "div.athena") -lastElementChild)
               next-el (nth (array-seq (.. result-el -children)) cur-index)]
-          (if (= cur-index (dec (count results)))
-            (.. next-el (scrollIntoView false {:behavior "auto"}))
-            (when (is-beyond-rect? next-el result-el)
-              (.. next-el (scrollIntoView true {:behavior "auto"}))))))
+          (when (is-beyond-rect? next-el result-el)
+            (.. next-el (scrollIntoView (not= cur-index (dec (count results))) {:behavior "auto"})))))
 
       (= key KeyCodes.DOWN)
       (do
         (swap! state update :index #(if (= index (dec (count results))) 0 (inc %)))
-        (let [cur-index (get @state :index)
+        (let [cur-index (:index @state)
               input-el (.. e -target)
               result-el (.. (. input-el closest "div.athena") -lastElementChild)
               next-el (nth (array-seq (.. result-el -children)) cur-index)]
-          (if (zero? cur-index)
-            (.. next-el (scrollIntoView true {:behavior "auto"}))
-            (when (is-beyond-rect? next-el result-el)
-              (.. next-el (scrollIntoView false {:behavior "auto"}))))))
+          (when (is-beyond-rect? next-el result-el)
+            (.. next-el (scrollIntoView (zero? cur-index) {:behavior "auto"})))))
 
       :else nil)))
 

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -205,29 +205,27 @@
       ;; TODO: what happens when user goes to -1? or past end of list?
       (= key KeyCodes.UP)
       (when (> index 0)
-        (do
-          (swap! state update :index dec)
-          (let [select-el (first (array-seq (. js/document getElementsByClassName "selected")))
-                next-el (.. select-el -previousElementSibling)
-                athena-el (first (array-seq (. js/document getElementsByClassName "athena")))
-                result-el (nth (array-seq (.. athena-el -children)) 2)
-                result-box (.. result-el getBoundingClientRect)
-                next-box (.. next-el getBoundingClientRect)]
-            (if (< (.. next-box -top) (.. result-box -top))
-              (.. next-el (scrollIntoView true {:behavior "auto"}))))))
+        (swap! state update :index dec)
+        (let [select-el (first (array-seq (. js/document getElementsByClassName "selected")))
+              next-el (.. select-el -previousElementSibling)
+              athena-el (first (array-seq (. js/document getElementsByClassName "athena")))
+              result-el (nth (array-seq (.. athena-el -children)) 2)
+              result-box (.. result-el getBoundingClientRect)
+              next-box (.. next-el getBoundingClientRect)]
+          (when (< (.. next-box -top) (.. result-box -top))
+            (.. next-el (scrollIntoView true {:behavior "auto"})))))
 
       (= key KeyCodes.DOWN)
       (when (< index (dec (count results)))
-        (do
-          (swap! state update :index inc)
-          (let [select-el (first (array-seq (. js/document getElementsByClassName "selected")))
-                next-el (.. select-el -nextElementSibling)
-                athena-el (first (array-seq (. js/document getElementsByClassName "athena")))
-                result-el (nth (array-seq (.. athena-el -children)) 2)
-                result-box (.. result-el getBoundingClientRect)
-                next-box (.. next-el getBoundingClientRect)]
-            (if (> (.. next-box -bottom) (.. result-box -bottom))
-              (.. next-el (scrollIntoView false {:behavior "auto"}))))))
+        (swap! state update :index inc)
+        (let [select-el (first (array-seq (. js/document getElementsByClassName "selected")))
+              next-el (.. select-el -nextElementSibling)
+              athena-el (first (array-seq (. js/document getElementsByClassName "athena")))
+              result-el (nth (array-seq (.. athena-el -children)) 2)
+              result-box (.. result-el getBoundingClientRect)
+              next-box (.. next-el getBoundingClientRect)]
+          (when (> (.. next-box -bottom) (.. result-box -bottom))
+            (.. next-el (scrollIntoView false {:behavior "auto"})))))
 
       :else nil)))
 

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -169,6 +169,15 @@
                                            (take 20 (search-in-block-content query)))
                                    vec)}))))
 
+(defn is-beyond-rect?
+  "Checks if any part of the element is above or below the container's bounding rect"
+  [element container]
+  (let [el-box (.. element getBoundingClientRect)
+        cont-box (.. container getBoundingClientRect)]
+    (or
+     (> (.. el-box -bottom) (.. cont-box -bottom))
+     (< (.. el-box -top) (.. cont-box -top)))))
+
 
 (defn key-down-handler
   [e state]
@@ -209,12 +218,10 @@
         (let [cur-index (get @state :index)
               input-el (.. e -target)
               result-el (.. (. input-el closest "div.athena") -lastElementChild)
-              result-box (.. result-el getBoundingClientRect)
-              next-el (nth (array-seq (.. result-el -children)) cur-index)
-              next-box (.. next-el getBoundingClientRect)]
+              next-el (nth (array-seq (.. result-el -children)) cur-index)]
           (if (= cur-index (dec (count results)))
             (.. next-el (scrollIntoView false {:behavior "auto"}))
-            (when (< (.. next-box -top) (.. result-box -top))
+            (when (is-beyond-rect? next-el result-el)
               (.. next-el (scrollIntoView true {:behavior "auto"}))))))
 
       (= key KeyCodes.DOWN)
@@ -223,12 +230,10 @@
         (let [cur-index (get @state :index)
               input-el (.. e -target)
               result-el (.. (. input-el closest "div.athena") -lastElementChild)
-              result-box (.. result-el getBoundingClientRect)
-              next-el (nth (array-seq (.. result-el -children)) cur-index)
-              next-box (.. next-el getBoundingClientRect)]
+              next-el (nth (array-seq (.. result-el -children)) cur-index)]
           (if (zero? cur-index)
             (.. next-el (scrollIntoView true {:behavior "auto"}))
-            (when (> (.. next-box -bottom) (.. result-box -bottom))
+            (when (is-beyond-rect? next-el result-el)
               (.. next-el (scrollIntoView false {:behavior "auto"}))))))
 
       :else nil)))


### PR DESCRIPTION
This PR closes #271 and checks off part of #126 

Athena can now scroll through the search results with arrow keys. The implementation also cycles through the search result list.