### PR TITLE
feat(blocks): copy, cut, paste for inline textarea

### DIFF
--- a/.carve_ignore
+++ b/.carve_ignore
@@ -16,3 +16,5 @@ athens.views.right-sidebar/sidebar-section-heading-style
 
 ;; for future use
 athens.db/v-by-ea
+athens.keybindings/is-character-key?
+athens.keybindings/write-char

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -188,7 +188,13 @@
      [(inc ?o) ?new-o]]
     [(dec-after ?p ?at ?ch ?new-o)
      (after ?p ?at ?ch ?o)
-     [(dec ?o) ?new-o]]])
+     [(dec ?o) ?new-o]]
+    [(plus-after ?p ?at ?ch ?new-o ?x)
+     (after ?p ?at ?ch ?o)
+     [(+ ?o ?x) ?new-o]]
+    [(minus-after ?p ?at ?ch ?new-o ?x)
+     (after ?p ?at ?ch ?o)
+     [(- ?o ?x) ?new-o]]])
 
 
 (defn sort-block-children

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -132,6 +132,7 @@
       (assoc db :selected/items new-vec))))
 
 
+;; TODO: minus-after to reindex but what about nested blocks?
 (reg-event-fx
   :selected/delete
   (fn [{:keys [db]} [_ selected-items]]

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -397,8 +397,8 @@
       (= key-code KeyCodes.ESC) (handle-escape e state)
       (or meta ctrl) (handle-shortcuts e uid state))))
 
