### PR TITLE
refactor(dropdown): use styles instead of thin wrappers -- page menu, inline search, and slash commands

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -143,7 +143,7 @@
 
 (defn get-node-document
   [id]
-  (->> @(pull dsdb '[:db/id :node/title :block/uid :block/string :block/open :block/order {:block/children ...} :edit/time] id)
+  (->> @(pull dsdb '[:db/id :node/title :block/uid :block/string :block/open :block/order :page/sidebar {:block/children ...} :edit/time] id)
        sort-block-children))
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -285,17 +285,17 @@
 
 
 (reg-event-fx
-  :page/make-shortcut
+  :page/add-shortcut
   (fn [_ [_ uid]]
-    (let [sidebar-ents (d/q '[:find ?e
+    (let [sidebar-ents (d/q '[:find (count ?e) .
                               :where
                               [?e :page/sidebar _]]
                             @db/dsdb)]
-      {:transact! [{:block/uid uid :page/sidebar (count sidebar-ents)}]})))
+      {:transact! [{:block/uid uid :page/sidebar sidebar-ents}]})))
 
 
 (reg-event-fx
-  :page/unmake-shortcut
+  :page/remove-shortcut
   (fn [_ [_ uid]]
     {:transact! [[:db/retract [:block/uid uid] :page/sidebar]]}))
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -299,8 +299,7 @@
 (reg-event-fx
   :page/unmake-shortcut
   (fn [_ [_ uid]]
-      {:transact! [[:db/retract [:block/uid uid] :page/sidebar]]}))
-
+    {:transact! [[:db/retract [:block/uid uid] :page/sidebar]]}))
 
 
 (reg-event-fx
@@ -649,7 +648,6 @@
   :left-sidebar/drop-below
   (fn-traced [_ [_ source-order target-order]]
              {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
-
 
 
 ;;;; TODO: delete the following logic when re-implementing title merge

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -287,13 +287,14 @@
 (reg-event-fx
   :page/add-shortcut
   (fn [_ [_ uid]]
-    (let [sidebar-ents (d/q '[:find (count ?e) .
+    (let [sidebar-ents (d/q '[:find ?e
                               :where
                               [?e :page/sidebar _]]
                             @db/dsdb)]
-      {:transact! [{:block/uid uid :page/sidebar sidebar-ents}]})))
+      {:transact! [{:block/uid uid :page/sidebar (count sidebar-ents)}]})))
 
 
+;; TODO: reindex
 (reg-event-fx
   :page/remove-shortcut
   (fn [_ [_ uid]]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -287,6 +287,23 @@
 
 
 (reg-event-fx
+  :page/make-shortcut
+  (fn [_ [_ uid]]
+    (let [sidebar-ents (d/q '[:find ?e
+                              :where
+                              [?e :page/sidebar _]]
+                            @db/dsdb)]
+      {:transact! [{:block/uid uid :page/sidebar (count sidebar-ents)}]})))
+
+
+(reg-event-fx
+  :page/unmake-shortcut
+  (fn [_ [_ uid]]
+      {:transact! [[:db/retract [:block/uid uid] :page/sidebar]]}))
+
+
+
+(reg-event-fx
   :undo
   (fn [_ _]
     (when-let [prev (db/find-prev @db/history #(identical? @db/dsdb %))]
@@ -632,6 +649,7 @@
   :left-sidebar/drop-below
   (fn-traced [_ [_ source-order target-order]]
              {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
+
 
 
 ;;;; TODO: delete the following logic when re-implementing title merge

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -2,6 +2,7 @@
   (:require
     [garden.color :refer [opacify hex->hsl]]
     [stylefy.core :as stylefy]))
+    ;;[athens.views.dropdown :as dropdown]))
 
 
 ;; (defn cssv
@@ -144,6 +145,7 @@
                             :height "auto"}]
                      [":focus" {:outline-width 0}]
                      [":focus-visible" {:outline-width "1px"}]]})
+
 
 
 (def app-styles

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -147,7 +147,6 @@
                      [":focus-visible" {:outline-width "1px"}]]})
 
 
-
 (def app-styles
   {:overflow "hidden"
    :height   "100vh"

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -309,10 +309,10 @@
   (let [{:search/keys [page block query results index]} @state]
     (when (or block page)
       [:div (merge (use-style dropdown-style)
-              {:style {:position "absolute"
-                       :top      "100%"
-                       :max-height "20rem"
-                       :left     "1.75em"}})
+                   {:style {:position "absolute"
+                            :top      "100%"
+                            :max-height "20rem"
+                            :left     "1.75em"}})
        (if (clojure.string/blank? query)
          [:div "Start Typing!"]
          (doall
@@ -490,7 +490,6 @@
           [block-content-el block state is-editing]]
 
          [slash-menu-el state]
-
 
 
          [page-search-el block state]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -10,7 +10,7 @@
     [athens.util :refer [now-ts gen-block-uid mouse-offset vertical-center]]
     [athens.views.all-pages :refer [date-string]]
     [athens.views.buttons :refer [button]]
-    [athens.views.dropdown :refer [slash-menu-component menu-style dropdown]]
+    [athens.views.dropdown :refer [menu-style dropdown-style]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [garden.selectors :as selectors]
@@ -308,21 +308,22 @@
   [_block state]
   (let [{:search/keys [page block query results index]} @state]
     (when (or block page)
-      [dropdown {:style   {:position "absolute"
-                           :top      "100%"
-                           :max-height "20rem"
-                           :left     "1.75em"}
-                 :content (if (clojure.string/blank? query)
-                            [:div "Start Typing!"]
-                            (doall
-                              [:div (use-style menu-style {:id "dropdown-menu"})
-                               (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
-                                 ^{:key (str "inline-search-item" uid)}
-                                 [button
-                                  {:on-click #(prn "expand")
-                                   :active (when (= index i) true)
-                                   :id (str "result-" i)}
-                                  (or title string)])]))}])))
+      [:div (merge (use-style dropdown-style)
+              {:style {:position "absolute"
+                       :top      "100%"
+                       :max-height "20rem"
+                       :left     "1.75em"}})
+       (if (clojure.string/blank? query)
+         [:div "Start Typing!"]
+         (doall
+           [:div (use-style menu-style {:id "dropdown-menu"})
+            (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list results)]
+              ^{:key (str "inline-search-item" uid)}
+              [button
+               {:on-click #(prn "expand")
+                :active (when (= index i) true)
+                :id (str "result-" i)}
+               (or title string)])]))])))
 
 
 ;; Actual string contents - two elements, one for reading and one for writing
@@ -471,7 +472,18 @@
           [block-content-el block state is-editing]]
 
          (when (:slash? @state)
-           [slash-menu-component {:style {:position "absolute" :top "100%" :left "-0.125em"}}])
+           [:div (merge (use-style dropdown-style)
+                   {:style {:position "absolute" :top "100%" :left "-0.125em"}})
+            [:div (merge (use-style menu-style) {:style {:max-height "8em"}})
+             [button [:<> [:> mui-icons/Done] [:span "Add Todo"] [:kbd "cmd-enter"]]]
+             [button [:<> [:> mui-icons/Description] [:span "Page Reference"] [:kbd "[["]]]
+             [button [:<> [:> mui-icons/Link] [:span "Block Reference"] [:kbd "(("]]]
+             [button [:<> [:> mui-icons/Timer] [:span "Current Time"]]]
+             [button [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]]
+             [button [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]]
+             [button [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]]
+             [button [:<> [:> mui-icons/Today] [:span "Today"]]]]])
+
          [page-search-el block state]
 
          ;; Children

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -326,6 +326,24 @@
                (or title string)])]))])))
 
 
