### PR TITLE
Split focused block into children on enter

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -501,16 +501,20 @@
         tail (subs val index)
         new-uid (gen-block-uid)
         new-block {:db/id        -1
-                   :block/order  (inc (:block/order block))
+                   :block/order  0
                    :block/uid    new-uid
                    :block/open   true
                    :block/string tail}
-        reindex (->> (inc-after (:db/id block) (:block/order block))
+        reindex (->> ((inc-after (:db/id block) -1) (:block/order block))
                      (concat [new-block]))]
     {:fx [[:dispatch [:transact [{:db/id (:db/id block) :block/string head :edit/time (now-ts)}
                                  {:db/id (:db/id block)
                                   :block/children reindex}]]]
           [:dispatch [:editing/uid new-uid]]]}))
+
+
+(comment
+  (inc-after 21 0))
 
 
 (reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -505,16 +505,12 @@
                    :block/uid    new-uid
                    :block/open   true
                    :block/string tail}
-        reindex (->> ((inc-after (:db/id block) -1) (:block/order block))
+        reindex (->> (inc-after (:db/id block) -1)
                      (concat [new-block]))]
     {:fx [[:dispatch [:transact [{:db/id (:db/id block) :block/string head :edit/time (now-ts)}
                                  {:db/id (:db/id block)
                                   :block/children reindex}]]]
           [:dispatch [:editing/uid new-uid]]]}))
-
-
-(comment
-  (inc-after 21 0))
 
 
 (reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -490,6 +490,7 @@
                                   :block/children reindex}]]]
           [:dispatch [:editing/uid new-uid]]]}))
 
+
 (defn split-block-to-children
   "Takes a block uid, its value, and the index to split the value string.
   It sets the value of the block to the head of (subs val 0 index)
@@ -511,10 +512,12 @@
                                   :block/children reindex}]]]
           [:dispatch [:editing/uid new-uid]]]}))
 
+
 (reg-event-fx
- :split-block-to-children
- (fn [_ [_ uid val index]]
-   (split-block-to-children uid val index)))
+  :split-block-to-children
+  (fn [_ [_ uid val index]]
+    (split-block-to-children uid val index)))
+
 
 (defn bump-up
   "If user presses enter at the start of non-empty string, push that block down and

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -73,18 +73,12 @@
 
 ;;; Components
 
+
 (defn handle-enter
-  [e uid _]
-  (let [new-uid (gen-block-uid)
-        now (now-ts)]
+  [e uid _state]
+  (let [{:keys [start value]} (destruct-event e)]
     (.. e preventDefault)
-    (dispatch [:transact [{:block/uid      uid
-                           :edit/time      now
-                           :block/children [{:block/order  0
-                                             :block/uid    new-uid
-                                             :block/open   true
-                                             :block/string ""}]}]])
-    (dispatch [:editing/uid new-uid])))
+    (dispatch [:split-block-to-children uid value start])))
 
 
 (defn block-page-key-down

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -5,7 +5,6 @@
     [athens.keybindings :refer [destruct-event]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color]]
-    [athens.util :refer [now-ts gen-block-uid]]
     [athens.views.blocks :refer [block-el]]
     [cljsjs.react]
     [cljsjs.react.dom]


### PR DESCRIPTION
Adds this functionality:

![Screen Recording 2020-09-21 at 05 50 PM](https://user-images.githubusercontent.com/4407263/93825264-eb08ac80-fc32-11ea-8362-d45397ea3e31.gif)




![](https://media1.giphy.com/media/kKzFYlqCv7yDe/giphy.gif?cid=5a38a5a2ni7q2s3sm8sdf47ggqrybqf2fiw35mi41zr5z718&rid=giphy.gif)
