### PR TITLE
rfct(textarea): use on-blur events for block transactions. refactor walk-parse-tree-for-links

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -305,12 +305,12 @@
 ;; TODO: put text caret in correct position
 (defn handle-shortcuts
   [e _ state]
-  (let [{:keys [key-code head tail selection]} (destruct-event e)]
+  (let [{:keys [key-code head tail selection shift]} (destruct-event e)]
     (cond
       (= key-code KeyCodes.B) (let [new-str (str head (surround selection "**") tail)]
                                 (swap! state assoc :string/generated new-str))
-      (= key-code KeyCodes.I) (let [new-str (str head (surround selection "__") tail)]
-                                (swap! state assoc :string/generated new-str)))))
+      (and (not shift) (= key-code KeyCodes.I)) (let [new-str (str head (surround selection "__") tail)]
+                                                   (swap! state assoc :string/generated new-str)))))
 
 
 (defn pair-char?

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -400,7 +400,7 @@
       type (update-query state head key type))))
 
 
-(defn block-key-down
+(defn textarea-key-down
   [e uid state]
   (let [d-event (destruct-event e)
         {:keys [meta ctrl key-code]} d-event]

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -310,7 +310,7 @@
       (= key-code KeyCodes.B) (let [new-str (str head (surround selection "**") tail)]
                                 (swap! state assoc :string/generated new-str))
       (and (not shift) (= key-code KeyCodes.I)) (let [new-str (str head (surround selection "__") tail)]
-                                                   (swap! state assoc :string/generated new-str)))))
+                                                  (swap! state assoc :string/generated new-str)))))
 
 
 (defn pair-char?

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -104,7 +104,6 @@
 
          ;; Header
          [:h1 (use-style title-style {:data-uid uid :class "block-header"})
-          (prn "LOCAL" (:string/local @state))
           [autosize/textarea
            {:value       (:string/local @state)
             :class       (when (= editing-uid uid) "is-editing")

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -4,7 +4,7 @@
     [athens.db :as db]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color]]
-    [athens.views.blocks :refer [block-el db-on-change]]
+    [athens.views.blocks :refer [block-el]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [garden.selectors :as selectors]
@@ -88,10 +88,11 @@
 ;; Header
    [:h1 (use-style title-style {:data-uid uid :class "block-header"})
     [autosize/textarea
-     {:default-value string
+     {:value string
       :class (when (= editing-uid uid) "is-editing")
       :auto-focus true
-      :on-change  (fn [e] (db-on-change (.. e -target -value) uid))}]
+      ;; TODO:
+      :on-change  (fn [e] (prn "TODO block page"))}]
     [:span string]]
 
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -8,7 +8,7 @@
     [athens.parser :as parser]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
-    [athens.util :refer [now-ts gen-block-uid mouse-offset vertical-center date-string]]
+    [athens.util :refer [now-ts gen-block-uid mouse-offset vertical-center]]
     [athens.views.buttons :refer [button]]
     [athens.views.dropdown :refer [menu-style dropdown-style]]
     [cljsjs.react]
@@ -18,7 +18,6 @@
     [garden.selectors :as selectors]
     [goog.dom.classlist :refer [contains]]
     [goog.events :as events]
-    [goog.functions :refer [debounce]]
     [instaparse.core :as parse]
     [komponentit.autosize :as autosize]
     [re-frame.core :refer [dispatch subscribe]]
@@ -357,7 +356,7 @@
 
 ;; FIXME: fix flicker from on-mouse-enter on-mouse-leave
 (defn tooltip-el
-  [{:block/keys [uid order] dbid :db/id edit-time :edit/time} state]
+  [{:block/keys [uid order] dbid :db/id} state]
   (let [{:keys [dragging tooltip]} @state]
     (when (and tooltip (not dragging))
       [:div (use-style tooltip-style
@@ -366,8 +365,7 @@
                         :on-mouse-leave #(swap! state assoc :tooltip false)})
        [:div [:b "db/id"] [:span dbid]]
        [:div [:b "uid"] [:span uid]]
-       [:div [:b "order"] [:span order]]
-       [:div [:b "last edit"] [:span (date-string edit-time)]]])))
+       [:div [:b "order"] [:span order]]])))
 
 
 (defn inline-search-el
@@ -471,6 +469,7 @@
     (parser/parse-to-ast string)))
 
 
