### PR TITLE
fix(inline): slash and search

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -119,12 +119,12 @@
 (defn auto-complete-slash
   [state e]
   (let [{:keys [string/local] :search/keys [index results]} @state
-        {:keys [head]} (destruct-event e)
+        {:keys [head tail]} (destruct-event e)
         [_ _ expansion _] (nth results index)
         expand (if (fn? expansion) (expansion) expansion)
         start-idx (dec (count (re-find #".*/" head)))
         new-head (subs local 0 start-idx)
-        new-str     (str new-head expand)]
+        new-str (str new-head expand tail)]
     (swap! state assoc
            :search/type nil
            :string/generated new-str)))

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -1,8 +1,8 @@
 (ns athens.views.blocks
   (:require
     ["@material-ui/icons" :as mui-icons]
-    [athens.db :as db :refer [count-linked-references-excl-uid e-by-av]]
-    [athens.events :refer [delete-page]]
+    [athens.db :as db :refer [count-linked-references-excl-uid #_e-by-av]]
+    #_[athens.events :refer [delete-page]]
     [athens.keybindings :refer [textarea-key-down #_auto-complete-slash #_auto-complete-inline]]
     [athens.listeners :refer [multi-block-select-over multi-block-select-up]]
     [athens.parse-renderer :refer [parse-and-render pull-node-from-string]]


### PR DESCRIPTION
- inline search auto-complete without results still moves caret
- typing after "/" without results hides slash menu
- `nth` over `get`
- proper expansion for "/" - remove query characters
- fix backspace bug where bksp with all text highlighted deleted block
- show lower opacity hint when no search results for inline
- [ ] modify `auto-complete-inline` and `auto-complete-slash` so they work on click, not just with enter
- [ ] there's a bug where after expanding, the first keypress right after doesn't change the textarea