### PR TITLE
fix(selection): nested opacities for shift+up/down, shift+click, and mousedown+mouseenter

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -407,6 +407,7 @@
         sib
         (recur (:block/uid parent))))))
 
+
 (defn next-block-uid
   "1-arity:
     if child, go to child 0

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -407,17 +407,25 @@
         sib
         (recur (:block/uid parent))))))
 
-;; if child, go to child 0
-;; else recursively find next sibling of parent
 (defn next-block-uid
-  [uid]
-  (let [block (->> (get-block [:block/uid uid])
-                   sort-block-children)
-        ch (:block/children block)
-        next-block-recursive (next-sibling-block-recursively uid)]
-    (cond
-      ch (:block/uid (first ch))
-      next-block-recursive (:block/uid next-block-recursive))))
+  "1-arity:
+    if child, go to child 0
+    else recursively find next sibling of parent
+  2-arity:
+    used for multi-block-selection; ignores child blocks"
+  ([uid]
+   (let [block                (->> (get-block [:block/uid uid])
+                                   sort-block-children)
+         ch                   (:block/children block)
+         next-block-recursive (next-sibling-block-recursively uid)]
+     (cond
+       ch (:block/uid (first ch))
+       next-block-recursive (:block/uid next-block-recursive))))
+  ([uid selection?]
+   (if selection?
+     (let [next-block-recursive (next-sibling-block-recursively uid)]
+       next-block-recursive (:block/uid next-block-recursive))
+     (next-block-uid uid))))
 
 ;; history
 

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -29,6 +29,7 @@
                :right-sidebar/open  false
                :right-sidebar/items {}
                ;;:dragging-global     false
+               :mouse-down false
                :daily-notes/items   []
                :selected/items   []})
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -152,6 +152,7 @@
         n               (count selected-items)
         new-items (cond
                     ;; if prev-block is root node TODO: (OR context root), don't do anything
+                    (and (zero? editing-idx) (> n 1)) (pop selected-items)
                     (:node/title prev-block) selected-items
                     ;; if prev block is parent, replace editing/uid and first item w parent; remove children
                     (= (:block/uid parent) prev-block-uid-) (let [parent-children (-> (map #(:block/uid %) (:block/children parent))
@@ -160,7 +161,6 @@
                                                                                           selected-items)
                                                                   new-vec         (into [prev-block-uid-] to-keep)]
                                                               new-vec)
-                    (and (zero? editing-idx) (> n 1)) (pop selected-items)
                     :else (into [prev-block-uid-] selected-items))]
     new-items))
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -72,10 +72,12 @@
   (fn [db [_ item]]
     (update-in db [:right-sidebar/items item :open] not)))
 
+
 (reg-event-db
   :mouse-down/set
   (fn [db _]
     (assoc db :mouse-down true)))
+
 
 (reg-event-db
   :mouse-down/unset
@@ -118,6 +120,7 @@
   :selected/add-item
   (fn [db [_ uid]]
     (update db :selected/items conj uid)))
+
 
 (reg-event-db
   :selected/remove-item

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -168,7 +168,6 @@
         next-block-uid-    (assoc db :selected/items (conj selected-items next-block-uid-))))))
 
 
