### PR TITLE
fix(dnd): fix several drag n drop bugs. rfct(blocks): decouple evt handlers from hiccup

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -569,8 +569,9 @@
 
 (defn drop-above-same-parent
   "Give source block target block's order
-    When source is below target, increment block orders between source and target-1
-    When source is above target, decrement block order between..."
+  When source is below target, increment block orders between source and target-1
+  When source is above target, decrement block order between them.
+  No effect if block/orders wouldn't change: :above and s-order == t-order - 1"
   [source target parent]
   (let [s-order (:block/order source)
         t-order (:block/order target)
@@ -603,7 +604,8 @@
 
 
 (defn drop-below-same-parent
-  "source block's new order is target block's order."
+  "Source block's new order is target block's order.
+  No effect if block/orders wouldn't change: :below and t-order == s-order - 1"
   [source parent target]
   (let [s-order (:block/order source)
         t-order (:block/order target)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -570,13 +570,12 @@
 (defn drop-above-same-parent
   "Give source block target block's order
     When source is below target, increment block orders between source and target-1
-    When source is above target, decrement block order between...";; TODO
-
+    When source is above target, decrement block order between..."
   [source target parent]
   (let [s-order (:block/order source)
-        t-order (:block/order target)]
-    (if (= s-order (dec t-order))
-      nil
+        t-order (:block/order target)
+        no-effect? (= s-order (dec t-order))]
+    (when-not no-effect?
       (let [new-source-block {:db/id (:db/id source) :block/order t-order}
             inc-or-dec       (if (> s-order t-order) inc dec)
             reindex          (->> (d/q '[:find ?ch ?new-order
@@ -604,11 +603,15 @@
 
 
 (defn drop-below-same-parent
-  "source block's new order is target block's order"
-  [source source-parent target]
-  (let [new-source-block {:db/id (:db/id source) :block/order (:block/order target)}
-        reindex (dec-after (:db/id source-parent) (:block/order source))]
-    (concat [new-source-block] reindex)))
+  "source block's new order is target block's order."
+  [source parent target]
+  (let [s-order (:block/order source)
+        t-order (:block/order target)
+        no-effect? (= (dec s-order) t-order)]
+    (when-not no-effect?
+      (let [new-source-block {:db/id (:db/id source) :block/order t-order}
+            reindex (dec-after (:db/id parent) s-order)]
+        (concat [new-source-block] reindex)))))
 
 
 (defn drop-below-diff-parent

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -35,11 +35,17 @@
 
 
 (defn mouse-offset
-  [e]
-  (let [rect (.. e -target getBoundingClientRect)
-        offset-x (- (.. e -pageX) (.. rect -left))
-        offset-y (- (.. e -pageY) (.. rect -top))]
-    {:x offset-x :y offset-y}))
+  "Finds offset coordinates within a container. If container is not passed, assume target is container."
+  ([e]
+   (let [rect (.. e -target getBoundingClientRect)
+         offset-x (- (.. e -pageX) (.. rect -left))
+         offset-y (- (.. e -pageY) (.. rect -top))]
+     {:x offset-x :y offset-y}))
+  ([e container]
+   (let [rect (.. container getBoundingClientRect)
+         offset-x (- (.. e -pageX) (.. rect -left))
+         offset-y (- (.. e -pageY) (.. rect -top))]
+     {:x offset-x :y offset-y})))
 
 
 (defn vertical-center

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -37,8 +37,7 @@
 (defn mouse-offset
   "Finds offset between mouse event and container. If container is not passed, use target as container."
   ([e]
-   (let [container (.. e -target)]
-     (mouse-offset e container)))
+   (mouse-offset e (.. e -target)))
   ([e container]
    (let [rect (.. container getBoundingClientRect)
          offset-x (- (.. e -pageX) (.. rect -left))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -35,12 +35,10 @@
 
 
 (defn mouse-offset
-  "Finds offset coordinates within a container. If container is not passed, assume target is container."
+  "Finds offset between mouse event and container. If container is not passed, use target as container."
   ([e]
-   (let [rect (.. e -target getBoundingClientRect)
-         offset-x (- (.. e -pageX) (.. rect -left))
-         offset-y (- (.. e -pageY) (.. rect -top))]
-     {:x offset-x :y offset-y}))
+   (let [container (.. e -target)]
+     (mouse-offset e container)))
   ([e container]
    (let [rect (.. container getBoundingClientRect)
          offset-x (- (.. e -pageX) (.. rect -left))

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -571,10 +571,12 @@
     (when-not (and related (contains related "tooltip"))
       (swap! state assoc :tooltip false))))
 
+
 (defn bullet-mouse-over
   "Show tooltip."
   [_e _uid state]
   (swap! state assoc :tooltip true))
+
 
 (defn bullet-context-menu
   "Handle right click. If no blocks are selected, just give option for copying current block's uid."
@@ -596,6 +598,7 @@
   (.. e -dataTransfer (setData "text/plain" uid))
   (swap! state assoc :dragging true))
 
+
 (defn bullet-drag-end
   "End drag event."
   [_e _uid state]
@@ -616,6 +619,7 @@
                          :on-mouse-out    (fn [e] (bullet-mouse-out e uid state))
                          :on-drag-start   (fn [e] (bullet-drag-start e uid state))
                          :on-drag-end     (fn [e] (bullet-drag-end e uid state))})])))
+
 
 (defn copy-refs-click
   [_ uid state]
@@ -657,6 +661,7 @@
                       :right "0px"
                       :z-index (:zindex-tooltip ZINDICES)})
      [button {:on-click #(dispatch [:right-sidebar/open-item uid])} count]]))
+
 
 (defn block-drag-over
   [e block state]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -658,22 +658,15 @@
                       :z-index (:zindex-tooltip ZINDICES)})
      [button {:on-click #(dispatch [:right-sidebar/open-item uid])} count]]))
 
-(defn mouse-offset-2
-  [e container]
-  (let [rect (.. container getBoundingClientRect)
-        offset-x (- (.. e -pageX) (.. rect -left))
-        offset-y (- (.. e -pageY) (.. rect -top))]
-    {:x offset-x :y offset-y}))
-
 (defn block-drag-over
   [e block state]
   (.. e preventDefault)
   (.. e stopPropagation)
   ;; if last block-container (i.e. no siblings), allow drop below
   ;; if block or ancestor has css dragging class, do not show drop indicator
-  (let [closest-container (.. e -target (closest ".block-container"))
-        {:keys [x y]} (mouse-offset-2 e closest-container)
-        {:block/keys [children]} block
+  (let [{:block/keys [children]} block
+        closest-container (.. e -target (closest ".block-container"))
+        {:keys [x y]} (mouse-offset e closest-container)
         middle-y (vertical-center closest-container)
         dragging-ancestor (.. e -target (closest ".dragging"))
         not-dragging?     (nil? dragging-ancestor)


### PR DESCRIPTION
- flickering mostly gone
- transition between states smoother
- prevent any drop effect if block/orders wouldn't change, using `no-effect?` condition
- separate and name event handlers: `block-drag-over`, `block-drag-leave`, `block-drop`, `bullet-...`