-      ;; -- Default: Add new character -----------------------------------------
-      ;(is-character-key? e) (write-char e uid state))))
+;; -- Default: Add new character -----------------------------------------
+;(is-character-key? e) (write-char e uid state))))
 
 
 ;;:else (prn "non-event" key key-code))))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -263,11 +263,11 @@
 ;; TODO: it's ctrl for windows and linux right?
 (defn handle-shortcuts
   [e _ state]
-  (let [{:keys [key-code selection]} (destruct-event e)]
+  (let [{:keys [key-code head tail selection]} (destruct-event e)]
     (cond
-      (= key-code KeyCodes.B) (let [new-str (surround selection "**")]
+      (= key-code KeyCodes.B) (let [new-str (str head (surround selection "**") tail)]
                                 (swap! state assoc :atom-string new-str))
-      (= key-code KeyCodes.I) (let [new-str (surround selection "__")]
+      (= key-code KeyCodes.I) (let [new-str (str head (surround selection "__") tail)]
                                 (swap! state assoc :atom-string new-str)))))
 
 

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -261,28 +261,12 @@
 
 
 ;; TODO: it's ctrl for windows and linux right?
-(defn handle-system-shortcuts
-  "Assumes meta is selected"
+(defn handle-shortcuts
   [e _ state]
-  (let [{:keys [key-code target end selection]} (destruct-event e)]
+  (let [{:keys [key-code selection]} (destruct-event e)]
     (cond
-      (= key-code KeyCodes.A) (do (setStart target 0)
-                                  (setEnd target end))
-
-      ;; TODO: undo. conflicts with datascript undo
-      (= key-code KeyCodes.Z) (prn "undo")
-
-      ;; TODO: cut
-      (= key-code KeyCodes.X) (prn "cut")
-
-      ;; TODO: paste. magical
-      (= key-code KeyCodes.V) (prn "paste")
-
-      ;; TODO: bold
       (= key-code KeyCodes.B) (let [new-str (surround selection "**")]
                                 (swap! state assoc :atom-string new-str))
-
-      ;; TODO: italicize
       (= key-code KeyCodes.I) (let [new-str (surround selection "__")]
                                 (swap! state assoc :atom-string new-str)))))
 
@@ -401,7 +385,9 @@
 ;; XXX: what happens here when we have multi-block selection? In this case we pass in `uids` instead of `uid`
 (defn block-key-down
   [e uid state]
-  (let [{:keys [meta key-code]} (destruct-event e)]
+  (let [{:keys [meta ctrl key-code]} (destruct-event e)]
+    (prn "DOWN" (destruct-event e))
+    ;(swap! state)
     (cond
       (arrow-key-direction e) (handle-arrow-key e uid state)
       (pair-char? e) (handle-pair-char e uid state)
@@ -409,10 +395,10 @@
       (= key-code KeyCodes.ENTER) (handle-enter e uid state)
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
       (= key-code KeyCodes.ESC) (handle-escape e state)
-      meta (handle-system-shortcuts e uid state)
+      (or meta ctrl) (handle-shortcuts e uid state))))
 
       ;; -- Default: Add new character -----------------------------------------
-      (is-character-key? e) (write-char e uid state))))
+      ;(is-character-key? e) (write-char e uid state))))
 
 
 ;;:else (prn "non-event" key key-code))))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -385,9 +385,9 @@
 ;; XXX: what happens here when we have multi-block selection? In this case we pass in `uids` instead of `uid`
 (defn block-key-down
   [e uid state]
-  (let [{:keys [meta ctrl key-code]} (destruct-event e)]
-    (prn "DOWN" (destruct-event e))
-    ;(swap! state)
+  (let [d-event (destruct-event e)
+        {:keys [meta ctrl key-code]} d-event]
+    (swap! state assoc :last-keydown d-event)
     (cond
       (arrow-key-direction e) (handle-arrow-key e uid state)
       (pair-char? e) (handle-pair-char e uid state)

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -148,8 +148,7 @@
   (->> blocks
     (map (fn [x] [:block/uid x]))
     (d/pull-many @dsdb '[:block/string])
-    (map #(str "- " (:block/string %)))
-    (clojure.string/join "\r\n")))
+    (map #(str "- " (:block/string %) "\n"))))
 
 
 (defn copy

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -146,9 +146,10 @@
 (defn to-markdown-list
   [blocks]
   (->> blocks
-    (map (fn [x] [:block/uid x]))
-    (d/pull-many @dsdb '[:block/string])
-    (map #(str "- " (:block/string %) "\n"))))
+       (map (fn [x] [:block/uid x]))
+       (d/pull-many @dsdb '[:block/string])
+       (map #(str "- " (:block/string %) "\n"))
+       (string/join "")))
 
 
 (defn copy
@@ -177,7 +178,7 @@
   (events/listen js/window EventType.MOUSEDOWN unfocus)
   (events/listen js/window EventType.MOUSEDOWN mouse-down-outside-athena)
   (events/listen js/window EventType.KEYDOWN multi-block-selection)
-  (events/listen js/window EventType.KEYDOWN key-down))
-  ;;(events/listen js/window EventType.COPY copy)
-  ;;(events/listen js/window EventType.CUT cut))
+  (events/listen js/window EventType.KEYDOWN key-down)
+  (events/listen js/window EventType.COPY copy)
+  (events/listen js/window EventType.CUT cut))
 

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -1,9 +1,11 @@
 (ns athens.listeners
   (:require
-    ;;[athens.util :refer [get-day]]
+    [athens.db :refer [dsdb]]
     [athens.keybindings :refer [arrow-key-direction]]
     [cljsjs.react]
     [cljsjs.react.dom]
+    [clojure.string :as string]
+    [datascript.core :as d]
     [goog.events :as events]
     [re-frame.core :refer [dispatch subscribe]])
   (:import
@@ -138,6 +140,38 @@
       (dispatch [:left-sidebar/toggle]))))
 
 
+;; -- Clipboard ----------------------------------------------------------
+
+;; TODO: once :selected/items is a nested tree instead of flat list, walk tree and add hyphens instead of mapping
+(defn to-markdown-list
+  [blocks]
+  (->> blocks
+    (map (fn [x] [:block/uid x]))
+    (d/pull-many @dsdb '[:block/string])
+    (map #(str "- " (:block/string %)))
+    (clojure.string/join "\r\n")))
+
+
+(defn copy
+  "If blocks are selected, copy blocks as markdown list."
+  [e]
+  (let [blocks @(subscribe [:selected/items])]
+    (when (not-empty blocks)
+      (.. e preventDefault)
+      ;; Use -event_ because goog events quirk
+      (.. e -event_ -clipboardData (setData "text/plain" (to-markdown-list blocks))))))
+
+
+;; do same as copy AND delete selected blocks
+(defn cut
+  [e]
+  (let [blocks @(subscribe [:selected/items])]
+    (when (not-empty blocks)
+      (.. e preventDefault)
+      (.. e -event_ -clipboardData (setData "text/plain" (to-markdown-list blocks)))
+      (dispatch [:selected/delete blocks]))))
+
+
 (defn init
   []
   ;; (events/listen js/window EventType.MOUSEDOWN edit-block)
@@ -145,4 +179,6 @@
   (events/listen js/window EventType.MOUSEDOWN mouse-down-outside-athena)
   (events/listen js/window EventType.KEYDOWN multi-block-selection)
   (events/listen js/window EventType.KEYDOWN key-down))
+  ;;(events/listen js/window EventType.COPY copy)
+  ;;(events/listen js/window EventType.CUT cut))
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -13,7 +13,6 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as str]
-    [clojure.string :as string]
     [garden.selectors :as selectors]
     [goog.dom.classlist :refer [contains]]
     [goog.events :as events]


### PR DESCRIPTION
- close #329 
- handles #330 partly, but need to fix selection bugs: better drag to select and (avoid redundant selection), figure out how to reindex the blocks after deleted blocks. also need more work for copy/cut/paste for nested blocks
- inline ctrl-z works inline as well now, but there will be collisions on MacOS I believe with global datascript undo/redo