### PR TITLE
docs: update CONTRIBUTING with better starting instructions. update community roles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
 
 ## Developers
 
-- Join our [Discord](https://discord.gg/GCJaV3V) 👾 and check out the `#engineering` and `#engineers` channels.
+- Join our [Discord](https://discord.gg/GCJaV3V) 👾 and check out the `#engineering` and `#engineers` channels. The former is for anything engineering-related, and the latter is for [contributors](./GOVERNANCE.md#contributors) who have already made non-trivial code contributions.
   - Post work updates in the `#build-in-public`. This keeps the team on the same page! Let's avoid stepping on each others toes, minimize blockers / dependencies, and cheer each other on!
 - Watch the repo and bookmark our [Project Board](https://github.com/athensresearch/athens/projects/2). This is the ultimate source of truth for product roadmapping.
 - To start working on your PR, you have a few ways to get started:
@@ -43,7 +43,7 @@
 
 ## Designers
 
-- Join our [Discord](https://discord.gg/GCJaV3V) 👾 and see what's happening in the `#design` and `#designers` channel.
+- Join our [Discord](https://discord.gg/GCJaV3V) 👾 and see what's happening in the `#design` and `#designers` channel. The former is for anything design-related, and the latter is for [contributors](./GOVERNANCE.md#contributors) who have already made non-trivial design contributions.
 - Duplicate the [Athens Design System](https://www.figma.com/file/XITWUHZHNJsIbcCsBkOHpZ/Athens-Design-System?node-id=0%3A1) on Figma to get the building blocks for creating UIs and workflows.
 - See previous concepts in the [Product Design Sandbox](https://www.figma.com/file/iCXP6z7H5IAQ6xyFr5AbZ7/Product-Design-Sandbox?node-id=183%3A37). This Figma is no longer actively used, but seeing previous work can help!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,16 @@
 # Table of Contents
 
 - [Contributing to Athens](#contributing-to-athens)
+  * [Developers](#developers)
+  * [Designers](#designers)
+  * [Others](#others)
 - [Running Athens Locally](#running-athens-locally)
 - [Deploying Athens and Devcards](#deploying-athens-and-devcards)
   * [Automated Deploys](#automated-deploys)
   * [Manual Deploys](#manual-deploys)
 - [Connecting your REPL](#connecting-your-repl)
   * [Cursive](#cursive)
-  * [Cider](#cider)
+  * [CIDER](#cider)
   * [Calva](#calva)
   * [Vim Plugins](#vim-plugins)
 - [Using re-frame-10x](#using-re-frame-10x)
@@ -25,10 +28,29 @@
 
 # Contributing to Athens
 
-Whether you are a designer, developer, or have other superpowers, please see our [v1 Project Board](https://github.com/athensresearch/athens/projects/2) to see what we're working on.
+## Developers
 
-- The best place to reach us is our [Discord](https://discord.gg/GCJaV3V)! 👾
+- Join our [Discord](https://discord.gg/GCJaV3V) 👾 and check out the `#engineering` and `#engineers` channels.
+  - Post work updates in the `#build-in-public`. This keeps the team on the same page! Let's avoid stepping on each others toes, minimize blockers / dependencies, and cheer each other on!
+- Watch the repo and bookmark our [Project Board](https://github.com/athensresearch/athens/projects/2). This is the ultimate source of truth for product roadmapping.
+- To start working on your PR, you have a few ways to get started:
+    1. ask a question in our `#engineering` [Discord](https://discord.gg/GCJaV3V) channel
+    1. comment on one of the existing top-level issues on the project board
+    1. create a PR draft or issue, then assign yourself (prefer drafts over new issues)
+- In all the cases above, try to scope out what you want to do and how, to the extent that you can at the start of a task! If you aren't sure about the scopes, chat in our Discord. If you feel confident, go ahead and start your PR draft — you don't need permission to start!
 - Read [Product Development at Athens](https://www.notion.so/athensresearch/Product-Development-at-Athens-4c99e37d1713441c99360668c39e5db7) to see our shipping philosophy. It's more nuanced than just "agile", with some inspiration from Basecamp. 🛠
+- If you don't have experience programming with Clojure, checkout our learning resources and join [ClojureFam](https://github.com/athensresearch/ClojureFam) to learn with some friends! In our experience, it takes ~4 weeks of part-time study to begin making solid code contributions to Athens.
+
+## Designers
+
+- Join our [Discord](https://discord.gg/GCJaV3V) 👾 and see what's happening in the `#design` and `#designers` channel.
+- Duplicate the [Athens Design System](https://www.figma.com/file/XITWUHZHNJsIbcCsBkOHpZ/Athens-Design-System?node-id=0%3A1) on Figma to get the building blocks for creating UIs and workflows.
+- See previous concepts in the [Product Design Sandbox](https://www.figma.com/file/iCXP6z7H5IAQ6xyFr5AbZ7/Product-Design-Sandbox?node-id=183%3A37). This Figma is no longer actively used, but seeing previous work can help!
+
+
+## Others
+
+- Have other superpowers?! Join our [Discord](https://discord.gg/GCJaV3V) 👾, introduce yourself in `#introductions`, and ask around in `#agora`!
 
 # Running Athens Locally
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,13 +17,9 @@
 
 # Overview
 
-This project is led by a [Benevolent Dictator](http://oss-watch.ac.uk/resources/benevolentdictatorgovernancemodel), otherwise known as the project lead, and Core Team. Together, they will make the strategic decisions for the high-level, at times overlapping, domains that a technology organization needs to manage in order to function and succeed. These domains include, but are not limited to: engineering, design, product, strategy, operations, training and education, finance, legal, administration, and communications.
+This project is led by a [Benevolent Dictator](http://oss-watch.ac.uk/resources/benevolentdictatorgovernancemodel), otherwise known as the project lead, and Core Team. Together, they make the strategic decisions for the high-level, at times overlapping, domains that a technology organization needs to manage in order to function and succeed. These domains include, but are not limited to: engineering, design, product, strategy, operations, training and education, finance, legal, administration, and communications. If needed, however, the Benevolent Dictator has executive power on strategic decisions that would influence the long-term direction of Athens. 
 
-This project is *radically open* to contributions, feedback, and input from the community, following the "Bazaar" model described in Eric S. Raymond's, "[The Cathedral and the Bazaar](http://www.catb.org/~esr/writings/cathedral-bazaar/cathedral-bazaar/index.html#catbmain)".
-
-Even within the [meritocratic open-source software governance model](http://oss-watch.ac.uk/resources/meritocraticgovernancemodel), "not everyone has a binding vote". Therefore, those who want greater influence over the direction of Athens are encouraged to make greater contributions in any of the aforementioned domains to be considered as a candidate for the Core Team.
-
-The Benevolent Dictator has executive power on strategic decisions. Strategic decisions are high-level decisions that will influence the direction of Athens for months or longer. This includes the addition or removal of Core Team members and Guardians. Over time, as the Core Team forms, they will have greater say over these strategic decisions. The Benevolent Dictator and Core Team may form their own internal structure and decision-making process, while still aligning optimally with the needs of the community.
+Another role exists for Contributors. There are primarily two types of Contributors, those who have [contributed](./CONTRIBUTING.md) domain-specific work to the project, and those that have financially sponsored the project.
 
 These roles and others will be discussed in further detail below.
 
@@ -35,25 +31,24 @@ These roles and others will be discussed in further detail below.
 
 The role of the project lead is to ensure that the project survives, if not thrives, long-term. The project lead does this by understanding the community as a whole, satisfying as many conflicting needs as possible, and articulating and exemplifying the shared [values]((https://github.com/athensresearch/athens/blob/master/CODE_OF_CONDUCT.md)) and [vision](https://github.com/athensresearch/athens/blob/master/VISION.md) for the Athens project.
 
-Thus, the role of the project lead is less about dictatorship and more about diplomacy. Because anyone can fork Athens at any time, the project lead is fully accountable to the Core Team, Guardians, and Athenians. The key to do doing this is to ensure that, as the project expands, the right people are given influence over it.
+Thus, the role of the project lead is less about dictatorship and more about diplomacy. Because anyone can fork Athens at any time, the project lead is fully accountable to the Core Team, Contributors, and users of the software. The key to doing this is to ensure that, as the project expands, the right people are given influence over it.
 
 ## Core Team
 
-The Core Team is comprised of Athenians who have demonstrated impactful contributions and significant commitment to the Athens project.
+The Core Team is composed of Athenians who have demonstrated impactful contributions and significant commitment to the Athens project.
 
-Contributions include, but are not limited to, the aforementioned domains (engineering, design, etc.). The degree of impact will be evaluated by the Benevolent Dictator and Core Team.
+Contributions include, but are not limited to, the aforementioned domains (engineering, design, etc.).
 
-Significant commitment means being an exemplary member of the Athens community. This requires upholding and championing the [Athens Values](https://github.com/athensresearch/athens/blob/master/CODE_OF_CONDUCT.md) to a distinguished degree, not just for oneself but for others.
+Significant commitment means being an exemplary member of the Athens community. This requires upholding and championing the [Athens Values](https://github.com/athensresearch/athens/blob/master/CODE_OF_CONDUCT.md) to a distinguished degree, not just for oneself but for others, as well as aligning oneself to the long-term actualization of the [Athens Vision](https://github.com/athensresearch/athens/blob/master/VISION.md). It's not enough to be a great engineer or designer. A Core Team member is also helping others grow through insightful and empathetic feedback.
 
-Significant commitment also means being dedicated oneself long-term to the actualization of the [Athens Vision](https://github.com/athensresearch/athens/blob/master/VISION.md).
 
 ## Contributors
 
-Contributors will receive the beta application first as well as the newest updates as the product matures, as explained in [MVP Update, Funding, and Why I Started Athens](https://www.notion.so/MVP-Update-Funding-and-Why-I-Started-Athens-e68822f0c3654660ae621cdcbf932bc4).
+Both kinds of Contributors will receive the beta application first and the newest updates as the product matures, as explained in [MVP Update, Funding, and Why I Started Athens](https://www.notion.so/MVP-Update-Funding-and-Why-I-Started-Athens-e68822f0c3654660ae621cdcbf932bc4).
 
 ### Work
 
-The main opportunities to contribute currently are through design, engineering, and product. By contributing non-trivial designs (Figma) and code (Clojure) to the project, you will gain write-access to three channels: `#engineers`, `#designers`, and `#product`. Read more at [Open Source Conversations](https://www.notion.so/athensresearch/Open-Source-Conversations-Discord-a8c959de3b194cefadd48b497fc12079).
+The main opportunities to contribute currently are through design, engineering, and product. By contributing non-trivial designs and code to the project, you will gain write-access to three Discord channels: `#engineers`, `#designers`, and `#product`. Read more at [Open Source Conversations](https://www.notion.so/athensresearch/Open-Source-Conversations-Discord-a8c959de3b194cefadd48b497fc12079).
 
 ### Financial
 
@@ -65,9 +60,9 @@ As the product matures, it's likely we will need specific guidance in areas such
 
 If you contribute interesting conversations, ideas, and feedback, and generally make our community a better place to be, that could also make you a Contibutor!
 
-
 ## Members
 
+Members are the rest of the Discord. They have read-access to effectively all channels, and write-access to all channels except for the contributor-specific channels listed above.
 
 ## Other Roles
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,11 +1,15 @@
 # Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Overview](#overview)
 - [Roles and Responsibilities](#roles-and-responsibilities)
   * [Benevolent Dictator](#benevolent-dictator)
   * [Core Team](#core-team)
-  * [Moderators (Guardians)](#moderators--guardians-)
-  * [Contributors (Athenians)](#contributors--athenians-)
+  * [Contributors](#contributors)
+    + [Work](#work)
+    + [Financial](#financial)
+    + [Other](#other)
+  * [Members](#members)
   * [Other Roles](#other-roles)
 - [Attribution](#attribution)
 
@@ -43,23 +47,33 @@ Significant commitment means being an exemplary member of the Athens community. 
 
 Significant commitment also means being dedicated oneself long-term to the actualization of the [Athens Vision](https://github.com/athensresearch/athens/blob/master/VISION.md).
 
-## Moderators (Guardians)
+## Contributors
 
-Moderators, or Guardians, are also exemplary members of the Athens community. Specifically, Guardians are responsible for ensuring that members are [being excellent](https://www.noisebridge.net/wiki/Noisebridge_Vision#Excellence) to one another, in accordance with Athens's values. Guardians are responsible for de-escalating and resolving conflicts should they arise, in the event that Athenians are unable to do so themselves.
+Contributors will receive the beta application first as well as the newest updates as the product matures, as explained in [MVP Update, Funding, and Why I Started Athens](https://www.notion.so/MVP-Update-Funding-and-Why-I-Started-Athens-e68822f0c3654660ae621cdcbf932bc4).
 
-Guardians have high degrees of emotional intelligence, leadership, and compassion. They are invested in creating an atmosphere of psychological safety. You are always free to DM the Guardians if you are feeling unwell. In order to become a Guardian, you will need to practice setting up your own Discord server with bots. Ideally, you will also have experience doing conflict resolution and emotional labor.
+### Work
 
-## Contributors (Athenians)
+The main opportunities to contribute currently are through design, engineering, and product. By contributing non-trivial designs (Figma) and code (Clojure) to the project, you will gain write-access to three channels: `#engineers`, `#designers`, and `#product`. Read more at [Open Source Conversations](https://www.notion.so/athensresearch/Open-Source-Conversations-Discord-a8c959de3b194cefadd48b497fc12079).
 
-Anyone who has agreed to the Athens guidelines and introduced themselves on the Athens Discord server is a Contributor, otherwise known as an Athenian.
+### Financial
 
-Athenians engage with the project by contributing expertise in the aforementioned domains (engineering, design, etc.). They also contribute by sharing constructive, hopefully actionable feedback on Athens the product, Athens the community, and [related topics of interest](https://github.com/athensresearch/athens#join-us).
+Financial Contributors are those that sponsor the project for $16/month or more through [OpenCollective](https://opencollective.com/athens). They will provide feedback on the product, which will be especially crucial in its early stages.
+
+### Other
+
+As the product matures, it's likely we will need specific guidance in areas such as finance, legal, operations, etc. If you have these or other skills not mentioned already, and see an opportunity to apply them, join our Discord!
+
+If you contribute interesting conversations, ideas, and feedback, and generally make our community a better place to be, that could also make you a Contibutor!
+
+
+## Members
+
 
 ## Other Roles
 
 Roles may be created, removed, and refactored in the future.
 
-Note that the roles in this document are also represented in the Discord with varying levels of permissions. However, not all roles on Discord pertain to governance and are therefore not mentioned here.
+Note that the roles in this document are also represented in the Discord with varying levels of permissions. However, not all roles on Discord pertain to governance and are therefore not mentioned here, e.g. learners, mentors, intro-only
 
 # Attribution
 


### PR DESCRIPTION
Are these instructions for getting started clearer? Will probably delete [README column of Project Board](https://github.com/athensresearch/athens/projects/2#column-9464291), then link to CONTRIBUTING from Top of "Good First Issues" column.

This doesn't include the resources for developers. It assumes that link to ClojureFam is a good entrypoint for learning.


@bonobo-d