### PR TITLE
feat(slash commands): scroll slash commands with arrow keys 

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -107,7 +107,7 @@
                                                   container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
                                                   next-el (nth (array-seq (.. container-el -children)) cur-index)]
                                               (when (is-beyond-rect? next-el container-el)
-                                                (.. next-el (scrollIntoView (not= cur-index (dec (count slash-options))) {:behavior "auto"})))))
+                                                (.. next-el (scrollIntoView false {:behavior "auto"})))))
 
                         (= :down direction) (do
                                               (.. e preventDefault)
@@ -116,7 +116,7 @@
                                                     container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
                                                     next-el (nth (array-seq (.. container-el -children)) cur-index)]
                                                 (when (is-beyond-rect? next-el container-el)
-                                                  (.. next-el (scrollIntoView (zero? cur-index) {:behavior "auto"}))))))
+                                                  (.. next-el (scrollIntoView false {:behavior "auto"}))))))
 
       (or (= type :page) (= type :block))
       (cond

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -106,9 +106,8 @@
                                             (let [cur-index (:search/index @state)
                                                   container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
                                                   next-el (nth (array-seq (.. container-el -children)) cur-index)]
-                                              (when (is-beyond-rect? next-el container-el)
+                                              (when (is-beyond-rect? next-el (.. container-el -parentNode))
                                                 (.. next-el (scrollIntoView false {:behavior "auto"})))))
-
                         (= :down direction) (do
                                               (.. e preventDefault)
                                               (swap! state update :search/index #(if (= % (dec (count slash-options))) 0 (inc %)))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
-    [athens.util :refer [scroll-if-needed get-day]]
+    [athens.util :refer [scroll-if-needed get-day is-beyond-rect?]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [goog.dom.selection :refer [setStart setEnd getText setCursorPosition getEndPoints]]
@@ -12,6 +12,7 @@
     (goog.events
       KeyCodes)))
 
+(declare slash-options)
 
 (defn modifier-keys
   [e]
@@ -101,10 +102,21 @@
       (= type :slash) (cond
                         (= :up direction) (do
                                             (.. e preventDefault)
-                                            (swap! state update :search/index dec))
+                                            (swap! state update :search/index #(dec (if (zero? %) (count slash-options) %)))
+                                            (let [cur-index (:search/index @state)
+                                                  container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
+                                                  next-el (nth (array-seq (.. container-el -children)) cur-index)]
+                                              (when (is-beyond-rect? next-el container-el)
+                                                (.. next-el (scrollIntoView (not= cur-index (dec (count slash-options))) {:behavior "auto"})))))
+
                         (= :down direction) (do
                                               (.. e preventDefault)
-                                              (swap! state update :search/index inc)))
+                                              (swap! state update :search/index #(if (= % (dec (count slash-options))) 0 (inc %)))
+                                              (let [cur-index (:search/index @state)
+                                                    container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
+                                                    next-el (nth (array-seq (.. container-el -children)) cur-index)]
+                                                (when (is-beyond-rect? next-el container-el)
+                                                  (.. next-el (scrollIntoView (zero? cur-index) {:behavior "auto"}))))))
 
       (or (= type :page) (= type :block))
       (cond

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -104,7 +104,7 @@
                                             (.. e preventDefault)
                                             (swap! state update :search/index #(dec (if (zero? %) (count slash-options) %)))
                                             (let [cur-index (:search/index @state)
-                                                  container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
+                                                  container-el (. js/document getElementById "slash-menu-container")
                                                   next-el (nth (array-seq (.. container-el -children)) cur-index)]
                                               (when (is-beyond-rect? next-el (.. container-el -parentNode))
                                                 (.. next-el (scrollIntoView false {:behavior "auto"})))))
@@ -112,7 +112,7 @@
                                               (.. e preventDefault)
                                               (swap! state update :search/index #(if (= % (dec (count slash-options))) 0 (inc %)))
                                               (let [cur-index (:search/index @state)
-                                                    container-el (.. e -target -parentNode -parentNode -nextSibling -firstChild)
+                                                    container-el (. js/document getElementById "slash-menu-container")
                                                     next-el (nth (array-seq (.. container-el -children)) cur-index)]
                                                 (when (is-beyond-rect? next-el container-el)
                                                   (.. next-el (scrollIntoView false {:behavior "auto"}))))))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -12,7 +12,9 @@
     (goog.events
       KeyCodes)))
 
+
 (declare slash-options)
+
 
 (defn modifier-keys
   [e]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -327,7 +327,7 @@
   [state]
   (let [{index :search/index} @state]
     [:div (merge (use-style dropdown-style) {:style {:position "absolute" :top "100%" :left "-0.125em"}})
-     [:div (merge (use-style menu-style) {:style {:max-height "8em"}})
+     [:div#slash-menu-container (merge (use-style menu-style) {:style {:max-height "8em"}})
       (for [[i [icon text _expansion kbd]] (map-indexed list athens.keybindings/slash-options)]
         [button {:active   (= i index)
                  :key      text


### PR DESCRIPTION
This PR closes #298 

The slash commands list can now scroll through the search results with arrow keys. The implementation also cycles through the search result list.

https://www.loom.com/share/db88315bda8d4b78a90fa3315cd94888