-
 ;; TODO: minus-after to reindex but what about nested blocks?
 (reg-event-fx
   :selected/delete

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -129,45 +129,44 @@
     (let [first-item (first selected-items)
           prev-block-uid- (db/prev-block-uid first-item)
           prev-block (db/get-block [:block/uid prev-block-uid-])
-          parent (db/get-parent [:block/uid first-item])]
-          ;;new-vec (cond
-          ;;         ;; if prev-block is root node TODO: (OR context root), don't do anything
-          ;;          (:node/title prev-block) selected-items
-          ;;         ;; if prev block is parent, replace editing/uid and first item w parent; remove children
-          ;;         (= (:block/uid parent) prev-block-uid-) (do
-          ;;                                                   (prn "replace" selected-items (:block/children prev-block))
-          ;;                                                   {:dispatch [:editing/uid prev-block-uid-]}
-          ;;                                                   selected-items)
-          ;;         :else (into [prev-block-uid-] selected-items))]
-          ;;         ;;:else (into [prev-block-uid-] selected-items))]
-         (cond
-           (:node/title prev-block) {:db (assoc db :selected/items selected-items)}
-           ;; if prev block is parent, replace editing/uid and first item w parent; remove children
-           (= (:block/uid parent) prev-block-uid-) (let [parent-children (-> (map #(:block/uid %) (:block/children parent))
-                                                                             set)
-                                                         to-keep (filter (fn [x] (not (contains? parent-children x)))
-                                                                         selected-items)
-                                                         new-vec (into [prev-block-uid-] to-keep)]
-                                                     {:dispatch [:editing/uid prev-block-uid-]
-                                                      :db       (assoc db :selected/items new-vec)})
-           :else {:db (assoc db :selected/items (into [prev-block-uid-] selected-items))}))))
+          parent (db/get-parent [:block/uid first-item])
+          editing-uid @(subscribe [:editing/uid])
+          editing-idx (first (keep-indexed (fn [idx x]
+                                             (when (= x editing-uid)
+                                               idx))
+                                           selected-items))
+          n (count selected-items)]
+      (cond
+        ;; if prev-block is root node TODO: (OR context root), don't do anything
+        (:node/title prev-block)          {:db (assoc db :selected/items selected-items)}
+        ;; if prev block is parent, replace editing/uid and first item w parent; remove children
+        (= (:block/uid parent) prev-block-uid-) (let [parent-children (-> (map #(:block/uid %) (:block/children parent))
+                                                                          set)
+                                                      to-keep (filter (fn [x] (not (contains? parent-children x)))
+                                                                      selected-items)
+                                                      new-vec (into [prev-block-uid-] to-keep)]
+                                                  {:dispatch [:editing/uid prev-block-uid-]
+                                                   :db       (assoc db :selected/items new-vec)})
+        (and (zero? editing-idx) (> n 1)) {:db (assoc db :selected/items (pop selected-items))}
+        :else                             {:db (assoc db :selected/items (into [prev-block-uid-] selected-items))}))))
 
 
-;; if user presses down and they had previously pressed up, most recently selected block should become unselected
-;; on hand we have: editing/uid and a vector of uids. if editing/uid is not at the front of the vector, we should
-;; pop off the front of the vector.
-;; if pressing down but editing/uid is at the top of the vect, then just conj to vect
 ;; using a set or a hash map, we would need a secondary editing/uid to maintain the head/tail position
 ;; this would let us know if the operation is additive or subtractive
 (reg-event-db
   :selected/down
   (fn [db [_ selected-items]]
-    (let [last-item (last selected-items)
-          next-block-uid- (db/next-block-uid last-item)
-          new-vec (conj selected-items next-block-uid-)]
-      ;; if next-block-uid- is nil, no op
-      (when next-block-uid-
-        (assoc db :selected/items new-vec)))))
+    (let [editing-uid @(subscribe [:editing/uid])
+          editing-idx (first (keep-indexed (fn [idx x]
+                                             (when (= x editing-uid)
+                                               idx))
+                                           selected-items))
+          last-item (last selected-items)
+          next-block-uid- (db/next-block-uid last-item true)]
+      (cond
+        (pos? editing-idx) (assoc db :selected/items (subvec selected-items 1))
+        next-block-uid-    (assoc db :selected/items (conj selected-items next-block-uid-))))))
+
 
 
 ;; TODO: minus-after to reindex but what about nested blocks?

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -72,6 +72,15 @@
   (fn [db [_ item]]
     (update-in db [:right-sidebar/items item :open] not)))
 
+(reg-event-db
+  :mouse-down/set
+  (fn [db _]
+    (assoc db :mouse-down true)))
+
+(reg-event-db
+  :mouse-down/unset
+  (fn [db _]
+    (assoc db :mouse-down false)))
 
 ;; TODO: dec all indices > closed item
 (reg-event-db
@@ -110,6 +119,12 @@
   (fn [db [_ uid]]
     (update db :selected/items conj uid)))
 
