### PR TITLE
fix(electron): rollback to 9.2 from 9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist": "electron-builder -p always"
   },
   "devDependencies": {
-    "electron": "^9.3.1",
+    "electron": "^9.2.0",
     "electron-builder": "22.8.1",
     "electron-builder-notarize": "^1.2.0",
     "gh-pages": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@ electron-updater@^4.3.4:
     lodash.isequal "^4.5.0"
     semver "^7.3.2"
 
-electron@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-9.3.1.tgz#e301932c5c0537d8c9a8850d216d3ba454dbf55c"
-  integrity sha512-DScrhqBT4a54KfdF0EoipALpHmdQTn3m7SSCtbpTcEcG+UDUiXad2cOfW6DHeVH7N+CVDKDG12q2PhVJjXkFAA==
+electron@^9.2.0:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-9.3.2.tgz#afa2942e2642ee25b422b90f1497f7d9bbeec550"
+  integrity sha512-0lleEf9msAXGDi2GukAuiGdw3VDgSTlONOnJgqDEz1fuSEVsXz5RX+hNPKDsVDerLTFg/C34RuJf4LwHvkKcBA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
People getting `async hooks` error from electron. I'm not sure if this is the problem as it seems to be non-deterministic, but hope it's a quick fix because I've spent a lot of time trying to debug this without results.