### PR TITLE
feat(page): update linked refs when title is updated

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -721,41 +721,6 @@
 
 
 ;;;; TODO: delete the following logic when re-implementing title merge
-
-;;(defn node-with-title
-;;  [ds title]
-;;  (d/q '[:find ?e .
-;;         :in $ ?title
-;;         :where [?e :node/title ?title]]
-;;       ds title))
-;;
-;;
-;;(defn referencing-blocks
-;;  [ds title]
-;;  (d/q '[:find ?e ?s
-;;         :in $ ?regex
-;;         :where
-;;         [?e :block/string ?s]
-;;         [(re-find ?regex ?s)]]
-;;       ds (patterns/linked title)))
-;;
-;;
-;;(defn rename-refs-tx
-;;  [old-title new-title [eid s]]
-;;  (let [new-s (str/replace
-;;                s
-;;                (patterns/linked old-title)
-;;                (str "$1$3$4" new-title "$2$5"))]
-;;    [:db/add eid :block/string new-s]))
-;;
-;;
-;;(defn rename-tx
-;;  [ds old-title new-title]
-;;  (let [eid (node-with-title ds old-title)
-;;        blocks (referencing-blocks ds old-title)]
-;;    (->> blocks
-;;         (map (partial rename-refs-tx old-title new-title))
-;;         (into [[:db/add eid :node/title new-title]]))))
 ;;
 ;;
 ;;(reg-event-fx


### PR DESCRIPTION
TODO: prompt to merge pages if renaming title to an existing page. Separate PR.
- Done during ClojureFam Office Hours to demonstrate REPL-driven development. [Video, starts at 43:00](https://www.notion.so/egghead/01-ClojureFam-Office-Hours-16d0d8642f474c18ad3ec8127b1a9cab).
- Differs from the video in that we store old-title a different way. The video grabs the title from the `ref-groups` data structure, but that's not a general solution.