+;; TODO: refactor, write better docs
 (defn textarea-blur
   "When textarea loses focus, transact to datascript.
   Compare previous string with current string.
@@ -629,7 +628,7 @@
 ;;TODO: more clarity on open? and closed? predicates, why we use `cond` in one case and `if` in another case)
 (defn block-el
   "Two checks to make sure block is open or not: children exist and :block/open bool"
-  [block]
+  [_]
   (let [state (r/atom {:string/local      nil
                        :string/generated  nil
                        :string/previous   nil
@@ -639,7 +638,6 @@
                        :search/index      nil
                        :dragging          false
                        :drag-target       nil
-                       :edit/time         (:edit/time block)
                        :last-keydown      nil
                        :context-menu/x    nil
                        :context-menu/y    nil
@@ -655,8 +653,8 @@
                    (swap! state assoc :string/local (:string/generated new)))))
 
     (fn [block]
-      (let [{:block/keys [uid string open children] edit-time :edit/time} block
-            {:search/keys [type] :keys [dragging drag-target] state-edit-time :edit/time} @state
+      (let [{:block/keys [uid string open children]} block
+            {:search/keys [type] :keys [dragging drag-target]} @state
             is-editing @(subscribe [:editing/is-editing uid])
             is-selected @(subscribe [:selected/is-selected uid])]
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -8,7 +8,7 @@
     [athens.parser :as parser]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
-    [athens.util :refer [now-ts gen-block-uid mouse-offset vertical-center]]
+    [athens.util :refer [gen-block-uid mouse-offset vertical-center]]
     [athens.views.buttons :refer [button]]
     [athens.views.dropdown :refer [menu-style dropdown-style]]
     [cljsjs.react]
@@ -426,29 +426,6 @@
     (if generated
       (swap! state assoc :string/local generated :string/generated nil)
       (swap! state assoc :string/local (.. e -target -value)))))
-
-
-(defn walk-parse-tree-for-links
-  [source-str link-fn db-fn]
-  (parse/transform
-    {:page-link (fn [& title]
-                  (let [inner-title (str/join "" title)]
-                    ;; `apply +` can return 0 if `title` is nil or empty string
-                    (when (and (string? inner-title)
-                               (link-fn inner-title))
-                      (let [now (now-ts)
-                            uid (gen-block-uid)]
-                        (db-fn inner-title now uid)))
-                    (str "[[" inner-title "]]")))
-     :hashtag   (fn [& title]
-                  (let [inner-title (str/join "" title)]
-                    (when (and (string? inner-title)
-                               (link-fn inner-title))
-                      (let [now (now-ts)
-                            uid (gen-block-uid)]
-                        (db-fn inner-title now uid)))
-                    (str "#" inner-title)))}
-    (parser/parse-to-ast source-str)))
 
 
 ;; It's likely that transform can return a clean data structure directly, but just updating an atom for now.


### PR DESCRIPTION
- [x] fix block page change events
  - not a complete fix. block-page title should actually have mostly same behavior as normal block textarea: slash commands, inline search, transact on blur, main difference is what happens on `backspace` and `enter`. not finishing in this PR because might take some more design work. see #344 @juniusfree
- rename all textarea event handlers to `textarea-*`
- fix italics happening when user presses `ctrl-shift-i` for devtools
- rewrite `walk-parse-tree-for-link` to use atoms
- no longer rely on `edit-time` for syncing datascript state to local block string state
- can finish #352 now - just add a key for the parser for `block-refs`