+(defn slash-menu-el
+  [state]
+  (let [{:keys [slash?]} @state]
+    (when slash?
+      [:div (merge (use-style dropdown-style)
+                   {:style {:position "absolute" :top "100%" :left "-0.125em"}})
+       [:div (merge (use-style menu-style)
+                    {:style {:max-height "8em"}})
+        [button [:<> [:> mui-icons/Done] [:span "Add Todo"] [:kbd "cmd-enter"]]]
+        [button [:<> [:> mui-icons/Description] [:span "Page Reference"] [:kbd "[["]]]
+        [button [:<> [:> mui-icons/Link] [:span "Block Reference"] [:kbd "(("]]]
+        [button [:<> [:> mui-icons/Timer] [:span "Current Time"]]]
+        [button [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]]
+        [button [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]]
+        [button [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]]
+        [button [:<> [:> mui-icons/Today] [:span "Today"]]]]])))
+
+
 ;; Actual string contents - two elements, one for reading and one for writing
 ;; seems hacky, but so far no better way to click into the correct position with one conditional element
 (defn block-content-el
@@ -471,18 +489,9 @@
           [tooltip-el block state]
           [block-content-el block state is-editing]]
 
-         (when (:slash? @state)
-           [:div (merge (use-style dropdown-style)
-                   {:style {:position "absolute" :top "100%" :left "-0.125em"}})
-            [:div (merge (use-style menu-style) {:style {:max-height "8em"}})
-             [button [:<> [:> mui-icons/Done] [:span "Add Todo"] [:kbd "cmd-enter"]]]
-             [button [:<> [:> mui-icons/Description] [:span "Page Reference"] [:kbd "[["]]]
-             [button [:<> [:> mui-icons/Link] [:span "Block Reference"] [:kbd "(("]]]
-             [button [:<> [:> mui-icons/Timer] [:span "Current Time"]]]
-             [button [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]]
-             [button [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]]
-             [button [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]]
-             [button [:<> [:> mui-icons/Today] [:span "Today"]]]]])
+         [slash-menu-el state]
+
+
 
          [page-search-el block state]
 

--- a/src/cljs/athens/views/buttons.cljs
+++ b/src/cljs/athens/views/buttons.cljs
@@ -72,6 +72,7 @@
 
 (stylefy/class "button" buttons-style)
 
