### PR TITLE
feat(style): only show focus ring if using keyboard

### DIFF
--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -141,7 +141,9 @@
                             :border-radius "0.25rem"
                             :padding "0.25em 0.5em"}]
                      [:img {:max-width "100%"
-                            :height "auto"}]]})
+                            :height "auto"}]
+                     [":focus" {:outline-width 0}]
+                     [":focus-visible" {:outline-width "1px"}]]})
 
 
 (def app-styles


### PR DESCRIPTION
[Demo](https://shanberg.github.io/athens)

Use the browser's :focus-visible pseudo-class to only show a focus highlight when the user's using the keyboard, e.g. when they're tabbing through buttons and form elements. Hide the focus highlight otherwise.