### PR TITLE
fix: athena, re-frame, daily-notes guard, right-sidebar, bold caret placement

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -14,6 +14,8 @@
     <!-- <script src="js/compiled/shared.js"></script> -->
     <!-- <script>athens.views.spinner.init_spinner()</script> -->
     <!-- <script src="js/compiled/app.js"></script> -->
+    <script>localStorage.setItem("day8.re-frame-10x.show-panel","\"false\"")</script>
+    <script>localStorage.setItem("day8.re-frame-10x.using-trace?","\"false\"")</script>
     <script src="js/compiled/renderer.js"></script>
   </body>
 </html>

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -88,7 +88,10 @@
 (reg-event-db
   :right-sidebar/close-item
   (fn [db [_ uid]]
-    (update db :right-sidebar/items dissoc uid)))
+    (let [{:right-sidebar/keys [items]} db]
+      (cond-> (update db :right-sidebar/items dissoc uid)
+              (= 1 (count items)) (assoc :right-sidebar/open false)))))
+
 
 
 ;; TODO: change right sidebar items from map to datascript

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -90,8 +90,7 @@
   (fn [db [_ uid]]
     (let [{:right-sidebar/keys [items]} db]
       (cond-> (update db :right-sidebar/items dissoc uid)
-              (= 1 (count items)) (assoc :right-sidebar/open false)))))
-
+        (= 1 (count items)) (assoc :right-sidebar/open false)))))
 
 
 ;; TODO: change right sidebar items from map to datascript

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -384,12 +384,21 @@
 ;; TODO: put text caret in correct position
 (defn handle-shortcuts
   [e _ state]
-  (let [{:keys [key-code head tail selection shift]} (destruct-key-down e)]
+  (let [{:keys [key-code head tail selection shift start end target]} (destruct-key-down e)
+        selection? (not= start end)]
     (cond
       (= key-code KeyCodes.B) (let [new-str (str head (surround selection "**") tail)]
-                                (swap! state assoc :string/local new-str))
+                                (swap! state assoc :string/local new-str)
+                                (if selection?
+                                  (js/setTimeout #(do (setStart target (+ 2 start))
+                                                      (setEnd target (+ 2 end))) 0)
+                                  (js/setTimeout #(setCursorPosition target (+ 2 start)) 0)))
       (and (not shift) (= key-code KeyCodes.I)) (let [new-str (str head (surround selection "__") tail)]
-                                                  (swap! state assoc :string/local new-str)))))
+                                                  (swap! state assoc :string/local new-str)
+                                                  (if selection?
+                                                    (js/setTimeout #(do (setStart target (+ 2 start))
+                                                                        (setEnd target (+ 2 end))) 0)
+                                                    (js/setTimeout #(setCursorPosition target (+ 2 start)) 0))))))
 
 
 (defn pair-char?

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -185,7 +185,8 @@
       (and shift (= KeyCodes.ENTER key) (zero? index) (nil? item))
       (let [uid (gen-block-uid)]
         (dispatch [:athena/toggle])
-        (dispatch [:right-sidebar/open-item uid]))
+        (dispatch [:page/create query uid])
+        (js/setTimeout #(dispatch [:right-sidebar/open-item uid]) 500))
 
       (and shift (= key KeyCodes.ENTER))
       (do
@@ -288,7 +289,7 @@
                                        s              (r/atom {:index   0
                                                                :query   nil
                                                                :results []})
-                                       search-handler (debounce (create-search-handler s) 500)]
+                                       search-handler (create-search-handler s)]
                                    (when open?
                                      [:div.athena (use-style container-style
                                                              {:ref #(reset! ref %)})

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -13,7 +13,7 @@
     [garden.selectors :as selectors]
     [goog.dom :refer [getElement]]
     [goog.events :as events]
-    [goog.functions :refer [debounce]]
+    ;;[goog.functions :refer [debounce]]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]])

--- a/src/cljs/athens/views/daily_notes.cljs
+++ b/src/cljs/athens/views/daily_notes.cljs
@@ -8,7 +8,7 @@
     [cljsjs.react.dom]
     [goog.dom :refer [getElement]]
     [goog.functions :refer [debounce]]
-    [posh.reagent :refer [pull-many]]
+    [posh.reagent :refer [q pull-many]]
     [re-frame.core :refer [dispatch subscribe]]
     [stylefy.core :refer [use-style]]))
 
@@ -68,7 +68,10 @@
     (fn []
       (if (empty? @note-refs)
         (dispatch [:daily-note/next (get-day)])
-        (let [notes (some->> @note-refs
+        (let [notes (some->> @(q '[:find [?uid ...]
+                                   :in $ [?uid ...]
+                                   :where [?e :block/uid ?uid]]
+                                 db/dsdb @note-refs)
                              not-empty
                              (map (fn [x] [:block/uid x]))
                              (pull-many db/dsdb '[*])


### PR DESCRIPTION
https://github.com/athensresearch/athens/projects/4#card-46358603 and others

- hide re-frame-10x: modifies `index.html` to set `localStorage` directly. probably want to not even bundle re-frame-10x in release app, but don't want to mess w config right now
- daily-notes guard: must check the entities exist before `pull`. I feel like I don't like that default behavior of `posh`/`datascript`
- athena: pressing enter before debounce has finished crashes. probably more elegant solution that still uses debounce but quick solution