+
 (defn button
   "Keep button interface as close to vanilla hiccup as possible.
   Dissoc :style :active and :class because we don't want to merge them in directly.

--- a/src/cljs/athens/views/buttons.cljs
+++ b/src/cljs/athens/views/buttons.cljs
@@ -70,6 +70,7 @@
 
 ;;; Components
 
+(stylefy/class "button" buttons-style)
 
 (defn button
   "Keep button interface as close to vanilla hiccup as possible.

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -70,14 +70,14 @@
    :margin "0.25rem 0"})
 
 
-(def submenu-indicator-style
-  {:margin-left "auto"
-   :opacity "0.5"
-   :display "flex"
-   :order 10
-   :align-self "flex-end"
-   :font-family "inherit"
-   ::stylefy/manual [[:&:last-child {:padding-inline-end "0"}]]})
+#_(def submenu-indicator-style
+    {:margin-left "auto"
+     :opacity "0.5"
+     :display "flex"
+     :order 10
+     :align-self "flex-end"
+     :font-family "inherit"
+     ::stylefy/manual [[:&:last-child {:padding-inline-end "0"}]]})
 
 
 ;;; Components

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -145,11 +145,11 @@
 
 
 (defn page-menu-component
-  [{:keys [style uid has-shortcut?]}]
+  [{:keys [style uid is-shortcut?]}]
   [dropdown {:style (merge {:font-size "14px"} style) :content
              [menu {:content
                     [:<>
-                     (if has-shortcut?
+                     (if is-shortcut?
                        [:button (use-style menu-item-style {:on-click #(dispatch [:page/unmake-shortcut uid])})
                         [:<>
                          [:> mui-icons/BookmarkBorder]

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -131,24 +131,10 @@
                      [button [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]]
                      [button [:<> [:> mui-icons/Today] [:span "Today"]]]]}]}])
 
-
-(defn page-menu-component
-  [{:keys [style uid is-shortcut?]}]
-  [dropdown {:style (merge {:font-size "14px"} style) :content
-             [menu {:content
-                    [:<>
-                     (if is-shortcut?
-                       [button {:on-click #(dispatch [:page/unmake-shortcut uid])}
-                        [:<>
-                         [:> mui-icons/BookmarkBorder]
-                         [:span "Remove Shortcut"]]]
-                       [button {:on-click #(dispatch [:page/make-shortcut uid])}
-                        [:<>
-                         [:> mui-icons/Bookmark]
-                         [:span "Add Shortcut"]]])
-                     [menu-separator]
-                     [button [:<> [:> mui-icons/Delete] [:span "Delete Page"]]]]}]}])
-
+(stylefy/class "dropdown" dropdown-style)
+(stylefy/class "menu" menu-style)
+(stylefy/class "menu-item" athens.views.buttons/buttons-style)
+(stylefy/class "menu-separator" menu-separator-style)
 
 (defn block-context-menu-component
   [style]

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -3,7 +3,7 @@
     ["@material-ui/icons" :as mui-icons]
     [athens.db]
     [athens.style :refer [color DEPTH-SHADOWS ZINDICES]]
-    [athens.views.buttons :refer [button]]
+    [athens.views.buttons :refer [button buttons-style]]
     [athens.views.filters :refer [filters-el]]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -50,6 +50,11 @@
                                          :margin-inline-start "0"
                                          :margin-inline-end "0.5rem"}]]]})
 
+(def menu-item-style
+  (merge {}
+         buttons-style))
+
+
 
 (def menu-heading-style
   {:min-height "2rem"
@@ -84,103 +89,54 @@
    ::stylefy/manual [[:&:last-child {:padding-inline-end "0"}]]})
 
 
-;;; Primitives
-
-
-(defn dropdown
-  [{:keys [style content]}]
-  [:div (use-style (merge dropdown-style style) {:id "dropdown"})
-   content])
-
-
-(defn menu
-  [{:keys [style content]}]
-  [:div (use-style (merge menu-style style))
-   content])
-
-
-(defn menu-separator
-  []
-  [:hr (use-style menu-separator-style)])
-
-
-(defn submenu-indicator
-  []
-  [:> mui-icons/ChevronRight (use-style submenu-indicator-style)])
-
-
-(defn menu-heading
-  [heading]
-  [:header (use-style menu-heading-style) [:span heading]])
-
-
 ;;; Components
-
-
-(defn slash-menu-component
-  [{:keys [style]}]
-  [dropdown {:style style :content
-             [menu {:style {:max-height "8em"} :content
-                    [:<>
-                     [button [:<> [:> mui-icons/Done] [:span "Add Todo"] [:kbd "cmd-enter"]]]
-                     [button [:<> [:> mui-icons/Description] [:span "Page Reference"] [:kbd "[["]]]
-                     [button [:<> [:> mui-icons/Link] [:span "Block Reference"] [:kbd "(("]]]
-                     [button [:<> [:> mui-icons/Timer] [:span "Current Time"]]]
-                     [button [:<> [:> mui-icons/DateRange] [:span "Date Picker"]]]
-                     [button [:<> [:> mui-icons/Attachment] [:span "Upload Image or File"]]]
-                     [button [:<> [:> mui-icons/ExposurePlus1] [:span "Word Count"]]]
-                     [button [:<> [:> mui-icons/Today] [:span "Today"]]]]}]}])
-
-(stylefy/class "dropdown" dropdown-style)
-(stylefy/class "menu" menu-style)
-(stylefy/class "menu-item" athens.views.buttons/buttons-style)
-(stylefy/class "menu-separator" menu-separator-style)
-
-(defn block-context-menu-component
-  [style]
-  [dropdown {:style style :content
-             [menu {:content
-                    [:<>
-                     ;;  [menu-heading "Modify Block 'Day of Datomic On-Prem 2016'"]
-                     ;;  [textinput {:icon [:> mui-icons/Face] :placeholder "Type to filter"}]
-                     [button [:<> [:> mui-icons/Link] [:span "Copy Page Reference"]]]
-                     [button [:<> [:> mui-icons/Star] [:span "Add to Shortcuts"]]]
-                     [button [:<> [:> mui-icons/Face] [:span "Add Reaction"] [submenu-indicator]]]
-                     [menu-separator]
-                     [button [:<> [:> mui-icons/LastPage] [:span "Open in Sidebar"] [:kbd "shift-click"]]]
-                     [button [:<> [:> mui-icons/Launch] [:span "Open in New Window"] [:kbd "ctrl-o"]]]
-                     [button [:<> [:> mui-icons/UnfoldMore] [:span "Expand All"]]]
-                     [button [:<> [:> mui-icons/UnfoldLess] [:span "Collapse All"]]]
-                     [button [:<> [:> mui-icons/Slideshow] [:span "View As"] [submenu-indicator]]]
-                     [menu-separator]
-                     [button [:<> [:> mui-icons/FileCopy] [:span "Duplicate and Break Links"]]]
-                     [button [:<> [:> mui-icons/LibraryAdd] [:span "Save as Template"]]]
-                     [button [:<> [:> mui-icons/History] [:span "Browse Versions"]]]
-                     [button [:<> [:> mui-icons/CloudDownload] [:span "Export As"]]]]}]}])
-
-
-(def items
-  {"Amet"   {:count 6 :state :added}
-   "At"     {:count 130 :state :excluded}
-   "Diam"   {:count 6}
-   "Donec"  {:count 6}
-   "Elit"   {:count 30}
-   "Elitudomin mesucen defibocutruon"  {:count 1}
-   "Erat"   {:count 11}
-   "Est"    {:count 2}
-   "Eu"     {:count 2}
-   "Ipsum"  {:count 2 :state :excluded}
-   "Magnis" {:count 10 :state :added}
-   "Metus"  {:count 29}
-   "Mi"     {:count 7 :state :added}
-   "Quam"   {:count 1}
-   "Turpis" {:count 97}
-   "Vitae"  {:count 1}})
-
-
-(defn filter-dropdown-component
-  []
-  [dropdown {:style   {:width "20em" :height "20em"}
-             :content [:<>
-                       [menu-heading "Filters"]
-                       [filters-el "((some-uid))" items]]}])
+;;
+;;
+;;(defn block-context-menu-component
+;;  [style]
+;;  [dropdown {:style style :content
+;;             [menu {:content
+;;                    [:<>
+;;                     ;;  [menu-heading "Modify Block 'Day of Datomic On-Prem 2016'"]
+;;                     ;;  [textinput {:icon [:> mui-icons/Face] :placeholder "Type to filter"}]
+;;                     [button [:<> [:> mui-icons/Link] [:span "Copy Page Reference"]]]
+;;                     [button [:<> [:> mui-icons/Star] [:span "Add to Shortcuts"]]]
+;;                     [button [:<> [:> mui-icons/Face] [:span "Add Reaction"] [submenu-indicator]]]
+;;                     [menu-separator]
+;;                     [button [:<> [:> mui-icons/LastPage] [:span "Open in Sidebar"] [:kbd "shift-click"]]]
+;;                     [button [:<> [:> mui-icons/Launch] [:span "Open in New Window"] [:kbd "ctrl-o"]]]
+;;                     [button [:<> [:> mui-icons/UnfoldMore] [:span "Expand All"]]]
+;;                     [button [:<> [:> mui-icons/UnfoldLess] [:span "Collapse All"]]]
+;;                     [button [:<> [:> mui-icons/Slideshow] [:span "View As"] [submenu-indicator]]]
+;;                     [menu-separator]
+;;                     [button [:<> [:> mui-icons/FileCopy] [:span "Duplicate and Break Links"]]]
+;;                     [button [:<> [:> mui-icons/LibraryAdd] [:span "Save as Template"]]]
+;;                     [button [:<> [:> mui-icons/History] [:span "Browse Versions"]]]
+;;                     [button [:<> [:> mui-icons/CloudDownload] [:span "Export As"]]]]}]}])
+;;
+;;
+;;(def items
+;;  {"Amet"   {:count 6 :state :added}
+;;   "At"     {:count 130 :state :excluded}
+;;   "Diam"   {:count 6}
+;;   "Donec"  {:count 6}
+;;   "Elit"   {:count 30}
+;;   "Elitudomin mesucen defibocutruon"  {:count 1}
+;;   "Erat"   {:count 11}
+;;   "Est"    {:count 2}
+;;   "Eu"     {:count 2}
+;;   "Ipsum"  {:count 2 :state :excluded}
+;;   "Magnis" {:count 10 :state :added}
+;;   "Metus"  {:count 29}
+;;   "Mi"     {:count 7 :state :added}
+;;   "Quam"   {:count 1}
+;;   "Turpis" {:count 97}
+;;   "Vitae"  {:count 1}})
+;;
+;;
+;;(defn filter-dropdown-component
+;;  []
+;;  [dropdown {:style   {:width "20em" :height "20em"}
+;;             :content [:<>
+;;                       [menu-heading "Filters"]
+;;                       [filters-el "((some-uid))" items]]}])

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -50,10 +50,10 @@
                                          :margin-inline-start "0"
                                          :margin-inline-end "0.5rem"}]]]})
 
