### PR TITLE
fix(devcards): broken devcards deploy

### DIFF
--- a/src/cljs/athens/devcards/dropdown.cljs
+++ b/src/cljs/athens/devcards/dropdown.cljs
@@ -1,6 +1,6 @@
 (ns athens.devcards.dropdown
   (:require
-    [athens.views.dropdown :refer [slash-menu-component block-context-menu-component filter-dropdown-component]]
+    [athens.views.dropdown :refer [block-context-menu-component filter-dropdown-component]]
     [devcards.core :refer-macros [defcard-rg]]))
 
 

--- a/src/cljs/athens/devcards/dropdown.cljs
+++ b/src/cljs/athens/devcards/dropdown.cljs
@@ -1,16 +1,18 @@
-(ns athens.devcards.dropdown
-  (:require
-    [athens.views.dropdown :refer [block-context-menu-component filter-dropdown-component]]
-    [devcards.core :refer-macros [defcard-rg]]))
+(ns athens.devcards.dropdown)
+
+;; (ns athens.devcards.dropdown
+;;   (:require
+;;    [athens.views.dropdown :refer [block-context-menu-component filter-dropdown-component]]
+;;    [devcards.core :refer-macros [defcard-rg]]))
 
 
-(defcard-rg Slash-Menu
-  [slash-menu-component])
+;; (defcard-rg Slash-Menu
+;;   [slash-menu-component])
 
 
-(defcard-rg Block-Context-Menu
-  [block-context-menu-component])
+;; (defcard-rg Block-Context-Menu
+;;   [block-context-menu-component])
 
 
-(defcard-rg Filter-Dropdown
-  [filter-dropdown-component])
+;; (defcard-rg Filter-Dropdown
+;;   [filter-dropdown-component])


### PR DESCRIPTION
`devcards/dropdown.cljs` was referring to components in `view/dropdown.cljs` that either don't exist anymore or have been commented out. This led to broken deploys at the `Compile App and Devcards` step.

This PR fixes the broken deploy by commenting out the offending functions in `devcards/dropdown.cljs`.