### PR TITLE
Inline search fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # Emacs files
 .#*
+.calva

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -501,7 +501,12 @@
 ;; Block state atom helpers
 
 (defn update-query
-  [state new-query query-fn]
-  (let [results (query-fn new-query)]
+  [state head key type]
+  (let [link-start (count (re-find #".*\[\[" head))
+        new-query (str (subs head link-start) key)
+        query-fn (cond
+                   (= type :block) search-in-block-content
+                   (= type :page) search-in-node-title)
+        results (query-fn new-query)]
     (swap! state assoc :search/query new-query)
     (swap! state assoc :search/results results)))

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -501,7 +501,8 @@
 ;; Block state atom helpers
 
 (defn update-query
-  [state head key type]
+  ([state head type] (update-query state head "" type))
+  ([state head key type]
   (let [query-fn (cond
                    (= type :block) search-in-block-content
                    (= type :page)  search-in-node-title)
@@ -511,4 +512,4 @@
         new-query (str (subs head link-start) key)
         results (query-fn new-query)]
     (swap! state assoc :search/query new-query)
-    (swap! state assoc :search/results results)))
+    (swap! state assoc :search/results results))))

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -502,11 +502,13 @@
 
 (defn update-query
   [state head key type]
-  (let [link-start (count (re-find #".*\[\[" head))
-        new-query (str (subs head link-start) key)
-        query-fn (cond
+  (let [query-fn (cond
                    (= type :block) search-in-block-content
-                   (= type :page) search-in-node-title)
+                   (= type :page)  search-in-node-title)
+        link-start (cond
+                     (= type :block) (count (re-find #".*\(\(" head))
+                     (= type :page)  (count (re-find #".*\[\[" head)))
+        new-query (str (subs head link-start) key)
         results (query-fn new-query)]
     (swap! state assoc :search/query new-query)
     (swap! state assoc :search/results results)))

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -503,13 +503,13 @@
 (defn update-query
   ([state head type] (update-query state head "" type))
   ([state head key type]
-  (let [query-fn (cond
-                   (= type :block) search-in-block-content
-                   (= type :page)  search-in-node-title)
-        link-start (cond
-                     (= type :block) (count (re-find #".*\(\(" head))
-                     (= type :page)  (count (re-find #".*\[\[" head)))
-        new-query (str (subs head link-start) key)
-        results (query-fn new-query)]
-    (swap! state assoc :search/query new-query)
-    (swap! state assoc :search/results results))))
+   (let [query-fn (cond
+                    (= type :block) search-in-block-content
+                    (= type :page)  search-in-node-title)
+         link-start (cond
+                      (= type :block) (count (re-find #".*\(\(" head))
+                      (= type :page)  (count (re-find #".*\[\[" head)))
+         new-query (str (subs head link-start) key)
+         results (query-fn new-query)]
+     (swap! state assoc :search/query new-query)
+     (swap! state assoc :search/results results))))

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -496,20 +496,3 @@
   (->> (get-linked-references-by-block title)
        (remove #(= (:block/uid %) uid))
        count))
-
-
-;; Block state atom helpers
-
-(defn update-query
-  ([state head type] (update-query state head "" type))
-  ([state head key type]
-   (let [query-fn (cond
-                    (= type :block) search-in-block-content
-                    (= type :page)  search-in-node-title)
-         link-start (cond
-                      (= type :block) (count (re-find #".*\(\(" head))
-                      (= type :page)  (count (re-find #".*\[\[" head)))
-         new-query (str (subs head link-start) key)
-         results (query-fn new-query)]
-     (swap! state assoc :search/query new-query)
-     (swap! state assoc :search/results results))))

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -496,3 +496,12 @@
   (->> (get-linked-references-by-block title)
        (remove #(= (:block/uid %) uid))
        count))
+
+
+;; Block state atom helpers
+
+(defn update-query
+  [state new-query query-fn]
+  (let [results (query-fn new-query)]
+    (swap! state assoc :search/query new-query)
+    (swap! state assoc :search/results results)))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -332,7 +332,6 @@
 ;; with keybindings
 (defn update-query
   [state new-query query-fun]
-  (prn new-query)
   (let [results (query-fun new-query)]
     (swap! state assoc :search/query new-query)
     (swap! state assoc :search/results results)))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -328,15 +328,6 @@
     ;;(= key-code KeyCodes.CLOSE_SQUARE_BRACKET)
 
 
-;; This should probably reside in another file as it has nothing to do
-;; with keybindings
-(defn update-query
-  [state new-query query-fun]
-  (let [results (query-fun new-query)]
-    (swap! state assoc :search/query new-query)
-    (swap! state assoc :search/results results)))
-
-
 (defn handle-backspace
   [e uid state]
   (let [{:keys [start end value head tail target meta]} (destruct-event e)
@@ -368,14 +359,14 @@
       :else (let [head    (subs value 0 (dec start))
                   new-str (str head tail)
                   {:search/keys [query type]} @state
-                  query-fun (cond
-                              (= type :page) db/search-in-node-title
-                              (= type :block) db/search-in-block-content)]
+                  query-fn (cond
+                             (= type :page) db/search-in-node-title
+                             (= type :block) db/search-in-block-content)]
               (when (= "/" (last value))
                 (swap! state merge {:search/type nil
                                     :search/query nil}))
               (when query
-                (update-query state (subs query 0 (dec (count query))) query-fun))
+                (db/update-query state (subs query 0 (dec (count query))) query-fn))
               (swap! state assoc :atom-string new-str)))))
 
 
@@ -400,10 +391,10 @@
       (= type :slash) (swap! state assoc :search/query new-str)
 
       ;; when in-line search dropdown is open
-      (= type :block) (update-query state new-query db/search-in-block-content)
+      (= type :block) (db/update-query state new-query db/search-in-block-content)
 
-    ;; when in-line search dropdown is open
-      (= type :page) (update-query state new-query db/search-in-node-title))
+      ;; when in-line search dropdown is open
+      (= type :page) (db/update-query state new-query db/search-in-node-title))
 
     (swap! state merge {:atom-string new-str})))
 

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -220,8 +220,8 @@
                    (= type :block) "$1(("
                    (= type :page)  "$1[[")
         closing-str (cond
-                   (= type :block) "))"
-                   (= type :page)  "]]")
+                      (= type :block) "))"
+                      (= type :page)  "]]")
         new-str (clojure.string/replace-first head head-pattern (str new-head completed-str closing-str))
         [_ closing-delimiter after-closing-str] (re-matches tail-pattern tail)]
     (swap! state merge {:atom-string (str new-str after-closing-str)

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -367,12 +367,15 @@
       ;; default backspace: delete a character
       :else (let [head    (subs value 0 (dec start))
                   new-str (str head tail)
-                  {:search/keys [query]} @state]
+                  {:search/keys [query type]} @state
+                  query-fun (cond
+                              (= type :page) db/search-in-node-title
+                              (= type :block) db/search-in-block-content)]
               (when (= "/" (last value))
                 (swap! state merge {:search/type nil
                                     :search/query nil}))
               (when query
-                (swap! state assoc :search/query (subs query 0 (dec (count query)))))
+                (update-query state (subs query 0 (dec (count query))) query-fun))
               (swap! state assoc :atom-string new-str)))))
 
 

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -5,6 +5,7 @@
     [athens.util :refer [scroll-if-needed get-day scroll-into-view]]
     [cljsjs.react]
     [cljsjs.react.dom]
+    [clojure.string :refer [replace-first]]
     [goog.dom :refer [getElement]]
     [goog.dom.selection :refer [setStart setEnd getText setCursorPosition getEndPoints]]
     [goog.events.KeyCodes :refer [isCharacterKey]]
@@ -235,7 +236,7 @@
         closing-str (cond
                       (= type :block) "))"
                       (= type :page)  "]]")
-        new-str (clojure.string/replace-first head head-pattern (str new-head completed-str closing-str))
+        new-str (replace-first head head-pattern (str new-head completed-str closing-str))
         [_ closing-delimiter after-closing-str] (re-matches tail-pattern tail)]
     (swap! state merge {:atom-string (str new-str after-closing-str)
                         :search/query nil

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -208,27 +208,28 @@
 
 (defn handle-enter
   [e uid state]
-  (let [{:keys [shift meta start head tail value]} (destruct-event e)
+  (let [{:keys [shift meta start head tail value target]} (destruct-event e)
         {:search/keys [query index results type]} @state]
     (.. e preventDefault)
     (cond
       (= type :slash) (select-slash-cmd index state)
 
-      ;; TODO: move caret beyond ]]
       ;; auto-complete link
       (= type :page)
       (let [{:keys [node/title]} (get results index)
             new-str (clojure.string/replace-first value (str query "]]") (str title "]]"))]
         (swap! state merge {:atom-string  new-str
                             :search/query nil
-                            :search/type  nil}))
+                            :search/type  nil})
+        (set! (. target -selectionStart) (+ 2 start)))
       ;; auto-complete block ref
       (= type :block)
       (let [{:keys [block/uid]} (get results index)
             new-str (clojure.string/replace-first value (str query "))") (str uid "))"))]
         (swap! state merge {:atom-string  new-str
                             :search/query nil
-                            :search/type nil}))
+                            :search/type nil})
+        (set! (. target -selectionStart) (+ 2 start)))
 
       ;; shift-enter: add line break to textarea
       shift (swap! state assoc :atom-string (str head "\n" tail))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -327,6 +327,15 @@
     ;;(= key-code KeyCodes.CLOSE_SQUARE_BRACKET)
 
 
+;; This should probably reside in another file as it has nothing to do
+;; with keybindings
+(defn update-query
+  [state new-query query-fun]
+  (prn new-query)
+  (let [results (query-fun new-query)]
+    (swap! state assoc :search/query new-query)
+    (swap! state assoc :search/results results)))
+
 
 (defn handle-backspace
   [e uid state]
@@ -388,14 +397,10 @@
       (= type :slash) (swap! state assoc :search/query new-str)
 
       ;; when in-line search dropdown is open
-      (= type :block) (let [results (db/search-in-block-content new-query)]
-                        (swap! state assoc :search/query new-query)
-                        (swap! state assoc :search/results results))
+      (= type :block) (update-query state new-query db/search-in-block-content)
 
     ;; when in-line search dropdown is open
-      (= type :page) (let [results (db/search-in-node-title new-query)]
-                       (swap! state assoc :search/query new-query)
-                       (swap! state assoc :search/results results)))
+      (= type :page) (update-query state new-query db/search-in-node-title))
 
     (swap! state merge {:atom-string new-str})))
 

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -388,12 +388,12 @@
       (= type :slash) (swap! state assoc :search/query new-str)
 
       ;; when in-line search dropdown is open
-      (= type :block) (let [results (db/search-in-block-content query)]
+      (= type :block) (let [results (db/search-in-block-content new-query)]
                         (swap! state assoc :search/query new-query)
                         (swap! state assoc :search/results results))
 
     ;; when in-line search dropdown is open
-      (= type :page) (let [results (db/search-in-node-title query)]
+      (= type :page) (let [results (db/search-in-node-title new-query)]
                        (swap! state assoc :search/query new-query)
                        (swap! state assoc :search/results results)))
 

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -216,7 +216,7 @@
 
       ;; auto-complete link
       (= type :page)
-      (let [{:keys [node/title]} (get results index)
+      (let [{:keys [node/title]} (nth results index)
             new-str (clojure.string/replace-first value (str query "]]") (str title "]]"))]
         (swap! state merge {:atom-string  new-str
                             :search/query nil
@@ -224,7 +224,7 @@
         (set! (. target -selectionStart) (+ 2 start)))
       ;; auto-complete block ref
       (= type :block)
-      (let [{:keys [block/uid]} (get results index)
+      (let [{:keys [block/uid]} (nth results index)
             new-str (clojure.string/replace-first value (str query "))") (str uid "))"))]
         (swap! state merge {:atom-string  new-str
                             :search/query nil


### PR DESCRIPTION
(This PR is mostly for learning. If you think it is out of place/unnecessary, I don't mind closing it. I learned a lot anyway)

1. Fix error when trying to type any character within `[[]]` or `(())` (closes #315 )
2. Even after fixing the above, the block search function hangs the whole app when entering the first character within `(())` (perhaps because there are too many results?) This is a deeper issue to be investigated, but as a temporary workaround I have turned off `db/search-in-block-content`'s behavior for queries shorter than 4 characters. This way we can at least test the other behavior.
    - ![ROdZcWLH2F](https://user-images.githubusercontent.com/66203865/89115371-9793a100-d4c2-11ea-9ec8-9bcdb89034ce.gif)
3. Refactored query/results updating into its own function to make it a bit DRYer.
4. Since hitting backspace was not updating the inline results list, I fixed that too. Now backspace works much better.
    - Before:
    - ![AKiqrnAUIQ](https://user-images.githubusercontent.com/66203865/89115415-1557ac80-d4c3-11ea-8a89-c1b782180416.gif)
    - After:
    - ![GVeQaHPPTI](https://user-images.githubusercontent.com/66203865/89115442-34563e80-d4c3-11ea-93e7-3922a991d93f.gif)
5. Improved the Enter behavior when inside `[[]]` or `(())`, to move the caret directly to after the last bracket.
    - Before:
    - ![NEZwuKkhEv](https://user-images.githubusercontent.com/66203865/89115485-a3339780-d4c3-11ea-9fde-48c3f07083f9.gif)
    - After:
    - ![voIZ40i5Ix](https://user-images.githubusercontent.com/66203865/89115490-b34b7700-d4c3-11ea-80ce-2b0974c45dc6.gif)