+
 (def menu-item-style
   (merge {}
          buttons-style))
-
 
 
 (def menu-heading-style

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -8,6 +8,7 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [garden.selectors :as selectors]
+    [re-frame.core :refer [dispatch]]
     [stylefy.core :as stylefy :refer [use-style]]))
 
 
@@ -25,7 +26,7 @@
   {:display "inline-flex"
    :z-index (:zindex-dropdown ZINDICES)
    :padding "0.25rem"
-   :border-radius "cal(0.25rem + 0.25rem)" ;; Button corner radius + container padding makes "concentric" container radius
+   :border-radius "calc(0.25rem + 0.25rem)" ;; Button corner radius + container padding makes "concentric" container radius
    :min-height "2em"
    :min-width "2em"
    :animation "dropdown-appear 0.125s"
@@ -144,12 +145,19 @@
 
 
 (defn page-menu-component
-  [{:keys [style]}]
+  [{:keys [style uid has-shortcut?]}]
   [dropdown {:style (merge {:font-size "14px"} style) :content
              [menu {:content
                     [:<>
-                     ;; TODO: Add to / Remove from Bookmarks, depending on which it is
-                     [menu-item {:label [:<> [:> mui-icons/BookmarkBorder] [:span "Add to Shortcuts"]]}]
+                     (if has-shortcut?
+                       [:button (use-style menu-item-style {:on-click #(dispatch [:page/unmake-shortcut uid])})
+                        [:<>
+                         [:> mui-icons/BookmarkBorder]
+                         [:span "Remove Shortcut"]]]
+                       [:button (use-style menu-item-style {:on-click #(dispatch [:page/make-shortcut uid])})
+                        [:<>
+                         [:> mui-icons/Bookmark]
+                         [:span "Add Shortcut"]]])
                      [menu-separator]
                      [menu-item {:label [:<> [:> mui-icons/Delete] [:span "Delete Page"]]}]]}]}])
 

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -1,15 +1,11 @@
 (ns athens.views.dropdown
   (:require
-    ["@material-ui/icons" :as mui-icons]
     [athens.db]
     [athens.style :refer [color DEPTH-SHADOWS ZINDICES]]
-    [athens.views.buttons :refer [button buttons-style]]
-    [athens.views.filters :refer [filters-el]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [garden.selectors :as selectors]
-    [re-frame.core :refer [dispatch]]
-    [stylefy.core :as stylefy :refer [use-style]]))
+    [stylefy.core :as stylefy]))
 
 
 ;;; Styles
@@ -51,23 +47,18 @@
                                          :margin-inline-end "0.5rem"}]]]})
 
 
