### PR TITLE
feat: auto-save

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -361,6 +361,7 @@
   (fn [_ [_ datoms]]
     (let [synced? @(subscribe [:db/synced])]
       {:fx [(when synced? [:dispatch [:db/not-synced]])
+            [:dispatch [:save]]
             [:transact! datoms]]})))
 
 


### PR DESCRIPTION
Block orders get messed up if you hold down enter. Otherwise, will write to fs on each transaction until we start getting performance issues