### PR TITLE
fix(pages): various improvements to pages

### DIFF
--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -86,34 +86,34 @@
   "Transforms Instaparse output to Hiccup."
   [tree uid]
   (insta/transform
-   {:block         (fn [& contents]
-                     (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
-     ;; for more information regarding how custom components are parsed, see `doc/components.md`
-    :component     (fn [& contents]
-                     (components/render-component (first contents) uid))
-    :page-link     (fn [& title] (render-page-link title))
-    :block-ref     (fn [uid]
-                     (let [block (pull db/dsdb '[*] [:block/uid uid])]
-                       [:span (use-style block-ref {:class "block-ref"})
-                        [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block) uid)]]))
-    :hashtag       (fn [tag-name]
-                     (let [node (pull db/dsdb '[*] [:node/title tag-name])]
-                       [:span (use-style hashtag {:class    "hashtag"
-                                                  :on-click #(navigate-uid (:block/uid @node))})
-                        [:span {:class "formatting"} "#"]
-                        [:span {:class "contents"} tag-name]]))
-    :url-image     (fn [{url :url alt :alt}]
-                     [:img (use-style image {:class "url-image"
-                                             :alt   alt
-                                             :src   url})])
-    :url-link      (fn [{url :url} text]
-                     [:a (use-style url-link {:class "url-link"
-                                              :href  url})
-                      text])
-    :bold          (fn [text]
-                     [:strong {:class "contents bold"} text])
-    :pre-formatted (fn [text]
-                     [:code text])}
+    {:block         (fn [& contents]
+                      (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
+      ;; for more information regarding how custom components are parsed, see `doc/components.md`
+     :component     (fn [& contents]
+                      (components/render-component (first contents) uid))
+     :page-link     (fn [& title] (render-page-link title))
+     :block-ref     (fn [uid]
+                      (let [block (pull db/dsdb '[*] [:block/uid uid])]
+                        [:span (use-style block-ref {:class "block-ref"})
+                         [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block) uid)]]))
+     :hashtag       (fn [tag-name]
+                      (let [node (pull db/dsdb '[*] [:node/title tag-name])]
+                        [:span (use-style hashtag {:class    "hashtag"
+                                                   :on-click #(navigate-uid (:block/uid @node))})
+                         [:span {:class "formatting"} "#"]
+                         [:span {:class "contents"} tag-name]]))
+     :url-image     (fn [{url :url alt :alt}]
+                      [:img (use-style image {:class "url-image"
+                                              :alt   alt
+                                              :src   url})])
+     :url-link      (fn [{url :url} text]
+                      [:a (use-style url-link {:class "url-link"
+                                               :href  url})
+                       text])
+     :bold          (fn [text]
+                      [:strong {:class "contents bold"} text])
+     :pre-formatted (fn [text]
+                      [:code text])}
    tree))
 
 

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -57,7 +57,7 @@
                                          :cursor "alias"}]]})
 
 ;;; Helper functions for recursive link rendering
-(defn get-block-node-from-string
+(defn pull-node-from-string
   "Gets a block's node from the display string name (or partially parsed string tree)"
   [string]
   (pull db/dsdb '[*] [:node/title (str "" (apply + (map (fn [el]
@@ -71,7 +71,7 @@
   [title]
   ;; This method feels a bit hacky: it extracts the DOM tree of its children components and re-wrap the content in double parentheses. Should we do something about it?
   ;; TODO: touch from inner content should navigate to the inner (children) page, but in this implementation doesn't work
-  (let [node (get-block-node-from-string title)]
+  (let [node (pull-node-from-string title)]
     [:span (use-style page-link {:class "page-link"})
      [:span {:class "formatting"} "[["]
      [:span {:on-click (fn [e] (.. e stopPropagation) (navigate-uid (:block/uid @node) e))} (concat title)]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
-    [athens.parse-renderer :as parse-renderer :refer [get-block-node-from-string]]
+    [athens.parse-renderer :as parse-renderer :refer [pull-node-from-string]]
     [athens.patterns :as patterns]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color]]
@@ -204,7 +204,7 @@
 
 ;;; Components
 
-(defn no-blocks-el
+(defn placeholder-block-el
   [parent-uid]
   [:div {:class "block-container"}
    [:div {:style {:display "flex"}}
@@ -271,8 +271,8 @@
           (parse-renderer/parse-and-render title uid)]
 
          ;; Children
-         (if (= (count children) 0)
-           [no-blocks-el uid]
+         (if (empty? children)
+           [placeholder-block-el uid]
            [:div
             (for [{:block/keys [uid] :as child} children]
               ^{:key uid}
@@ -293,7 +293,7 @@
                    (for [[group-title group] refs]
                      [:div (use-style references-group-style {:key (str "group-" group-title)})
                       [:h4 (use-style references-group-title-style)
-                       [:a {:on-click #(navigate-uid (:block/uid @(get-block-node-from-string group-title)))} group-title]]
+                       [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
                       (doall
                         (for [{:block/keys [uid parents] :as block} group]
                           [:div (use-style references-group-block-style {:key (str "ref-" uid)})

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -2,11 +2,12 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
-    [athens.parse-renderer :as parse-renderer]
+    [athens.parse-renderer :as parse-renderer :refer [get-block-node-from-string]]
     [athens.patterns :as patterns]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color]]
-    [athens.views.blocks :refer [block-el]]
+    [athens.util :refer [now-ts gen-block-uid]]
+    [athens.views.blocks :refer [block-el bullet-style]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]
     [athens.views.dropdown :refer [dropdown-style menu-style menu-separator-style]]
@@ -188,7 +189,27 @@
       (catch js/Object _ false))))
 
 
+(defn handle-new-first-child-block-click
+  [parent-uid]
+  (let [new-uid   (gen-block-uid)
+        now       (now-ts)]
+    (dispatch [:transact [{:block/uid       parent-uid
+                           :edit/time       now
+                           :block/children  [{:block/order  0
+                                              :block/uid    new-uid
+                                              :block/open   true
+                                              :block/string ""}]}]])
+    (dispatch [:editing/uid new-uid])))
+
+
 ;;; Components
+
+(defn no-blocks-el
+  [parent-uid]
+  [:div {:class "block-container"}
+   [:div {:style {:display "flex"}}
+    [:span (use-style bullet-style)]
+    [:span {:on-click #(handle-new-first-child-block-click parent-uid)} "Click here to add content..."]]])
 
 
 ;; TODO: where to put page-level link filters?
@@ -250,10 +271,13 @@
           (parse-renderer/parse-and-render title uid)]
 
          ;; Children
-         [:div
-          (for [{:block/keys [uid] :as child} children]
-            ^{:key uid}
-            [block-el child])]
+         (if (= (count children) 0)
+           [no-blocks-el uid]
+           [:div
+            (for [{:block/keys [uid] :as child} children]
+              ^{:key uid}
+              [block-el child])])
+
 
          ;; References
          (doall
@@ -269,7 +293,7 @@
                    (for [[group-title group] refs]
                      [:div (use-style references-group-style {:key (str "group-" group-title)})
                       [:h4 (use-style references-group-title-style)
-                       [:a {:on-click #(navigate-uid uid)} group-title]] ;; FIXME: use correct uid
+                       [:a {:on-click #(navigate-uid (:block/uid @(get-block-node-from-string group-title)))} group-title]]
                       (doall
                         (for [{:block/keys [uid parents] :as block} group]
                           [:div (use-style references-group-block-style {:key (str "ref-" uid)})


### PR DESCRIPTION
## Fixes
* Empty pages auto-created from links can now be edited
* Clicking on titles for linked references can now navigate to the page
* Clikcing on page links will not drop to editing view now

_Note: upstream `devcard/dropdown` is broken, so currently building would fail, but the changes work on my local machine (after deleting `devcard/dropdown`). Sorry for no demo :)_