### PR TITLE
refactor: search functions

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -280,16 +280,18 @@
 
 
 (defn search-in-node-title
-  [query]
-  (d/q '[:find [(pull ?node [:db/id :node/title :block/uid]) ...]
-         :in $ ?query-pattern ?query
-         :where
-         [?node :node/title ?title]
-         [(re-find ?query-pattern ?title)]
-         [(not= ?title ?query)]] ;; ignore exact match to avoid duplicate
-       @dsdb
-       (re-case-insensitive query)
-       query))
+  ([query] (search-in-node-title query 20))
+  ([query n]
+   (->> (d/q '[:find [(pull ?node [:db/id :node/title :block/uid]) ...]
+               :in $ ?query-pattern ?query
+               :where
+               [?node :node/title ?title]
+               [(re-find ?query-pattern ?title)]
+               [(not= ?title ?query)]] ;; ignore exact match to avoid duplicate
+             @dsdb
+             (re-case-insensitive query)
+             query)
+        (take n))))
 
 
 (defn get-root-parent-node
@@ -301,17 +303,19 @@
 
 
 (defn search-in-block-content
-  [query]
-  (->>
-    (d/q '[:find [(pull ?block [:db/id :block/uid :block/string :node/title {:block/_children ...}]) ...]
-           :in $ ?query-pattern
-           :where
-           [?block :block/string ?txt]
-           [(re-find ?query-pattern ?txt)]]
-         @dsdb
-         (re-case-insensitive query))
-    (map get-root-parent-node)
-    (mapv #(dissoc % :block/_children))))
+  ([query] (search-in-block-content query 20))
+  ([query n]
+   (->>
+     (d/q '[:find [(pull ?block [:db/id :block/uid :block/string :node/title {:block/_children ...}]) ...]
+            :in $ ?query-pattern
+            :where
+            [?block :block/string ?txt]
+            [(re-find ?query-pattern ?txt)]]
+          @dsdb
+          (re-case-insensitive query))
+     (take n)
+     (map get-root-parent-node)
+     (mapv #(dissoc % :block/_children)))))
 
 
 ;; xxx 2 kinds of operations

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -165,8 +165,8 @@
       (reset! state {:index   0
                      :query   query
                      :results (->> (concat [(search-exact-node-title query)]
-                                           (take 20 (search-in-node-title query))
-                                           (take 20 (search-in-block-content query)))
+                                           (search-in-node-title query)
+                                           (search-in-block-content query))
                                    vec)}))))
 
 


### PR DESCRIPTION
Refactor the `search-in-node-title` and `search-in-block-content` functions to return only 20 items by default. This should fix #269.

* These functions also now take an optional parameter to specify max number of results

* Remove (take 20) from create-search-handler since those functions default to returning 20 results

Advantage of this refactor is that we can exert more control over these functions by specifying the maximum number of results returned by these functions.

There is still some latency when the search query is 1 or 2 characters long but the search functions do not hang anymore.