### PR TITLE
fix(selection): indent and unindent multiple blocks

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -266,6 +266,30 @@
       get-block))
 
 
+(defn get-older-sib
+  "Given a block and a parent, find the older sibling.
+  Rfct: can be rewritten with just `block` parameter, and could use a check if it is oldest sibling (block zero)."
+  [block parent]
+  (->> parent
+       :block/children
+       (filter #(= (dec (:block/order block)) (:block/order %)))
+       first
+       :db/id
+       get-block))
+
+
+(defn same-parent?
+  "Given a coll of uids, determine if uids are all direct children of the same parent."
+  [uids]
+  (let [parents (d/q '[:find ?parents
+                       :in $ [?uids ...]
+                       :where
+                       [?e :block/uid ?uids]
+                       [?parents :block/children ?e]]
+                     @dsdb uids)]
+    (= (count parents) 1)))
+
+
 (defn deepest-child-block
   [id]
   (let [document (->> @(pull dsdb '[:block/order :block/uid {:block/children ...}] id))]

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -250,13 +250,10 @@
 (defn handle-tab
   [e uid]
   (.. e preventDefault)
-  (let [{:keys [shift]} (destruct-event e)
-        ;; xxx: probably makes more sense to pass block value to handler directly
-        block-zero? (zero? (:block/order (db/get-block [:block/uid uid])))]
-    (cond
-      shift (dispatch [:unindent uid])
-      :else (when-not block-zero?
-              (dispatch [:indent uid])))))
+  (let [{:keys [shift]} (destruct-event e)]
+    (if shift
+      (dispatch [:unindent uid])
+      (dispatch [:indent uid]))))
 
 
 (defn handle-escape

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -51,16 +51,15 @@
 
 
 (def ARROW-KEYS
-  {KeyCodes.UP    :up
-   KeyCodes.LEFT  :left
-   KeyCodes.DOWN  :down
-   KeyCodes.RIGHT :right})
+  #{KeyCodes.UP
+    KeyCodes.LEFT
+    KeyCodes.DOWN
+    KeyCodes.RIGHT})
 
 
 (defn arrow-key-direction
   [e]
-  (let [key-code (.. e -keyCode)]
-    (ARROW-KEYS key-code)))
+  (contains? ARROW-KEYS (.. e -keyCode)))
 
 
 ;;; Dropdown: inline-search and slash commands
@@ -248,12 +247,19 @@
 ;;; Tab
 
 (defn handle-tab
-  [e uid]
+  "Bug: indenting sets the cursor position to 0, liekely because a new textarea element is created on the DOM. Set selection appropriately.
+  See :indent event for why value must be passed as well."
+  [e uid _state]
   (.. e preventDefault)
-  (let [{:keys [shift]} (destruct-event e)]
+  (let [{:keys [shift value start end]} (destruct-event e)]
     (if shift
-      (dispatch [:unindent uid])
-      (dispatch [:indent uid]))))
+      (dispatch [:unindent uid value])
+      (dispatch [:indent uid value]))
+    (js/setTimeout (fn []
+                     (when-let [el (getElement (str "editable-uid-" uid))]
+                       (setStart el start)
+                       (setEnd el end)))
+                   50)))
 
 
 (defn handle-escape
@@ -416,7 +422,7 @@
     (cond
       (arrow-key-direction e)         (handle-arrow-key e uid state)
       (pair-char? e)                  (handle-pair-char e uid state)
-      (= key-code KeyCodes.TAB)       (handle-tab e uid)
+      (= key-code KeyCodes.TAB)       (handle-tab e uid state)
       (= key-code KeyCodes.ENTER)     (handle-enter e uid state)
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
       (= key-code KeyCodes.ESC)       (handle-escape e state)

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -144,7 +144,6 @@
 
 (defn init
   []
-  ;; (events/listen js/window EventType.MOUSEDOWN edit-block)
   (events/listen js/document EventType.MOUSEDOWN unfocus)
   (events/listen js/window EventType.CLICK click-outside-athena)
   (events/listen js/window EventType.KEYDOWN multi-block-selection)

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -1,7 +1,6 @@
 (ns athens.listeners
   (:require
     [athens.db :refer [dsdb]]
-    [athens.keybindings :refer [arrow-key-direction]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as string]
@@ -39,7 +38,9 @@
           bksp? (dispatch [:selected/delete selected-items])
           tab? (do
                  (.preventDefault e)
-                 (dispatch [:indent/multi selected-items]))
+                 (if shift
+                   (dispatch [:unindent/multi selected-items])
+                   (dispatch [:indent/multi selected-items])))
           (and shift up?) (dispatch [:selected/up selected-items])
           (and shift down?) (dispatch [:selected/down selected-items])
           (or up? down?) (do

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -14,32 +14,40 @@
       KeyCodes)))
 
 
-;; -- shift-up/down when multi-block selection ---------------------------
-
-;; can no longer use on-key-down from keybindings.cljs. textarea is no longer focused, so events must be handled globally
 (defn multi-block-selection
+  "When blocks are selected, handle various keypresses:
+  - shift+up/down: increase/decrease selection.
+  - enter: deselect and begin editing textarea
+  - backspace: delete all blocks
+  - up/down: change editing textarea
+  - tab: indent/unindent blocks
+  Can't use textarea-key-down from keybindings.cljs because textarea is no longer focused."
   [e]
   (let [selected-items @(subscribe [:selected/items])]
     (when (not-empty selected-items)
       (let [shift     (.. e -shiftKey)
             key-code (.. e -keyCode)
-            direction (arrow-key-direction e)]
-        ;; what should tab/shift-tab do? roam and workflowy have slightly different behavior
+            enter? (= key-code KeyCodes.ENTER)
+            bksp? (= key-code KeyCodes.BACKSPACE)
+            up? (= key-code KeyCodes.UP)
+            down? (= key-code KeyCodes.DOWN)
+            tab? (= key-code KeyCodes.TAB)]
         (cond
-          (= key-code KeyCodes.ENTER) (do
-                                        (dispatch [:editing/uid (first selected-items)])
-                                        (dispatch [:selected/clear-items]))
-          (= key-code KeyCodes.BACKSPACE) (dispatch [:selected/delete selected-items])
-          (and shift (= direction :up)) (dispatch [:selected/up selected-items])
-          (and shift (= direction :down)) (dispatch [:selected/down selected-items])
-          (= direction :up) (do
-                              (.preventDefault e)
-                              (dispatch [:selected/clear-items])
-                              (dispatch [:up (first selected-items)]))
-          (= direction :down) (do
-                                (.preventDefault e)
-                                (dispatch [:selected/clear-items])
-                                (dispatch [:down (last selected-items)])))))))
+          enter? (do
+                   (dispatch [:editing/uid (first selected-items)])
+                   (dispatch [:selected/clear-items]))
+          bksp? (dispatch [:selected/delete selected-items])
+          tab? (do
+                 (.preventDefault e)
+                 (dispatch [:indent/multi selected-items]))
+          (and shift up?) (dispatch [:selected/up selected-items])
+          (and shift down?) (dispatch [:selected/down selected-items])
+          (or up? down?) (do
+                           (.preventDefault e)
+                           (dispatch [:selected/clear-items])
+                           (if up?
+                             (dispatch [:up (first selected-items)])
+                             (dispatch [:down (last selected-items)]))))))))
 
 
 ;; -- When user clicks elsewhere -----------------------------------------
@@ -135,6 +143,7 @@
 
 (defn init
   []
+  ;; (events/listen js/window EventType.MOUSEDOWN edit-block)
   (events/listen js/document EventType.MOUSEDOWN unfocus)
   (events/listen js/window EventType.CLICK click-outside-athena)
   (events/listen js/window EventType.KEYDOWN multi-block-selection)


### PR DESCRIPTION
- currently don't know best way to indent when latter blocks are at a different level in the tree, e.g. https://www.loom.com/share/77e2d4be8fd64fabaf5528fa3d824346
  - so only allow multi-block indent if blocks have same parent
- creates pretty gnarly `indent-multi` and `unindent-multi` fns. very ugly but I think there's a better solution down the line so not optimizing for now.