### PR TITLE
feat(app): supports import from Roam database

### DIFF
--- a/src/cljs/athens/devcards/app_toolbar.cljs
+++ b/src/cljs/athens/devcards/app_toolbar.cljs
@@ -204,7 +204,7 @@
                       [:p "Some helpful framing about what Athens does and what users should expect. Athens is not Roam."]
                       [:p "To export a Roam database to the " [:code "json triplet"] " format that Athens understands, refer to the official Athens documentation."]
                       [features-table]
-                      [:input {:type "file" 
+                      [:input {:type "file"
                                :id "db-import-add-files"
                                :style {:display "none"}
                                :on-change (fn [e] (file-cb e) (reset! import-modal-open? false))}]

--- a/src/cljs/athens/devcards/app_toolbar.cljs
+++ b/src/cljs/athens/devcards/app_toolbar.cljs
@@ -11,6 +11,15 @@
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style]]))
 
+;;; Helper functions
+(defn file-cb
+  [e]
+  (let [fr (js/FileReader.)
+        file (.. e -target -files (item 0))]
+    ;; TODO: maybe rename `http-success/get-db` into a more intuitive name like `get-db/parse-triplet-json-and-import` ?
+    (set! (.-onload fr) #(dispatch [:http-success/get-db (.. % -target -result)]))
+    (.readAsText fr file)))
+
 
 ;;; Styles
 
@@ -193,8 +202,13 @@
             :content [:div (use-style modal-contents-style)
                       ;; TODO: Write intro copy
                       [:p "Some helpful framing about what Athens does and what users should expect. Athens is not Roam."]
+                      [:p "To export a Roam database to the " [:code "json triplet"] " format that Athens understands, refer to the official Athens documentation."]
                       [features-table]
-                      ;; TODO: Create browser file dialog and actually import stuff
-                      [:div [button {:primary true} "Add Files"]]]
+                      [:input {:type "file" 
+                               :id "db-import-add-files"
+                               :style {:display "none"}
+                               :on-change (fn [e] (file-cb e) (reset! import-modal-open? false))}]
+                      [:div [button {:primary true
+                                     :on-click #(.click (.getElementById js/document "db-import-add-files"))} "Add Files"]]]
             :on-close #(reset! import-modal-open? false)}]])])))
 

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -52,14 +52,6 @@
       (dispatch [:alert/unset]))))
 
 
-(defn file-cb
-  [e]
-  (let [fr (js/FileReader.)
-        file (.. e -target -files (item 0))]
-    (set! (.-onload fr) #(dispatch [:parse-datoms (.. % -target -result)]))
-    (.readAsText fr file)))
-
-
 ;; Panels
 
 


### PR DESCRIPTION
Check the "Files changed" tab for my discussions on how this commit fits into the bigger picture (this is closer to the "literate programming" paradigm that I thought would be wonderful for Athens, even better if we can one day include all these in an Athens database as referenced by @tangjeff0 and @itsrainingmani [here](https://github.com/athensresearch/athens/pull/274#discussion_r456984186))

## Changes
- Re-added feature to import Roam database.

## Discussion
- In what format should we export our data?

## Demo
![my screenshot using my Roam DB](https://user-images.githubusercontent.com/29003511/87920021-3673d280-caab-11ea-8d3e-a84454ffe483.png)