-(def menu-item-style
-  (merge {}
-         buttons-style))
-
-
-(def menu-heading-style
-  {:min-height "2rem"
-   :text-align "center"
-   :padding "0.375rem 0.5rem"
-   :display "flex"
-   :align-content "flex-end"
-   :justify-content "center"
-   :align-items "center"
-   :font-size "12px"
-   :max-width "100%"
-   :overflow "hidden"
-   :text-overflow "ellipsis"})
+#_(def menu-heading-style
+    {:min-height "2rem"
+     :text-align "center"
+     :padding "0.375rem 0.5rem"
+     :display "flex"
+     :align-content "flex-end"
+     :justify-content "center"
+     :align-items "center"
+     :font-size "12px"
+     :max-width "100%"
+     :overflow "hidden"
+     :text-overflow "ellipsis"})
 
 
 (def menu-separator-style

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -9,7 +9,7 @@
     [athens.views.blocks :refer [block-el]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]
-    ;;[athens.views.dropdown :refer [page-menu-component]]
+    [athens.views.dropdown :refer [dropdown-style menu-item-style menu-style menu-separator-style]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as string]
@@ -217,34 +217,35 @@
               :class         (when (= editing-uid uid) "is-editing")
               :auto-focus    true
               :on-change     (fn [e] (db-handler (.. e -target -value) uid))}])
