### PR TITLE
feat(parser): italics and raw urls

### DIFF
--- a/src/cljc/athens/parser.cljc
+++ b/src/cljc/athens/parser.cljc
@@ -19,7 +19,7 @@
    
    (* This first rule is the top-level one. *)
    (* `/` ordered alternation is used to, for example, try to interpret a string beginning with '[[' as a page-link before interpreting it as raw characters. *)
-   block = (non-reserved-chars / pre-formatted / syntax-in-block / reserved-char) *
+   block = (raw-url / non-reserved-chars / pre-formatted / syntax-in-block / reserved-char) *
    
    (* The following regular expression expresses this: (any character except '`') <- This repeated as many times as possible *)
    <any-non-pre-formatted-chars> = #'[^\\`]*'
@@ -45,6 +45,8 @@
    hashtag = hashtag-bare | hashtag-delimited
    <hashtag-bare> = <'#'> #'[^\\ \\+\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\?\\\"\\;\\:\\]\\[]+'  (* Unicode: L = letters, M = combining marks, N = numbers *)
    <hashtag-delimited> = <'#'> <'[['> page-link-content <']]'>
+
+   raw-url = #'(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})'
 
    url-image = <'!'> url-link-text url-link-url
    

--- a/src/cljc/athens/parser.cljc
+++ b/src/cljc/athens/parser.cljc
@@ -28,7 +28,7 @@
    <inline-pre-formatted> = <'`'> any-non-pre-formatted-chars <'`'>
    
    (* Because code blocks are pre-formatted, we process them before these applied syntaxes. *)
-   <syntax-in-block> = (component | page-link | block-ref | hashtag | url-image | url-link | bold)
+   <syntax-in-block> = (component | page-link | block-ref | hashtag | url-image | url-link | bold | italics)
    
    <syntax-in-component> = (page-link | block-ref)
    <any-non-component-reserved-chars> = #'[^\\{\\}]*'
@@ -62,18 +62,22 @@
    (* The following regular expression expresses this: (any character except '*') <- This repeated as many times as possible *)
    <non-bold-chars> = #'[^\\*]*'
    bold = <'**'> non-bold-chars <'**'>
-   
-   (* -- It’s useful to extract this rule because its transform joins the individual characters everywhere it’s used. *)
+
+   <non-italics-chars> = #'[^\\_]*'
+   italics = <'__'> non-italics-chars <'__'>
+
+
+   <non-bold-chars> = #'[^\\*]*'\n   bold = <'**'> non-bold-chars <'**'>\n   (* -- It’s useful to extract this rule because its transform joins the individual characters everywhere it’s used. *)
    (* -- However, I think in many cases a more specific rule can be used. So we will migrate away from uses of this rule. *)
    
    (* Here are a list of 'stop characters' we implemented, to get the LL(1) performance. *)
-   (* The current reserved characters are:  ->  ( [ * < ` {  # ! <- *)
+   (* The current reserved characters are: ( [ * < ` {  # ! _       *)
    (* Note that since our grammar is a left-recursive one, we only use the opening chars in the pair. *)
    (* IMPORTANT: if you are adding new reserved characters to the list, remember to change them all in the following regex & update the list above! *)
    (* Regex could be a thinker at times, but you can use this tool https://regex101.com/ for a visual debugging experience. *)
-   <non-reserved-char> =  #'[^\\(\\[\\*\\<\\`\\{\\#\\!]'
-   <reserved-char> =       #'[\\(\\[\\*\\<\\`\\{\\#\\!]'
-   <non-reserved-chars> = #'[^\\(\\[\\*\\<\\`\\{\\#\\!]*'
+   <non-reserved-char> =  #'[^\\(\\[\\*\\<\\`\\{\\#\\!\\_]'
+   <reserved-char> =       #'[\\(\\[\\*\\<\\`\\{\\#\\!]\\_'
+   <non-reserved-chars> = #'[^\\(\\[\\*\\<\\`\\{\\#\\!\\_]*'
    <any-char> = #'\\w|\\W'
    <any-chars> = #'[\\w|\\W]+'
    

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -126,13 +126,20 @@
                                               :src   url})])
      :url-link      (fn [{url :url} text]
                       [:a (use-style url-link {:class "url-link"
-                                               :href  url})
+                                               :href  url
+                                               :target "_blank"})
                        text])
+     :raw-url       (fn [url]
+                      [:a (use-style url-link {:class "url-link"
+                                               :href  url
+                                               :target "_blank"})
+
+                       url])
      :bold          (fn [text]
                       [:strong {:class "contents bold"} text])
      :pre-formatted (fn [text]
                       [:code text])}
-   tree))
+    tree))
 
 
 (defn parse-and-render

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -137,6 +137,8 @@
                        url])
      :bold          (fn [text]
                       [:strong {:class "contents bold"} text])
+     :italics       (fn [text]
+                      [:em {:class "contents bold"} text])
      :pre-formatted (fn [text]
                       [:code text])}
     tree))

--- a/test/athens/parser_test.clj
+++ b/test/athens/parser_test.clj
@@ -31,7 +31,10 @@
     "((V8_jUYc-k))"
 
     [:block "it’s " [:bold "very"] " important"]
-    "it’s **very** important"))
+    "it’s **very** important"
+
+    [:block "I found the answer at" [:raw-url "https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url."]]
+    "I found the answer at https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url"))
 
 
 (deftest parser-pre-formatted-tests

--- a/test/athens/parser_test.clj
+++ b/test/athens/parser_test.clj
@@ -33,6 +33,10 @@
     [:block "it’s " [:bold "very"] " important"]
     "it’s **very** important"
 
+    [:block "I cannot" [:italics "emphasize"] " this enough"]
+    "I cannot __emphasize__ this enough"
+    "it’s **very** important"
+
     [:block "I found the answer at" [:raw-url "https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url."]]
     "I found the answer at https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url"))
 


### PR DESCRIPTION
- italics fails tests because links can have `_`, e.g. `#a_hashtag` or `[[a_link]]`
- raw url fails if there are characters before the start of the link.
  - `https://google.com foo` works
  - `foo https://google.com` does not work
- using regex from https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url