+(reg-event-db
+  :selected/remove-item
+  (fn [db [_ uid]]
+    (let [items (:selected/items db)]
+      (assoc db :selected/items (filterv #(not= % uid) items)))))
+
 
 (reg-event-db
   :selected/add-items
@@ -145,8 +160,7 @@
                                                       to-keep (filter (fn [x] (not (contains? parent-children x)))
                                                                       selected-items)
                                                       new-vec (into [prev-block-uid-] to-keep)]
-                                                  {:dispatch [:editing/uid prev-block-uid-]
-                                                   :db       (assoc db :selected/items new-vec)})
+                                                  {:db       (assoc db :selected/items new-vec)})
         (and (zero? editing-idx) (> n 1)) {:db (assoc db :selected/items (pop selected-items))}
         :else                             {:db (assoc db :selected/items (into [prev-block-uid-] selected-items))}))))
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -182,7 +182,8 @@
         next-block-uid- (db/next-block-uid last-item true)]
     (cond
       (pos? editing-idx) (subvec selected-items 1)
-      next-block-uid-    (conj selected-items next-block-uid-))))
+      next-block-uid-    (conj selected-items next-block-uid-)
+      :else selected-items)))
 
 
 ;; using a set or a hash map, we would need a secondary editing/uid to maintain the head/tail position

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -222,7 +222,6 @@
               (or (and up? top-row?)
                   (and down? bottom-row?)) (do
                                              (.. target blur)
-                                             ;;(dispatch [:editing/uid nil])
                                              (dispatch [:selected/add-item uid])))
 
       ;; Type, one of #{:slash :block :page}: If slash commands or inline search is open, cycle through options

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -222,7 +222,7 @@
               (or (and up? top-row?)
                   (and down? bottom-row?)) (do
                                              (.. target blur)
-                                             (dispatch [:editing/uid nil])
+                                             ;;(dispatch [:editing/uid nil])
                                              (dispatch [:selected/add-item uid])))
 
       ;; Type, one of #{:slash :block :page}: If slash commands or inline search is open, cycle through options

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -46,7 +46,7 @@
 
 (defn unfocus
   [e]
-  (let [selected-items? (boolean @(subscribe [:selected/items]))
+  (let [selected-items? (not-empty @(subscribe [:selected/items]))
         editing-uid    @(subscribe [:editing/uid])
         closest-block (.. e -target (closest ".block-content"))
         closest-block-header (.. e -target (closest ".block-header"))
@@ -135,7 +135,6 @@
 
 (defn init
   []
-  ;; (events/listen js/window EventType.MOUSEDOWN edit-block)
   (events/listen js/document EventType.MOUSEDOWN unfocus)
   (events/listen js/window EventType.CLICK click-outside-athena)
   (events/listen js/window EventType.KEYDOWN multi-block-selection)

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -42,8 +42,6 @@
                                 (dispatch [:down (last selected-items)])))))))
 
 
-
-
 ;; -- When user clicks elsewhere -----------------------------------------
 
 (defn unfocus

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -69,11 +69,11 @@
   (fn-traced [db _]
              (:right-sidebar/items db)))
 
+
 (re-frame/reg-sub
   :mouse-down
   (fn [db _]
-     (:mouse-down db)))
-
+    (:mouse-down db)))
 
 
 (re-frame/reg-sub

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -101,7 +101,7 @@
   (fn [_]
     [(subscribe [:selected/items])])
   (fn [[selected-items] [_ uid]]
-    ((set selected-items) uid)))
+    (contains? (set selected-items) uid)))
 
 
 (re-frame/reg-sub

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -69,6 +69,12 @@
   (fn-traced [db _]
              (:right-sidebar/items db)))
 
+(re-frame/reg-sub
+  :mouse-down
+  (fn [db _]
+     (:mouse-down db)))
+
+
 
 (re-frame/reg-sub
   :merge-prompt

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -68,6 +68,13 @@
     (.. element (scrollIntoView align-top? {:behavior "auto"}))))
 
 
+(defn get-dataset-uid
+  [el]
+  (let [block (when el (.. el (closest ".block-container")))
+        uid (when block (.. block -dataset -uid))]
+    uid))
+
+
 ;; -- Date and Time ------------------------------------------------------
 
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -754,10 +754,13 @@
   (let [{target-uid :block/uid} block
         {:keys [drag-target]} @state
         source-uid (.. e -dataTransfer (getData "text/plain"))
+        effect-allowed (.. e -dataTransfer -effectAllowed)
         valid-drop (and (not (nil? drag-target))
-                        (not= source-uid target-uid))]
+                        (not= source-uid target-uid)
+                        (= effect-allowed "move"))]
     (when valid-drop
       (dispatch [:drop-bullet source-uid target-uid drag-target]))
+    (dispatch [:mouse-down/unset])
     (swap! state assoc :drag-target nil)))
 
 


### PR DESCRIPTION
- fixes #326 for shift+up/down, shift+click, and mousedown+mouseenter
- fixes bug where drag and drop with selected text in textarea crashes app
- UI: comments out `hover` and `is-editing` opacities, to make selected blocks easier
- TODO: some behavior for indent, cut, and backspace when multi-selected blocks (especially indexing, order)
- TODO: reorganize blocks and listeners