-          [:button.button {:class    [(when show "active")]
-                           :on-click (fn [e]
-                                       (if show
-                                         (swap! state assoc :menu/show false)
-                                         (let [rect (.. e -target getBoundingClientRect)]
-                                           (swap! state merge {:menu/show true
-                                                               :menu/x    (.. rect -left)
-                                                               :menu/y    (.. rect -bottom)}))))
-                           :style    page-menu-toggle-style}
+          [button {:class    [(when show "active")]
+                   :on-click (fn [e]
+                               (if show
+                                 (swap! state assoc :menu/show false)
+                                 (let [rect (.. e -target getBoundingClientRect)]
+                                   (swap! state merge {:menu/show true
+                                                       :menu/x    (.. rect -left)
+                                                       :menu/y    (.. rect -bottom)}))))
+                   :style    page-menu-toggle-style}
            [:> mui-icons/ExpandMore]]
 
           (when show
-            [:div.dropdown {:style {:font-size "14px"
-                                    :position "fixed"
-                                    :left (str x "px")
-                                    :top (str y "px")}}
-             [:div.menu
+            [:div (merge (use-style dropdown-style)
+                    {:style {:font-size "14px"
+                             :position "fixed"
+                             :left (str x "px")
+                             :top (str y "px")}})
+             [:div (use-style menu-style)
               (if is-shortcut?
-                [:button.menu-item {:on-click #(dispatch [:page/remove-shortcut uid])}
+                [button {:on-click #(dispatch [:page/remove-shortcut uid])}
                  [:<>
                   [:> mui-icons/BookmarkBorder]
                   [:span "Remove Shortcut"]]]
-                [:button.menu-item {:on-click #(dispatch [:page/add-shortcut uid])}
+                [button {:on-click #(dispatch [:page/add-shortcut uid])}
                  [:<>
                   [:> mui-icons/Bookmark]
                   [:span "Add Shortcut"]]])
-              [:hr.menu-separator]
-              [:button.menu-item {:disabled true}
+              [:hr (use-style menu-separator-style)]
+              [button {:disabled true}
                [:<> [:> mui-icons/Delete] [:span "Delete Page"]]]]])
           (parse-renderer/parse-and-render title uid)]
 

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -13,6 +13,7 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as string]
+    [datascript.core :as d]
     [garden.selectors :as selectors]
     [goog.functions :refer [debounce]]
     [komponentit.autosize :as autosize]
@@ -188,12 +189,18 @@
       (catch js/Object _ false))))
 
 
+
 ;;; Components
 
 
 ;; TODO: where to put page-level link filters?
 (defn node-page-el
-  [{:block/keys [children uid] title :node/title} editing-uid ref-groups timeline-page? show-page-menu? page-menu-position]
+  [{:block/keys [children uid] title :node/title has-shortcut? :page/sidebar}
+   editing-uid
+   ref-groups
+   timeline-page?
+   show-page-menu?
+   page-menu-position]
 
   [:div (use-style page-style)
 
@@ -219,7 +226,11 @@
              :label [:> mui-icons/ExpandMore]
              :style page-menu-toggle-style}]
     (when @show-page-menu?
-      [page-menu-component {:style {:position "fixed" :left (str (:x @page-menu-position) "px") :top (str (:y @page-menu-position) "px")}}])
+      [page-menu-component {:style {:position "fixed"
+                                    :left (str (:x @page-menu-position) "px")
+                                    :top (str (:y @page-menu-position) "px")}
+                            :uid uid
+                            :has-shortcut? has-shortcut?}])
     (parse-renderer/parse-and-render title)]
 
    ;; Children
@@ -270,4 +281,6 @@
       ;; TODO: turn ref-groups into an atom, let users toggle open/close
       (let [ref-groups [["Linked References" (-> title patterns/linked get-data)]
                         ["Unlinked References" (-> title patterns/unlinked get-data)]]]
-        [node-page-el node editing-uid ref-groups timeline-page? show-page-menu? page-menu-position]))))
+        [node-page-el node editing-uid ref-groups timeline-page? show-page-menu?
+        ;;  has-shortcut?
+         page-menu-position]))))

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -193,7 +193,7 @@
 
 ;; TODO: where to put page-level link filters?
 (defn node-page-el
-  [{:block/keys [children uid] title :node/title has-shortcut? :page/sidebar}
+  [{:block/keys [children uid] title :node/title is-shortcut? :page/sidebar}
    editing-uid
    ref-groups
    timeline-page?
@@ -227,7 +227,7 @@
                                     :left (str (:x @page-menu-position) "px")
                                     :top (str (:y @page-menu-position) "px")}
                             :uid uid
-                            :has-shortcut? has-shortcut?}])
+                            :is-shortcut? is-shortcut?}])
     (parse-renderer/parse-and-render title)]
 
    ;; Children
