### PR TITLE
fix(athena): close the athena menu when navigating to a page via click

### DIFF
--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -324,6 +324,7 @@
                                                                                    :block/uid    uid
                                                                                    :block/string string
                                                                                    :query        query}]
+                                                                (dispatch [:athena/toggle])
                                                                 (dispatch [:athena/update-recent-items selected-page])
                                                                 (navigate-uid uid)))
                                                   :class    (when (= i index) "selected")})


### PR DESCRIPTION
This closes #299 by dispatching the `:athena/toggle` event when the user clicks on a search result.