### PR TITLE
fix(parser): errors and warnings from TODOS, nested links, self-transclusions

### DIFF
--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -56,8 +56,17 @@
               [:iframe {:src         (find-weblink content)}]])})
 
 
+;; SELF: when blocks try to transclude themselves
+(def component-self
+  {:match  #"SELF"
+   :render (fn [content _]
+             [:button {:style {:color "red"
+                               :font-family "IBM Plex Mono"}}
+              content])})
+
+
 ;; Components
-(def components [component-todo component-done component-youtube-embed component-generic-embed])
+(def components [component-todo component-done component-youtube-embed component-generic-embed component-self])
 
 
 ;; ---- Render function for custom components

--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -28,15 +28,16 @@
   {:match #"\[\[TODO\]\]"
    :render (fn [_ uid]
              [:input {:type     "checkbox"
-                      :on-click #(todo-on-click uid #"\{\{\[\[TODO\]\]\}\}" "{{[[DONE]]}}")}])})
+                      :checked  false
+                      :on-change #(todo-on-click uid #"\{\{\[\[TODO\]\]\}\}" "{{[[DONE]]}}")}])})
 
 
 (def component-done
   {:match #"\[\[DONE\]\]"
    :render (fn [_ uid]
              [:input {:type     "checkbox"
-                      :checked  "true"
-                      :on-click #(todo-on-click uid #"\{\{\[\[DONE\]\]\}\}" "{{[[TODO]]}}")}])})
+                      :checked  true
+                      :on-change #(todo-on-click uid #"\{\{\[\[DONE\]\]\}\}" "{{[[TODO]]}}")}])})
 
 
 ;; ---- Website embed component declaration ----

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -90,14 +90,17 @@
   (insta/transform
     {:block         (fn [& contents]
                       (concat [:span {:class "block" :style {:white-space "pre-line"}}] contents))
-      ;; for more information regarding how custom components are parsed, see `doc/components.md`
+     ;; for more information regarding how custom components are parsed, see `doc/components.md`
      :component     (fn [& contents]
                       (components/render-component (first contents) uid))
      :page-link     (fn [& title] (render-page-link title))
      :block-ref     (fn [uid]
                       (let [block (pull db/dsdb '[*] [:block/uid uid])]
                         [:span (use-style block-ref {:class "block-ref"})
-                         [:span {:class "contents" :on-click #(navigate-uid uid)} (parse-and-render (:block/string @block) uid)]]))
+                         [:span {:class "contents" :on-click #(navigate-uid uid)}
+                          (if (= uid (:block/uid @block))
+                            [parse-and-render "{{SELF}}"]
+                            [parse-and-render (:block/string @block) uid])]]))
      :hashtag       (fn [& tag-name]
                       (let [parsed-name (concat tag-name)
                             node        (pull db/dsdb '[*] [:node/title parsed-name])]

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -5,6 +5,7 @@
     [athens.parser :as parser]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color OPACITIES]]
+    [clojure.string :as str]
     [instaparse.core :as insta]
     [posh.reagent :refer [pull #_q]]
     [stylefy.core :as stylefy :refer [use-style]]))
@@ -69,12 +70,13 @@
 (defn render-page-link
   "Renders a page link given the title of the page."
   [title]
-  ;; This method feels a bit hacky: it extracts the DOM tree of its children components and re-wrap the content in double parentheses. Should we do something about it?
-  ;; TODO: touch from inner content should navigate to the inner (children) page, but in this implementation doesn't work
   (let [node (pull-node-from-string title)]
     [:span (use-style page-link {:class "page-link"})
      [:span {:class "formatting"} "[["]
-     [:span {:on-click (fn [e] (.. e stopPropagation) (navigate-uid (:block/uid @node) e))} (concat title)]
+     (into [:span {:on-click (fn [e]
+                               (.. e stopPropagation) ;; prevent bubbling up click handler for nested links
+                               (navigate-uid (:block/uid @node) e))}]
+           title)
      [:span {:class "formatting"} "]]"]]))
 
 


### PR DESCRIPTION
- fix(page-links): react index error from nested links
- fix(todo): `checked` boolean instead of string value
- fix(todo): on-change instead of on-click
- fix(block-refs): break out of self transclusions to avoid stack overflow. [card](https://github.com/athensresearch/athens/projects/4#card-43628910)