### PR TITLE
feat: clicking outside closes out of dropdowns

### DIFF
--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -67,16 +67,6 @@
       (dispatch [:editing/uid nil]))))
 
 
-;; -- Close Athena -------------------------------------------------------
-
-(defn click-outside-athena
-  [e]
-  (let [athena? @(subscribe [:athena/open])
-        closest (.. e -target (closest ".athena"))]
-    (when (and athena? (nil? closest))
-      (dispatch [:athena/toggle]))))
-
-
 ;; -- Hotkeys ------------------------------------------------------------
 
 
@@ -145,7 +135,6 @@
 (defn init
   []
   (events/listen js/document EventType.MOUSEDOWN unfocus)
-  (events/listen js/window EventType.CLICK click-outside-athena)
   (events/listen js/window EventType.KEYDOWN multi-block-selection)
   (events/listen js/window EventType.KEYDOWN key-down)
   (events/listen js/window EventType.COPY copy)

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -283,64 +283,65 @@
       {:display-name           "athena"
        :component-did-mount    (fn [_this] (events/listen js/document "mousedown" handle-click-outside))
        :component-will-unmount (fn [_this] (events/unlisten js/document "mousedown" handle-click-outside))
-       :reagent-render         (fn [] (let [open?          @(subscribe [:athena/open])
-                                            s              (r/atom {:index   0
-                                                                    :query   nil
-                                                                    :results []})
-                                            search-handler (debounce (create-search-handler s) 500)]
-                                        (when open?
-                                          [:div.athena (use-style container-style
-                                                                  {:ref #(reset! ref %)})
-                                           [:header {:style {:position "relative"}}
-                                            [:input (use-style athena-input-style
-                                                               {:type        "search"
-                                                                :id          "athena-input"
-                                                                :auto-focus  true
-                                                                :required    true
-                                                                :placeholder "Find or Create Page"
-                                                                :on-change   (fn [e] (search-handler (.. e -target -value)))
-                                                                :on-key-down (fn [e] (key-down-handler e s))})]
-                                            [:button (use-style search-cancel-button-style
-                                                                {:on-click #(set! (.-value (getElement "athena-input")))})
-                                             [:> mui-icons/Close]]]
-                                           [results-el s]
-                                           [(fn []
-                                              (let [{:keys [results query index]} @s]
-                                                [:div (use-style results-list-style)
-                                                 (doall
-                                                   (for [[i x] (map-indexed list results)
-                                                         :let [parent (:block/parent x)
-                                                               title  (or (:node/title parent) (:node/title x))
-                                                               uid    (or (:block/uid parent) (:block/uid x))
-                                                               string (:block/string x)]]
-                                                     (if (nil? x)
-                                                       ^{:key i}
-                                                       [:div (use-style result-style {:on-click (fn [_]
-                                                                                                  (let [uid (gen-block-uid)]
-                                                                                                    (dispatch [:athena/toggle])
-                                                                                                    (dispatch [:page/create query uid])
-                                                                                                    (navigate-uid uid)))
-                                                                                      :class    (when (= i index) "selected")})
+       :reagent-render         (fn []
+                                 (let [open?          @(subscribe [:athena/open])
+                                       s              (r/atom {:index   0
+                                                               :query   nil
+                                                               :results []})
+                                       search-handler (debounce (create-search-handler s) 500)]
+                                   (when open?
+                                     [:div.athena (use-style container-style
+                                                             {:ref #(reset! ref %)})
+                                      [:header {:style {:position "relative"}}
+                                       [:input (use-style athena-input-style
+                                                          {:type        "search"
+                                                           :id          "athena-input"
+                                                           :auto-focus  true
+                                                           :required    true
+                                                           :placeholder "Find or Create Page"
+                                                           :on-change   (fn [e] (search-handler (.. e -target -value)))
+                                                           :on-key-down (fn [e] (key-down-handler e s))})]
+                                       [:button (use-style search-cancel-button-style
+                                                           {:on-click #(set! (.-value (getElement "athena-input")))})
+                                        [:> mui-icons/Close]]]
+                                      [results-el s]
+                                      [(fn []
+                                         (let [{:keys [results query index]} @s]
+                                           [:div (use-style results-list-style)
+                                            (doall
+                                              (for [[i x] (map-indexed list results)
+                                                    :let [parent (:block/parent x)
+                                                          title  (or (:node/title parent) (:node/title x))
+                                                          uid    (or (:block/uid parent) (:block/uid x))
+                                                          string (:block/string x)]]
+                                                (if (nil? x)
+                                                  ^{:key i}
+                                                  [:div (use-style result-style {:on-click (fn [_]
+                                                                                             (let [uid (gen-block-uid)]
+                                                                                               (dispatch [:athena/toggle])
+                                                                                               (dispatch [:page/create query uid])
+                                                                                               (navigate-uid uid)))
+                                                                                 :class    (when (= i index) "selected")})
 
-                                                        [:div (use-style result-body-style)
-                                                         [:h4.title (use-sub-style result-style :title)
-                                                          [:b "Create Page: "]
-                                                          query]]
-                                                        [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
+                                                   [:div (use-style result-body-style)
+                                                    [:h4.title (use-sub-style result-style :title)
+                                                     [:b "Create Page: "]
+                                                     query]]
+                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
 
-                                                       [:div (use-style result-style {:key      i
-                                                                                      :on-click (fn []
-                                                                                                  (let [selected-page {:node/title   title
-                                                                                                                       :block/uid    uid
-                                                                                                                       :block/string string
-                                                                                                                       :query        query}]
-                                                                                                    (dispatch [:athena/toggle])
-                                                                                                    (dispatch [:athena/update-recent-items selected-page])
-                                                                                                    (navigate-uid uid)))
-                                                                                      :class    (when (= i index) "selected")})
-                                                        [:div (use-style result-body-style)
+                                                  [:div (use-style result-style {:key      i
+                                                                                 :on-click (fn []
+                                                                                             (let [selected-page {:node/title   title
+                                                                                                                  :block/uid    uid
+                                                                                                                  :block/string string
+                                                                                                                  :query        query}]
+                                                                                               (dispatch [:athena/toggle])
+                                                                                               (dispatch [:athena/update-recent-items selected-page])
+                                                                                               (navigate-uid uid)))
+                                                                                 :class    (when (= i index) "selected")})
+                                                   [:div (use-style result-body-style)
 
-                                                         [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
-                                                         (when string
-                                                           [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
-                                                        [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]])))})))
+                                                    [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
+                                                    (when string
+                                                      [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
+                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]])))})))

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -12,6 +12,7 @@
     [clojure.string :as str]
     [garden.selectors :as selectors]
     [goog.dom :refer [getElement]]
+    [goog.events :as events]
     [goog.functions :refer [debounce]]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
@@ -273,63 +274,73 @@
 
 (defn athena-component
   []
-  (let [open? @(subscribe [:athena/open])
-        s (r/atom {:index 0
-                   :query nil
-                   :results []})
-        search-handler (debounce (create-search-handler s) 500)]
-    (when open?
-      [:div.athena (use-style container-style)
-       [:header {:style {:position "relative"}}
-        [:input (use-style athena-input-style
-                           {:type        "search"
-                            :id          "athena-input"
-                            :auto-focus  true
-                            :required    true
-                            :placeholder "Find or Create Page"
-                            :on-change   (fn [e] (search-handler (.. e -target -value)))
-                            :on-key-down (fn [e] (key-down-handler e s))})]
-        [:button (use-style search-cancel-button-style
-                            {:on-click #(set! (.-value (getElement "athena-input")))})
-         [:> mui-icons/Close]]]
-       [results-el s]
-       [(fn []
-          (let [{:keys [results query index]} @s]
-            [:div (use-style results-list-style)
-             (doall
-               (for [[i x] (map-indexed list results)
-                     :let [parent (:block/parent x)
-                           title  (or (:node/title parent) (:node/title x))
-                           uid    (or (:block/uid parent) (:block/uid x))
-                           string (:block/string x)]]
-                 (if (nil? x)
-                   ^{:key i}
-                   [:div (use-style result-style {:on-click (fn [_]
-                                                              (let [uid (gen-block-uid)]
-                                                                (dispatch [:athena/toggle])
-                                                                (dispatch [:page/create query uid])
-                                                                (navigate-uid uid)))
-                                                  :class (when (= i index) "selected")})
+  (let [ref                  (atom nil)
+        handle-click-outside (fn [e]
+                               (when (and @(subscribe [:athena/open])
+                                          (not (.. @ref (contains (.. e -target)))))
+                                 (dispatch [:athena/toggle])))]
+    (r/create-class
+      {:display-name           "athena"
+       :component-did-mount    (fn [_this] (events/listen js/document "mousedown" handle-click-outside))
+       :component-will-unmount (fn [_this] (events/unlisten js/document "mousedown" handle-click-outside))
+       :reagent-render         (fn [] (let [open?          @(subscribe [:athena/open])
+                                            s              (r/atom {:index   0
+                                                                    :query   nil
+                                                                    :results []})
+                                            search-handler (debounce (create-search-handler s) 500)]
+                                        (when open?
+                                          [:div.athena (use-style container-style
+                                                                  {:ref #(reset! ref %)})
+                                           [:header {:style {:position "relative"}}
+                                            [:input (use-style athena-input-style
+                                                               {:type        "search"
+                                                                :id          "athena-input"
+                                                                :auto-focus  true
+                                                                :required    true
+                                                                :placeholder "Find or Create Page"
+                                                                :on-change   (fn [e] (search-handler (.. e -target -value)))
+                                                                :on-key-down (fn [e] (key-down-handler e s))})]
+                                            [:button (use-style search-cancel-button-style
+                                                                {:on-click #(set! (.-value (getElement "athena-input")))})
+                                             [:> mui-icons/Close]]]
+                                           [results-el s]
+                                           [(fn []
+                                              (let [{:keys [results query index]} @s]
+                                                [:div (use-style results-list-style)
+                                                 (doall
+                                                   (for [[i x] (map-indexed list results)
+                                                         :let [parent (:block/parent x)
+                                                               title  (or (:node/title parent) (:node/title x))
+                                                               uid    (or (:block/uid parent) (:block/uid x))
+                                                               string (:block/string x)]]
+                                                     (if (nil? x)
+                                                       ^{:key i}
+                                                       [:div (use-style result-style {:on-click (fn [_]
+                                                                                                  (let [uid (gen-block-uid)]
+                                                                                                    (dispatch [:athena/toggle])
+                                                                                                    (dispatch [:page/create query uid])
+                                                                                                    (navigate-uid uid)))
+                                                                                      :class    (when (= i index) "selected")})
 
-                    [:div (use-style result-body-style)
-                     [:h4.title (use-sub-style result-style :title)
-                      [:b "Create Page: "]
-                      query]]
-                    [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
+                                                        [:div (use-style result-body-style)
+                                                         [:h4.title (use-sub-style result-style :title)
+                                                          [:b "Create Page: "]
+                                                          query]]
+                                                        [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
 
-                   [:div (use-style result-style {:key      i
-                                                  :on-click (fn []
-                                                              (let [selected-page {:node/title   title
-                                                                                   :block/uid    uid
-                                                                                   :block/string string
-                                                                                   :query        query}]
-                                                                (dispatch [:athena/toggle])
-                                                                (dispatch [:athena/update-recent-items selected-page])
-                                                                (navigate-uid uid)))
-                                                  :class    (when (= i index) "selected")})
-                    [:div (use-style result-body-style)
+                                                       [:div (use-style result-style {:key      i
+                                                                                      :on-click (fn []
+                                                                                                  (let [selected-page {:node/title   title
+                                                                                                                       :block/uid    uid
+                                                                                                                       :block/string string
+                                                                                                                       :query        query}]
+                                                                                                    (dispatch [:athena/toggle])
+                                                                                                    (dispatch [:athena/update-recent-items selected-page])
+                                                                                                    (navigate-uid uid)))
+                                                                                      :class    (when (= i index) "selected")})
+                                                        [:div (use-style result-body-style)
 
-                     [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
-                     (when string
-                       [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
-                    [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]])))
+                                                         [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
+                                                         (when string
+                                                           [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
+                                                        [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]])))})))

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -728,7 +728,7 @@
 
 (defn context-menu-el
   "Only option in context menu right now is copy block ref(s)."
-  [block state]
+  [_block state]
   (let [ref (atom nil)
         handle-click-outside (fn [e]
                                (when (and (:context-menu/show @state)
@@ -846,7 +846,7 @@
 
     (fn [block]
       (let [{:block/keys [uid string open children _refs]} block
-            {:search/keys [type] :keys [dragging drag-target]} @state
+            {:search/keys [] :keys [dragging drag-target]} @state
             is-editing @(subscribe [:editing/is-editing uid])
             is-selected @(subscribe [:selected/is-selected uid])]
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -703,19 +703,30 @@
 (defn context-menu-el
   "Only option in context menu right now is copy block ref(s)."
   [block state]
-  (let [{:block/keys [uid]} block
-        {:context-menu/keys [show x y]} @state]
-    (when show
-      [:div (merge (use-style dropdown-style)
-                   {:style {:position "fixed"
-                            :x        (str x "px")
-                            :y        (str y "px")}})
-       [:div (use-style menu-style)
-        ;; TODO: create listener that lets user exit context menu if click outside
-        [button {:on-click (fn [e] (copy-refs-click e uid state))}
-         (case show
-           :one "Copy block ref"
-           :many "Copy block refs")]]])))
+  (let [ref (atom nil)
+        handle-click-outside (fn [e]
+                               (when (and (:context-menu/show @state)
+                                          (not (.. @ref (contains (.. e -target)))))
+                                 (swap! state assoc :context-menu/show false)))]
+    (r/create-class
+      {:display-name "context-menu"
+       :component-did-mount (fn [_this] (events/listen js/document "mousedown" handle-click-outside))
+       :component-will-unmount (fn [_this] (events/unlisten js/document "mousedown" handle-click-outside))
+       :reagent-render (fn [block state]
+                         (let [{:block/keys [uid]} block
+                               {:context-menu/keys [show x y]} @state]
+                           (when show
+                             [:div (merge (use-style dropdown-style
+                                                     {:ref #(reset! ref %)})
+                                          {:style {:position "fixed"
+                                                   :x        (str x "px")
+                                                   :y        (str y "px")}})
+                              [:div (use-style menu-style)
+                               ;; TODO: create listener that lets user exit context menu if click outside
+                               [button {:on-click (fn [e] (copy-refs-click e uid state))}
+                                (case show
+                                  :one "Copy block ref"
+                                  :many "Copy block refs")]]])))})))
 
 
 (defn block-refs-count-el

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -291,7 +291,7 @@
 
 
 (defn menu-dropdown
-  [block state]
+  [_block state]
   (let [ref                  (atom nil)
         handle-click-outside (fn [e]
                                (when (and (:menu/show @state)


### PR DESCRIPTION
closes #328

- [x] `context-menu` when clicking on bullets
- [x] page menu
- [x] inline search
- [x] slash command menu
- [x] though not a dropdown, Athena could use this too

Implemented using Reagent lifecycle methods](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md) and [refs](https://medium.com/@pitipatdop/little-neat-trick-to-capture-click-outside-react-component-5604830beb7f).

Not using React Hooks but probably could. Haven't using Hooks from Reagent yet but it requires some extra steps, I believe.

Made a weak attempt at a [generic `dropdown` component](https://gist.github.com/tangjeff0/520c1b7d73213fd6053bd45a16e17c20). Form-3 components have a good amount of boilerplate, and the logic for dropdowns is quite similar. Would probably pass these as parameters for a generic dropdown class:

- `handle-click-outside`
- `display-name`
- `component-fn`