### PR TITLE
fix(athena): escape special chars in search input and title

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -1,5 +1,6 @@
 (ns athens.db
   (:require
+    [athens.util :refer [escape-str]]
     [clojure.edn :as edn]
     [datascript.core :as d]
     [posh.reagent :refer [posh! pull]]))
@@ -265,7 +266,7 @@
 (defn re-case-insensitive
   "More options here https://clojuredocs.org/clojure.core/re-pattern"
   [query]
-  (re-pattern (str "(?i)" query)))
+  (re-pattern (str "(?i)" (escape-str query))))
 
 
 (defn search-exact-node-title

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -92,3 +92,16 @@
       (string/replace x #"PM" "pm"))))
 
 
+;; -- Regex -----------------------------------------------------------
+
+;; https://stackoverflow.com/a/11672480
+(def regex-esc-char-map
+  (let [esc-chars "()*&^%$#![]"]
+    (zipmap esc-chars
+            (map #(str "\\" %) esc-chars))))
+
+
+(defn escape-str
+  "Take a string and escape all regex special characters in it"
+  [str]
+  (string/escape str regex-esc-char-map))

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -39,7 +39,7 @@
    :transform     "translate(-50%, -50%)"
    ;; Styling for the states of the custom search-cancel button, which depend on the input contents
    ::stylefy/manual [[(selectors/+ :input :button) {:opacity 0}]
-   ;; Using ':valid' here as a proxy for "has contents", i.e. "button should appear"
+                     ;; Using ':valid' here as a proxy for "has contents", i.e. "button should appear"
                      [(selectors/+ :input:valid :button) {:opacity 1}]]})
 
 

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -6,7 +6,7 @@
     [athens.patterns :as patterns]
     [athens.router :refer [navigate-uid navigate]]
     [athens.style :refer [color]]
-    [athens.util :refer [now-ts gen-block-uid]]
+    [athens.util :refer [now-ts gen-block-uid escape-str]]
     [athens.views.blocks :refer [block-el bullet-style]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]
@@ -318,6 +318,6 @@
         timeline-page? (is-timeline-page uid)]
     (when-not (string/blank? title)
       ;; TODO: let users toggle open/close references
-      (let [ref-groups [["Linked References" (-> title patterns/linked get-data)]
-                        ["Unlinked References" (-> title patterns/unlinked get-data)]]]
+      (let [ref-groups [["Linked References" (-> (escape-str title) patterns/linked get-data)]
+                        ["Unlinked References" (-> (escape-str title) patterns/unlinked get-data)]]]
         [node-page-el node editing-uid ref-groups timeline-page?]))))


### PR DESCRIPTION
This PR closes #301 

* create util function for escaping all regexp special characters in a given string

* escape the title in Linked and Unlinked references.

* escape the query in re-case-insensitive

Co-authored-by: nthd3gr33