@@ -279,5 +279,5 @@
       (let [ref-groups [["Linked References" (-> title patterns/linked get-data)]
                         ["Unlinked References" (-> title patterns/unlinked get-data)]]]
         [node-page-el node editing-uid ref-groups timeline-page? show-page-menu?
-        ;;  has-shortcut?
+        ;;  is-shortcut?
          page-menu-position]))))

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -9,7 +9,7 @@
     [athens.views.blocks :refer [block-el]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]
-    [athens.views.dropdown :refer [page-menu-component]]
+    ;;[athens.views.dropdown :refer [page-menu-component]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as string]
@@ -193,71 +193,93 @@
 
 ;; TODO: where to put page-level link filters?
 (defn node-page-el
-  [{:block/keys [children uid] title :node/title is-shortcut? :page/sidebar}
-   editing-uid
-   ref-groups
-   timeline-page?
-   show-page-menu?
-   page-menu-position]
+  [_ _ _ _]
+  (let [state (r/atom {:menu/show false
+                       :menu/x nil
+                       :menu/y nil})]
+    (fn [block editing-uid ref-groups timeline-page?]
+      (let [{:block/keys [children uid] title :node/title is-shortcut? :page/sidebar} block
+            {:menu/keys [show x y]} @state]
 
-  [:div (use-style page-style {:class ["node-page"]})
-   ;; TODO: implement timeline
-   ;;(when timeline-page?
-   ;;  [button {:on-click #(dispatch [:jump-to-timeline uid])}
-   ;;              [:<>
-   ;;               [:mui-icons Left]
-   ;;               [:span "Timeline"]]}])
+        [:div (use-style page-style {:class ["node-page"]})
+         ;; TODO: implement timeline
+         ;;(when timeline-page?
+         ;;  [button {:on-click #(dispatch [:jump-to-timeline uid])}
+         ;;              [:<>
+         ;;               [:mui-icons Left]
+         ;;               [:span "Timeline"]]}])
 
-   ;; Header
-   [:h1 (use-style title-style {:data-uid uid :class "page-header"})
-    (when-not timeline-page?
-      [autosize/textarea
-       {:default-value title
-        :class      (when (= editing-uid uid) "is-editing")
-        :auto-focus true
-        :on-change  (fn [e] (db-handler (.. e -target -value) uid))}])
-    [button {:on-click (fn [e]
-                         (doall (swap! show-page-menu? not)
-                                (reset! page-menu-position {:x (.. e -target getBoundingClientRect -left) :y (.. e -target getBoundingClientRect -bottom)})))
-             :active (when @show-page-menu? true)
-             :style page-menu-toggle-style}
-     [:> mui-icons/ExpandMore]]
-    (when @show-page-menu?
-      [page-menu-component {:style {:position "fixed" :left (str (:x @page-menu-position) "px") :top (str (:y @page-menu-position) "px")}}])
-    (parse-renderer/parse-and-render title uid)]
+         ;; Header
+         [:h1 (use-style title-style {:data-uid uid :class "page-header"})
+          (when-not timeline-page?
+            [autosize/textarea
+             {:default-value title
+              :class         (when (= editing-uid uid) "is-editing")
+              :auto-focus    true
+              :on-change     (fn [e] (db-handler (.. e -target -value) uid))}])
+          [:button.button {:class    [(when show "active")]
+                           :on-click (fn [e]
+                                       (if show
+                                         (swap! state assoc :menu/show false)
+                                         (let [rect (.. e -target getBoundingClientRect)]
+                                           (swap! state merge {:menu/show true
+                                                               :menu/x    (.. rect -left)
+                                                               :menu/y    (.. rect -bottom)}))))
+                           :style    page-menu-toggle-style}
+           [:> mui-icons/ExpandMore]]
 
-   ;; Children
-   [:div
-    (for [{:block/keys [uid] :as child} children]
-      ^{:key uid}
-      [block-el child])]
+          (when show
+            [:div.dropdown {:style {:font-size "14px"
+                                    :position "fixed"
+                                    :left (str x "px")
+                                    :top (str y "px")}}
+             [:div.menu
+              (if is-shortcut?
+                [:button.menu-item {:on-click #(dispatch [:page/remove-shortcut uid])}
+                 [:<>
+                  [:> mui-icons/BookmarkBorder]
+                  [:span "Remove Shortcut"]]]
+                [:button.menu-item {:on-click #(dispatch [:page/add-shortcut uid])}
+                 [:<>
+                  [:> mui-icons/Bookmark]
+                  [:span "Add Shortcut"]]])
+              [:hr.menu-separator]
+              [:button.menu-item {:disabled true}
+               [:<> [:> mui-icons/Delete] [:span "Delete Page"]]]]])
+          (parse-renderer/parse-and-render title uid)]
 
-   ;; References
-   (doall
-     (for [[linked-or-unlinked refs] ref-groups]
-       (when (not-empty refs)
-         [:section (use-style references-style {:key linked-or-unlinked})
-          [:h4 (use-style references-heading-style)
-           [(r/adapt-react-class mui-icons/Link)]
-           [:span linked-or-unlinked]
-           [button {:disabled true} [(r/adapt-react-class mui-icons/FilterList)]]]
-          [:div (use-style references-list-style)
-           (doall
-             (for [[group-title group] refs]
-               [:div (use-style references-group-style {:key (str "group-" group-title)})
-                [:h4 (use-style references-group-title-style)
-                 [:a {:on-click #(navigate-uid uid)} group-title]] ;; FIXME: use correct uid
-                (doall
-                  (for [{:block/keys [uid parents] :as block} group]
-                    [:div (use-style references-group-block-style {:key (str "ref-" uid)})
-                ;; TODO: expand parent on click
-                     [block-el block]
-                     (when (> (count parents) 1)
-                       [breadcrumbs-list {:style reference-breadcrumbs-style}
-                        [(r/adapt-react-class mui-icons/LocationOn)]
-                        (doall
-                          (for [{:keys [node/title block/string block/uid]} parents]
-                            [breadcrumb {:key (str "breadcrumb-" uid) :on-click #(navigate-uid uid)} (or title string)]))])]))]))]])))])
+         ;; Children
+         [:div
+          (for [{:block/keys [uid] :as child} children]
+            ^{:key uid}
+            [block-el child])]
+
+         ;; References
+         (doall
+           (for [[linked-or-unlinked refs] ref-groups]
+             (when (not-empty refs)
+               [:section (use-style references-style {:key linked-or-unlinked})
+                [:h4 (use-style references-heading-style)
+                 [(r/adapt-react-class mui-icons/Link)]
+                 [:span linked-or-unlinked]
+                 [button {:disabled true} [(r/adapt-react-class mui-icons/FilterList)]]]
+                [:div (use-style references-list-style)
+                 (doall
+                   (for [[group-title group] refs]
+                     [:div (use-style references-group-style {:key (str "group-" group-title)})
+                      [:h4 (use-style references-group-title-style)
+                       [:a {:on-click #(navigate-uid uid)} group-title]] ;; FIXME: use correct uid
+                      (doall
+                        (for [{:block/keys [uid parents] :as block} group]
+                          [:div (use-style references-group-block-style {:key (str "ref-" uid)})
+                           ;; TODO: expand parent on click
+                           [block-el block]
+                           (when (> (count parents) 1)
+                             [breadcrumbs-list {:style reference-breadcrumbs-style}
+                              [(r/adapt-react-class mui-icons/LocationOn)]
+                              (doall
+                                (for [{:keys [node/title block/string block/uid]} parents]
+                                  [breadcrumb {:key (str "breadcrumb-" uid) :on-click #(navigate-uid uid)} (or title string)]))])]))]))]])))]))))
 
 
 (defn node-page-component
@@ -266,13 +288,9 @@
   [ident]
   (let [{:keys [block/uid node/title] :as node} (db/get-node-document ident)
         editing-uid @(subscribe [:editing/uid])
-        timeline-page? (is-timeline-page uid)
-        show-page-menu? (r/atom false)
-        page-menu-position (r/atom {:x 0 :y 0})]
+        timeline-page? (is-timeline-page uid)]
     (when-not (string/blank? title)
-      ;; TODO: turn ref-groups into an atom, let users toggle open/close
+      ;; TODO: let users toggle open/close references
       (let [ref-groups [["Linked References" (-> title patterns/linked get-data)]
                         ["Unlinked References" (-> title patterns/unlinked get-data)]]]
-        [node-page-el node editing-uid ref-groups timeline-page? show-page-menu?
-        ;;  is-shortcut?
-         page-menu-position]))))
+        [node-page-el node editing-uid ref-groups timeline-page?]))))

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -13,7 +13,6 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as string]
-    [datascript.core :as d]
     [garden.selectors :as selectors]
     [goog.functions :refer [debounce]]
     [komponentit.autosize :as autosize]
@@ -187,7 +186,6 @@
       (let [[m d y] (string/split uid "-")]
         (t/date (string/join "-" [y m d])))
       (catch js/Object _ false))))
-
 
 
 ;;; Components

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -9,7 +9,7 @@
     [athens.views.blocks :refer [block-el]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]
-    [athens.views.dropdown :refer [dropdown-style menu-item-style menu-style menu-separator-style]]
+    [athens.views.dropdown :refer [dropdown-style menu-style menu-separator-style]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as string]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -230,10 +230,10 @@
 
           (when show
             [:div (merge (use-style dropdown-style)
-                    {:style {:font-size "14px"
-                             :position "fixed"
-                             :left (str x "px")
-                             :top (str y "px")}})
+                         {:style {:font-size "14px"
+                                  :position "fixed"
+                                  :left (str x "px")
+                                  :top (str y "px")}})
              [:div (use-style menu-style)
               (if is-shortcut?
                 [button {:on-click #(dispatch [:page/remove-shortcut uid])}


### PR DESCRIPTION
Branches off of @shanberg 's #272, so also implements shortcut add/remove
