### PR TITLE
Fix cljs repl issue by removing the :repl-init-ns option

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -20,8 +20,7 @@
                 :devtools        {:preloads [devtools.preload
                                              day8.re-frame-10x.preload]
                                   :http-root    "resources/public"
-                                  :http-port    3000
-                                  :repl-init-ns athens.core}}
+                                  :http-port    3000}}
 
           :devcards         {:asset-path "js/devcards"
                              :modules {:main {:init-fn athens.devcards/main}}


### PR DESCRIPTION
The local cljs repl is broken after updating `shadow-cljs` to `2.8.110`. This PR fixes that issue by removing the offending `:repl-init-ns` option.

Reference - https://github.com/thheller/shadow-cljs/issues/700#issuecomment-623991281