### PR TITLE
fix(enter): split should give new block children rfct(db): prev-older-sib feat(backspace): add nil conditions for backspace feat(delete): delete keydown == backspace next-block feat(delete): add global listener too

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -456,7 +456,7 @@
   If prev-block has children"
   [uid value]
   (let [block           (db/get-block [:block/uid uid])
-        {:block/keys [children order]} block
+        {:block/keys [children order] :or {children []}} block
         parent          (db/get-parent [:block/uid uid])
         reindex         (dec-after (:db/id parent) (:block/order block))
         prev-block-uid- (db/prev-block-uid uid)
@@ -473,8 +473,8 @@
         prev-sib        (db/get-block prev-sib)]
     (cond
       (and (:node/title parent) (zero? order)) nil
-      (and children (not-empty (:block/children prev-sib))) nil
-      (and children (= parent prev-block)) nil
+      (and (not-empty children) (not-empty (:block/children prev-sib))) nil
+      (and (not-empty children) (= parent prev-block)) nil
       :else (let [retract-block  [:db/retractEntity [:block/uid uid]]
                   retracts       (mapv (fn [x] [:db/retract (:db/id block) :block/children (:db/id x)]) children)
                   new-prev-block {:db/id          [:block/uid prev-block-uid-]
@@ -497,7 +497,7 @@
   [uid val index]
   (let [parent     (db/get-parent [:block/uid uid])
         block      (db/get-block [:block/uid uid])
-        {:block/keys [order children]} block
+        {:block/keys [order children] :or {children []}} block
         head       (subs val 0 index)
         tail       (subs val index)
         new-uid    (gen-block-uid)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -478,7 +478,7 @@
                   retracts       (mapv (fn [x] [:db/retract (:db/id block) :block/children (:db/id x)]) children)
                   new-prev-block {:db/id          [:block/uid prev-block-uid-]
                                   :block/string   (str (:block/string prev-block) value)
-                                  :block/children (or children [])}
+                                  :block/children children}
                   new-parent     {:db/id (:db/id parent) :block/children reindex}
                   tx-data        (conj retracts retract-block new-prev-block new-parent)]
               {:dispatch-later [{:ms 0 :dispatch [:transact tx-data]}

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -447,7 +447,6 @@
     {:dispatch [:editing/uid (or (db/next-block-uid uid) uid)]}))
 
 
-
 (defn backspace
   "No-op if root and 0th child.
   No-op if parent is prev-block and block has children.
@@ -484,7 +483,6 @@
                   tx-data        (conj retracts retract-block new-prev-block new-parent)]
               {:dispatch-later [{:ms 0 :dispatch [:transact tx-data]}
                                 {:ms 10 :dispatch [:editing/uid prev-block-uid-]}]}))))
-
 
 
 (reg-event-fx

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -505,6 +505,17 @@
       type (update-query state head key type))))
 
 
+(defn handle-delete
+  [e uid _state]
+  (let [{:keys [start end value]} (destruct-key-down e)
+        no-selection? (= start end)
+        end? (= end (count value))]
+    (when (and no-selection? end?)
+      (let [next-block-uid (db/next-block-uid uid)
+            next-block (db/get-block [:block/uid next-block-uid])]
+        (dispatch [:backspace next-block-uid (:block/string next-block)])))))
+
+
 (defn textarea-key-down
   [e uid state]
   (let [d-event (destruct-key-down e)
@@ -517,6 +528,7 @@
       (= key-code KeyCodes.TAB)       (handle-tab e uid state)
       (= key-code KeyCodes.ENTER)     (handle-enter e uid state)
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
+      (= key-code KeyCodes.DELETE)    (handle-delete e uid state)
       (= key-code KeyCodes.ESC)       (handle-escape e state)
       (or meta ctrl)                  (handle-shortcuts e uid state)
       (is-character-key? e)           (write-char e uid state))))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -506,6 +506,7 @@
 
 
 (defn handle-delete
+  "Delete has the same behavior as pressing backspace on the next block."
   [e uid _state]
   (let [{:keys [start end value]} (destruct-key-down e)
         no-selection? (= start end)

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -24,18 +24,19 @@
   [e]
   (let [selected-items @(subscribe [:selected/items])]
     (when (not-empty selected-items)
-      (let [shift     (.. e -shiftKey)
+      (let [shift    (.. e -shiftKey)
             key-code (.. e -keyCode)
-            enter? (= key-code KeyCodes.ENTER)
-            bksp? (= key-code KeyCodes.BACKSPACE)
-            up? (= key-code KeyCodes.UP)
-            down? (= key-code KeyCodes.DOWN)
-            tab? (= key-code KeyCodes.TAB)]
+            enter?   (= key-code KeyCodes.ENTER)
+            bksp?    (= key-code KeyCodes.BACKSPACE)
+            up?      (= key-code KeyCodes.UP)
+            down?    (= key-code KeyCodes.DOWN)
+            tab?     (= key-code KeyCodes.TAB)
+            delete?  (= key-code KeyCodes.DELETE)]
         (cond
           enter? (do
                    (dispatch [:editing/uid (first selected-items)])
                    (dispatch [:selected/clear-items]))
-          bksp? (dispatch [:selected/delete selected-items])
+          (or bksp? delete?) (dispatch [:selected/delete selected-items])
           tab? (do
                  (.preventDefault e)
                  (if shift

--- a/src/cljs/athens/views/daily_notes.cljs
+++ b/src/cljs/athens/views/daily_notes.cljs
@@ -68,24 +68,17 @@
     (fn []
       (if (empty? @note-refs)
         (dispatch [:daily-note/next (get-day)])
-        (try
-          (let [notes (some->> @note-refs
-                               not-empty
-                               (map (fn [x] [:block/uid x]))
-                               ;; the problem is note-refs from re-frame is updated, and there is a brief period where datascript has not yet updated
-                               ;; and when pull-many doesn't find anything, it throws an error
-                               (pull-many db/dsdb '[*])
-                               deref)]
-            [:div#daily-notes (use-style daily-notes-scroll-area-style)
-             (doall
-               (for [{:keys [block/uid]} notes]
-                 ^{:key uid}
-                 [:<>
-                  [:div (use-style daily-notes-page-style)
-                   [node-page-component [:block/uid uid]]]]))
-             [:div (use-style daily-notes-notional-page-style)
-              [:h1 "Earlier"]]])
-          (catch js/Object e
-            (prn "EXCEPTION" e)))))))
-
-
+        (let [notes (some->> @note-refs
+                             not-empty
+                             (map (fn [x] [:block/uid x]))
+                             (pull-many db/dsdb '[*])
+                             deref)]
+          [:div#daily-notes (use-style daily-notes-scroll-area-style)
+           (doall
+             (for [{:keys [block/uid]} notes]
+               ^{:key uid}
+               [:<>
+                [:div (use-style daily-notes-page-style)
+                 [node-page-component [:block/uid uid]]]]))
+           [:div (use-style daily-notes-notional-page-style)
+            [:h1 "Earlier"]]])))))


### PR DESCRIPTION
fix(enter): split should give new block children
rfct(db): prev-older-sib
feat(backspace): add nil conditions for backspace
feat(delete): delete keydown == backspace next-block
feat(delete): add global listener too