### PR TITLE
Proposed fix to on-change conflict

### DIFF
--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -468,7 +468,10 @@
 
 (defn block-on-change
   [e _uid state]
-  (swap! state assoc :atom-string (.. e -target -value)))
+  (let [{:keys [generated-str]} @state]
+    (if generated-str
+      (swap! state assoc :atom-string generated-str :generated-str nil)
+      (swap! state assoc :atom-string (.. e -target -value)))))
 
 
 ;; Actual string contents - two elements, one for reading and one for writing
@@ -594,6 +597,7 @@
   "Two checks to make sure block is open or not: children exist and :block/open bool"
   [block]
   (let [state (r/atom {:atom-string (:block/string block)
+                       :generated-str nil
                        :old-string (:block/string block) ;; this is for detecting what's deleted to process page deletion
                        :search/type nil ;; one of #{:page :block :slash}
                        :search/query nil


### PR DESCRIPTION
I'm proposing a way to fix #340. Now all functions that auto-generate text (auto-pairing, auto-complete, enter, etc.) in keybindings.cljs write to a new atom parameter `:generated-str` instead of directly to `:atom-string`. The job of writing to `:atom-string` is left to `blocks/block-on-change` instead. `blocks/block-on-change` now has some logic to switch between auto-generated text and event text from `on-change`.

This seems to fix all behavior I've tested (auto-completion, auto-pairing, copy&paste), but it does feel a bit hacky. Without a deeper understanding of the direction we want to take I can't come up with a better solution right now.