### PR TITLE
rfct(blocks): docs, better naming, code reuse

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -25,7 +25,7 @@
                :athena/open         false
                :athena/recent-items '()
                :devtool/open        false
-               :left-sidebar/open   true
+               :left-sidebar/open   false
                :right-sidebar/open  false
                :right-sidebar/items {}
                ;;:dragging-global     false

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -412,6 +412,7 @@
   [e uid state]
   (let [d-event (destruct-event e)
         {:keys [meta ctrl key-code]} d-event]
+    ;; used for paste, to determine if shift key was held down
     (swap! state assoc :last-keydown d-event)
     (cond
       (arrow-key-direction e) (handle-arrow-key e uid state)

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -443,13 +443,13 @@
 
 (defn slash-menu-el
   [state]
-  (let [{index :search/index} @state]
+  (let [{:search/keys [index results]} @state]
     [:div (merge (use-style dropdown-style) {:style {:position "absolute" :top "100%" :left "-0.125em"}})
      [:div#slash-menu-container (merge (use-style menu-style) {:style {:max-height "8em"}})
-      (for [[i [icon text _expansion kbd]] (map-indexed list athens.keybindings/slash-options)]
+      (for [[i [text icon _expansion kbd]] (map-indexed list results)]
         [button {:active   (= i index)
                  :key      text
-                 :on-click #(athens.keybindings/select-slash-cmd i state)}
+                 :on-click #(athens.keybindings/auto-complete-slash i state)}
          [:<> [(r/adapt-react-class icon)] [:span text] (when kbd [:kbd kbd])]])]]))
 
 
@@ -603,6 +603,7 @@
                        :generated-str nil
                        :old-string (:block/string block) ;; this is for detecting what's deleted to process page deletion
                        :search/type nil ;; one of #{:page :block :slash}
+                       :search/results nil
                        :search/query nil
                        :search/index 0
                        :dragging false

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db :refer [count-linked-references-excl-uid]]
-    [athens.keybindings :refer [block-key-down auto-complete-slash auto-complete-inline]]
+    [athens.keybindings :refer [block-key-down auto-complete-slash #_auto-complete-inline]]
     [athens.listeners :refer [multi-block-select-over multi-block-select-up]]
     [athens.parse-renderer :refer [parse-and-render pull-node-from-string]]
     [athens.parser :as parser]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -455,18 +455,16 @@
 
 (defn paste
   "Clipboard data can only be accessed if user triggers JavaScript paste event.
+  Uses previous keydown event to determine if shift was held, since the paste event has no knowledge of shift key.
   Cases:
   - User pastes and last keydown has shift -> default
   - User pastes and clipboard data doesn't have new lines -> default
-  - User pastes without shift and clipboard data has new lines -> convert to blocks and prevent default
-  The clipboard data has blocks if it has new line characters.
-  Uses previous keydown event to determine if shift was held, since the paste event has no knowledge of shift key."
+  - User pastes without shift and clipboard data has new line characters -> PREVENT default and convert to outliner blocks"
   [e uid state]
   (let [data (.. e -clipboardData (getData "text"))
-        lines-breaks? (re-find #"\r?\n" data)
-        last-keydown (:last-keydown @state)
-        {:keys [shift]} last-keydown]
-    (when (and lines-breaks? (not shift))
+        line-breaks (re-find #"\r?\n" data)
+        no-shift (-> @state :last-keydown :shift not)]
+    (when (and line-breaks no-shift)
       (.. e preventDefault)
       (dispatch [:paste uid data]))))
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -454,14 +454,19 @@
 
 
 (defn paste
-  "if user does typical copy and paste, meta+v, and "
+  "Clipboard data can only be accessed if user triggers JavaScript paste event.
+  Cases:
+  - User pastes and last keydown has shift -> default
+  - User pastes and clipboard data doesn't have new lines -> default
+  - User pastes without shift and clipboard data has new lines -> convert to blocks and prevent default
+  The clipboard data has blocks if it has new line characters.
+  Uses previous keydown event to determine if shift was held, since the paste event has no knowledge of shift key."
   [e uid state]
   (let [data (.. e -clipboardData (getData "text"))
-        is-block (re-find #"\r?\n" data)
+        lines-breaks? (re-find #"\r?\n" data)
         last-keydown (:last-keydown @state)
         {:keys [shift]} last-keydown]
-    ;; if `not shift`, do normal plain-text paste
-    (when (and is-block (not shift))
+    (when (and lines-breaks? (not shift))
       (.. e preventDefault)
       (dispatch [:paste uid data]))))
 

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -266,6 +266,17 @@
     [:span {:on-click #(handle-new-first-child-block-click parent-uid)} "Click here to add content..."]]])
 
 
+(defn sync-title
+  "Ensures :title/initial is synced to node/title.
+  Cases:
+  - User opens a page for the first time.
+  - User navigates from a page to another page.
+  - User merges current page with existing page, navigating to existing page."
+  [title state]
+  (when (not= title (:title/initial @state))
+    (swap! state assoc :title/initial title :title/local title)))
+
+
 (def init-state
   {:menu/show        false
    :menu/x           nil
@@ -277,9 +288,10 @@
    :alert/confirm-fn nil
    :alert/cancel-fn  nil})
 
+
 ;; TODO: where to put page-level link filters?
 (defn node-page-el
-  "title/inital is the title when a page is first loaded.
+  "title/initial is the title when a page is first loaded.
   title/local is the value of the textarea.
   We have both, because we want to be able to change the local title without transacting to the db until user confirms.
   Similar to atom-string in blocks. Hacky, but state consistency is hard!"
@@ -289,8 +301,7 @@
       (let [{:block/keys [children uid] title :node/title is-shortcut? :page/sidebar} block
             {:menu/keys [show x y] :alert/keys [message confirm-fn cancel-fn] alert-show :alert/show} @state]
 
-        (when (not= title (:title/initial @state))
-          (swap! state assoc :title/initial title :title/local title))
+        (sync-title title state)
 
         [:div (use-style page-style {:class ["node-page"]})
 


### PR DESCRIPTION
- better naming for strings
`:atom-string` -> `:string/local`
`:generated-str` -> `:string/generated`
`:old-string` -> `:string/previous`
- typeahead for slash commands, expansion fixed with `generated`. closes #327
- lots of docstring comments
- refactor arrow keys, more code reuse by condensing slash commands and inline search menus into generic dropdown
- let backspace use more textarea default behavior
- create second atom listener for `generated`
- organize function order