### PR TITLE
fix: re-positioned page reference helper functions to a more logical place

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -1,9 +1,10 @@
 (ns athens.db
   (:require
+    [athens.patterns :as patterns]
     [athens.util :refer [escape-str]]
     [clojure.edn :as edn]
     [datascript.core :as d]
-    [posh.reagent :refer [posh! pull]]))
+    [posh.reagent :refer [posh! pull q]]))
 
 
 ;; -- Example Roam DBs ---------------------------------------------------
@@ -426,3 +427,71 @@
                                       (conj db-after)
                                       (trim-head history-limit))))))))
 
+;; -- Linked & Unlinked References ----------
+
+(defn get-ref-ids
+  [pattern]
+  @(q '[:find [?e ...]
+        :in $ ?regex
+        :where
+        [?e :block/string ?s]
+        [(re-find ?regex ?s)]]
+      dsdb
+      pattern))
+
+
+(defn merge-parents-and-block
+  [ref-ids]
+  (let [parents (reduce-kv (fn [m _ v] (assoc m v (get-parents-recursively v)))
+                           {}
+                           ref-ids)
+        blocks (map (fn [id] (get-block-document id)) ref-ids)]
+    (mapv
+      (fn [block]
+        (merge block {:block/parents (get parents (:db/id block))}))
+      blocks)))
+
+
+(defn group-by-parent
+  [blocks]
+  (group-by (fn [x]
+              (-> x
+                  :block/parents
+                  first
+                  :node/title))
+            blocks))
+
+
+(defn get-data
+  [pattern]
+  (-> pattern get-ref-ids merge-parents-and-block group-by-parent seq))
+
+
+(defn get-data-by-block
+  [pattern]
+  (-> pattern get-ref-ids merge-parents-and-block seq))
+
+
+(defn get-linked-references
+  [title]
+  (-> title patterns/linked get-data))
+
+
+(defn get-linked-references-by-block
+  [title]
+  (-> title patterns/linked get-data-by-block))
+
+
+(defn get-unlinked-references
+  [title]
+  (-> title patterns/unlinked get-data))
+
+
+(defn count-linked-references-excl-uid
+  [title uid]
+  (reduce (fn [current-count ref]
+            (if (= (:block/uid ref) uid)
+              current-count
+              (inc current-count)))
+          0
+          (get-linked-references-by-block title)))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -1,9 +1,7 @@
 (ns athens.util
   (:require
-    [athens.db :as db]
-    [athens.patterns :as patterns]
     [clojure.string :as string]
-    [posh.reagent :refer [#_pull q]]
+    [posh.reagent :refer [#_pull]]
     [tick.alpha.api :as t]
     [tick.locale-en-us]))
 
@@ -94,75 +92,6 @@
       (string/replace x #"AM" "am")
       (string/replace x #"PM" "pm"))))
 
-
-;; -- Linked & Unlinked References ----------
-
-(defn get-ref-ids
-  [pattern]
-  @(q '[:find [?e ...]
-        :in $ ?regex
-        :where
-        [?e :block/string ?s]
-        [(re-find ?regex ?s)]]
-      db/dsdb
-      pattern))
-
-
-(defn merge-parents-and-block
-  [ref-ids]
-  (let [parents (reduce-kv (fn [m _ v] (assoc m v (db/get-parents-recursively v)))
-                           {}
-                           ref-ids)
-        blocks (map (fn [id] (db/get-block-document id)) ref-ids)]
-    (mapv
-      (fn [block]
-        (merge block {:block/parents (get parents (:db/id block))}))
-      blocks)))
-
-
-(defn group-by-parent
-  [blocks]
-  (group-by (fn [x]
-              (-> x
-                  :block/parents
-                  first
-                  :node/title))
-            blocks))
-
-
-(defn get-data
-  [pattern]
-  (-> pattern get-ref-ids merge-parents-and-block group-by-parent seq))
-
-
-(defn get-data-by-block
-  [pattern]
-  (-> pattern get-ref-ids merge-parents-and-block seq))
-
-
-(defn get-linked-references
-  [title]
-  (-> title patterns/linked get-data))
-
-
-(defn get-linked-references-by-block
-  [title]
-  (-> title patterns/linked get-data-by-block))
-
-
-(defn get-unlinked-references
-  [title]
-  (-> title patterns/unlinked get-data))
-
-
-(defn count-linked-references-excl-uid
-  [title uid]
-  (reduce (fn [current-count ref]
-            (if (= (:block/uid ref) uid)
-              current-count
-              (inc current-count)))
-          0
-          (get-linked-references-by-block title)))
 
 ;; -- Regex -----------------------------------------------------------
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -1,13 +1,13 @@
 (ns athens.views.blocks
   (:require
     ["@material-ui/icons" :as mui-icons]
-    [athens.db :as db]
+    [athens.db :as db :refer [count-linked-references-excl-uid]]
     [athens.keybindings :refer [block-key-down]]
     [athens.listeners :refer [multi-block-select-over multi-block-select-up]]
     [athens.parse-renderer :refer [parse-and-render pull-node-from-string]]
     [athens.parser :as parser]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
-    [athens.util :refer [now-ts gen-block-uid mouse-offset vertical-center date-string count-linked-references-excl-uid]]
+    [athens.util :refer [now-ts gen-block-uid mouse-offset vertical-center date-string]]
     [athens.views.buttons :refer [button]]
     [athens.views.dropdown :refer [menu-style dropdown-style]]
     [cljsjs.react]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -1,11 +1,11 @@
 (ns athens.views.node-page
   (:require
     ["@material-ui/icons" :as mui-icons]
-    [athens.db :as db]
+    [athens.db :as db :refer [get-linked-references get-unlinked-references]]
     [athens.parse-renderer :as parse-renderer :refer [pull-node-from-string]]
     [athens.router :refer [navigate-uid navigate]]
     [athens.style :refer [color]]
-    [athens.util :refer [now-ts gen-block-uid get-linked-references get-unlinked-references escape-str]]
+    [athens.util :refer [now-ts gen-block-uid escape-str]]
     [athens.views.blocks :refer [block-el bullet-style]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]


### PR DESCRIPTION
Reference: <https://github.com/athensresearch/athens/pull/297#discussion_r461228254>

I was hesitate to move helper functions to `db` (temporarily) than `util` because I didn't want the `db` file to get too large and unmaintainable, but it turned out that `db` is a more logical place in terms of common sense and namespace references - because `db` imports `util`, putting the helper functions in `util` results in circular references.

I'll keep in mind to split it out in the future when more counting, query, and graph features are implemented, and sorry @tangjeff0 for this inconvenience.