### PR TITLE
fix(left-sidebar) extra scrollbar when opening left sidebar

### DIFF
--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -22,6 +22,7 @@
    :height "100%"
    :display "flex"
    :flex-direction "column"
+   :overflow-x "hidden"
    :overflow-y "auto"
    :transition "width 0.5s ease"
    ::stylefy/sub-styles {:top-line {:margin-bottom "2.5rem"


### PR DESCRIPTION
This prevents an extra vertical scrollbar from being displayed at the bottom when opening/closing the left sidebar. There is still a vertical scrollbar displayed when the text is wider than the left sidebar.

Before:
<img src="https://user-images.githubusercontent.com/10530973/94712486-8b3b9100-0317-11eb-821f-792f388b59fa.gif" width="400"/> <img src="https://user-images.githubusercontent.com/10530973/94712492-8d055480-0317-11eb-9302-b99d3ec29d5a.gif" width="400"/>

After:
<img src="https://user-images.githubusercontent.com/10530973/94712530-9abada00-0317-11eb-92c3-8d0a5d8caa93.gif" width="400"/> <img src="https://user-images.githubusercontent.com/10530973/94712537-9d1d3400-0317-11eb-9e68-7ba36de8d6ce.gif" width="400"/>