### PR TITLE
feat(keybindings): use ctrl or meta based on OS (windows/linux/mac)

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
-    [athens.util :refer [scroll-if-needed get-day get-caret-position]]
+    [athens.util :refer [scroll-if-needed get-day get-caret-position shortcut-key?]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :refer [replace-first blank?]]
@@ -581,5 +581,5 @@
       (= key-code KeyCodes.BACKSPACE) (handle-backspace e uid state)
       (= key-code KeyCodes.DELETE)    (handle-delete e uid state)
       (= key-code KeyCodes.ESC)       (handle-escape e state)
-      (or meta ctrl)                  (handle-shortcuts e uid state)
+      (shortcut-key? meta ctrl)       (handle-shortcuts e uid state)
       (is-character-key? e)           (write-char e uid state))))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -406,6 +406,7 @@
   [e _ state]
   (let [{:keys [key-code head tail selection shift start end target value]} (destruct-key-down e)
         selection? (not= start end)]
+
     (cond
       (and (= key-code KeyCodes.A) (= selection value)) (let [closest-node-page  (.. target (closest ".node-page"))
                                                               closest-block-page (.. target (closest ".block-page"))

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -77,34 +77,35 @@
   [e]
   (let [key (.. e -keyCode)
         ctrl (.. e -ctrlKey)
-        ;meta (.. e -metaKey)
-        shift (.. e -shiftKey)]
+        meta (.. e -metaKey)
+        shift (.. e -shiftKey)
+        mac? false
+        linux? true
+        windows? false]
 
-    (cond
-      (and (= key KeyCodes.S) ctrl)
-      (dispatch [:save])
+    (when ctrl (or (and mac? meta)
+                   (and linux? ctrl)
+                   (and windows? ctrl))
 
-      (and (= key KeyCodes.Z) ctrl shift)
-      (dispatch [:redo])
+      (condp = key
+        KeyCodes.S (dispatch [:save])
 
-      ;; When no editing/uid, do datascript undo.
-      (and (= key KeyCodes.Z) ctrl) (let [editing-uid    @(subscribe [:editing/uid])
-                                          selected-items @(subscribe [:selected/items])]
-                                      (when (or (nil? editing-uid)
-                                                (not-empty selected-items))
-                                        (dispatch [:undo])))
+        KeyCodes.K (dispatch [:athena/toggle])
 
-      (and (= key KeyCodes.K) ctrl)
-      (dispatch [:athena/toggle])
+        KeyCodes.G (dispatch [:devtool/toggle])
 
-      (and (= key KeyCodes.G) ctrl)
-      (dispatch [:devtool/toggle])
+        KeyCodes.Z (let [editing-uid    @(subscribe [:editing/uid])
+                         selected-items @(subscribe [:selected/items])]
+                     ;; editing/uid must be nil or selected-items must be non-empty
+                     (when (or (nil? editing-uid)
+                               (not-empty selected-items))
+                       (if shift
+                         (dispatch [:redo])
+                         (dispatch [:undo]))))
 
-      (and (= key KeyCodes.BACKSLASH) ctrl shift)
-      (dispatch [:right-sidebar/toggle])
-
-      (and (= key KeyCodes.BACKSLASH) ctrl)
-      (dispatch [:left-sidebar/toggle]))))
+        KeyCodes.BACKSLASH (if shift
+                             (dispatch [:right-sidebar/toggle])
+                             (dispatch [:left-sidebar/toggle]))))))
 
 
 ;; -- Clipboard ----------------------------------------------------------

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -1,6 +1,7 @@
 (ns athens.listeners
   (:require
     [athens.db :as db]
+    [athens.util :as util]
     [cljsjs.react]
     [cljsjs.react.dom]
     [goog.events :as events]
@@ -75,17 +76,12 @@
 
 (defn key-down
   [e]
-  (let [key (.. e -keyCode)
-        ctrl (.. e -ctrlKey)
-        meta (.. e -metaKey)
-        shift (.. e -shiftKey)
-        mac? false
-        linux? true
-        windows? false]
+  (let [key      (.. e -keyCode)
+        ctrl     (.. e -ctrlKey)
+        meta     (.. e -metaKey)
+        shift    (.. e -shiftKey)]
 
-    (when ctrl (or (and mac? meta)
-                   (and linux? ctrl)
-                   (and windows? ctrl))
+    (when (util/shortcut-key? meta ctrl)
 
       (condp = key
         KeyCodes.S (dispatch [:save])
@@ -105,7 +101,8 @@
 
         KeyCodes.BACKSLASH (if shift
                              (dispatch [:right-sidebar/toggle])
-                             (dispatch [:left-sidebar/toggle]))))))
+                             (dispatch [:left-sidebar/toggle]))
+        nil))))
 
 
 ;; -- Clipboard ----------------------------------------------------------

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -152,3 +152,24 @@
   "Take a string and escape all regex special characters in it"
   [str]
   (string/escape str regex-esc-char-map))
+
+
+;; OS
+
+(defn get-os
+  []
+  (let [os (.. js/window -navigator -appVersion)]
+    (cond
+      (re-find #"Windows" os) :windows
+      (re-find #"Linux" os) :linux
+      (re-find #"Mac" os) :mac)))
+
+
+(defn shortcut-key?
+  "Use meta for mac, ctrl for others."
+  [meta ctrl]
+  (let [os (get-os)]
+    (or (and (= os :mac) meta)
+        (and (= os :windows) ctrl)
+        (and (= os :linux) ctrl))))
+


### PR DESCRIPTION
`case` doesn't work with enumerators it seems like?

not tested on Windows