### PR TITLE
fix(block-page): use destruct-key-down instead of destruct-e

### DIFF
--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -75,7 +75,7 @@
 
 (defn handle-enter
   [e uid _state]
-  (let [{:keys [start value]} (athens.keybindings/destruct-event e)]
+  (let [{:keys [start value]} (destruct-key-down e)]
     (.. e preventDefault)
     (dispatch [:split-block-to-children uid value start])))
 


### PR DESCRIPTION
@theianjones the reason why you were getting a linting error in #365 is that the branch was stale. #374 refactors `destruct-e`, so that there is now `destruct-target` and `destruct-key-down`. This PR should fix current build, which was previously using an unresolved symbol. 