### PR TITLE
feat(editing/uid): don't jump around if multiple HTML elements with same block uid

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -2,7 +2,7 @@
   (:require
     [athens.db :as db]
     [athens.parser :as parser]
-    [athens.util :refer [now-ts gen-block-uid]]
+    [athens.util :as util :refer [now-ts gen-block-uid]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [go <!]]
     [cljs.pprint :refer [pprint]]
@@ -10,7 +10,7 @@
     [datascript.core :as d]
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
-    [goog.dom :refer [getElement getElementsByClass findCommonAncestor]]
+    [goog.dom.classlist :refer [contains]]
     [goog.dom.selection :refer [setCursorPosition]]
     [instaparse.core :as parse]
     [posh.reagent :refer [transact!]]
@@ -191,27 +191,29 @@
 
 
 ;; Using DOM, focus the target block.
+;; There can actually be multiple elements with the same #editable-uid-UID HTML id
+;; The same unique datascript block can be rendered multiple times: node-page, right sidebar, linked/unlinked references
+;; In this case, find the all the potential HTML blocks with that uid. The one that shares the same closest ancestor as the
+;; activeElement (where the text caret is before the new focus happens), is the container of the block to focus on.
+
 ;; If an index is passed, set cursor that index.
 (reg-fx
   :editing/focus
   (fn [[uid index]]
-    ;;(js/console.log "A" (findCommonAncestor (.. js/document -activeElement)))
-    ;;(js/console.log (js/document.querySelectorAll "textarea.is-editing"))
-    (js/setTimeout (fn []
-                     (let [id        (str "editable-uid-" uid)
-                           el        (if (string? uid)
-                                       (getElement id)
-                                       uid)
-                           potential (js/document.querySelectorAll (str "#editable-uid-" uid))
-                           active-el (.. js/document -activeElement)
-                           ancestors (mapv #(findCommonAncestor active-el %) potential)]
-                       ;; XXX: problem is that findCommonAncestor finds greatest/deepest ancestor. i want the lowest ancestor.
-                       (js/console.log "ANCESTORS" ancestors potential active-el)
-                       (when el
-                         (.focus el)
-                         (when index
-                           (setCursorPosition el index)))))
-                   300)))
+    (let [active-el (.. js/document -activeElement)]
+      (js/setTimeout (fn []
+                       (let [html-id (str "#editable-uid-" uid)
+                             el      (as-> html-id x
+                                           (js/document.querySelectorAll x)
+                                           (map #(util/common-ancestor active-el %) x)
+                                           (filter #(contains % "block-container") x)
+                                           (first x)
+                                           (.. x (querySelector html-id)))]
+                         (when el
+                           (.focus el)
+                           (when index
+                             (setCursorPosition el index)))))
+                     300))))
 
 
 (reg-fx

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -10,7 +10,7 @@
     [datascript.core :as d]
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
-    [goog.dom :refer [getElement]]
+    [goog.dom :refer [getElement getElementsByClass findCommonAncestor]]
     [goog.dom.selection :refer [setCursorPosition]]
     [instaparse.core :as parse]
     [posh.reagent :refer [transact!]]
@@ -195,9 +195,18 @@
 (reg-fx
   :editing/focus
   (fn [[uid index]]
+    ;;(js/console.log "A" (findCommonAncestor (.. js/document -activeElement)))
+    ;;(js/console.log (js/document.querySelectorAll "textarea.is-editing"))
     (js/setTimeout (fn []
-                     (let [id (str "editable-uid-" uid)
-                           el (getElement id)]
+                     (let [id        (str "editable-uid-" uid)
+                           el        (if (string? uid)
+                                       (getElement id)
+                                       uid)
+                           potential (js/document.querySelectorAll (str "#editable-uid-" uid))
+                           active-el (.. js/document -activeElement)
+                           ancestors (mapv #(findCommonAncestor active-el %) potential)]
+                       ;; XXX: problem is that findCommonAncestor finds greatest/deepest ancestor. i want the lowest ancestor.
+                       (js/console.log "ANCESTORS" ancestors potential active-el)
                        (when el
                          (.focus el)
                          (when index

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -3,12 +3,12 @@
     [athens.db :as db :refer [retract-uid-recursively inc-after dec-after plus-after minus-after]]
     [athens.style :as style]
     [athens.util :refer [now-ts gen-block-uid]]
+    [clojure.string :as string]
     [datascript.core :as d]
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
     [day8.re-frame.tracing :refer-macros [fn-traced]]
-    [re-frame.core :refer [reg-event-db reg-event-fx inject-cofx subscribe]]
-    [clojure.string :as string]))
+    [re-frame.core :refer [reg-event-db reg-event-fx inject-cofx subscribe]]))
 
 
 ;; -- re-frame app-db events ---------------------------------------------
@@ -271,9 +271,6 @@
   :loading/unset
   (fn-traced [db]
              (assoc-in db [:loading?] false)))
-
-
-
 
 
 (reg-event-db

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -7,7 +7,8 @@
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
     [day8.re-frame.tracing :refer-macros [fn-traced]]
-    [re-frame.core :refer [reg-event-db reg-event-fx inject-cofx subscribe]]))
+    [re-frame.core :refer [reg-event-db reg-event-fx inject-cofx subscribe]]
+    [clojure.string :as string]))
 
 
 ;; -- re-frame app-db events ---------------------------------------------
@@ -112,10 +113,20 @@
                             [:right-sidebar/toggle])})))
 
 
-(reg-event-db
-  :dragging-global/toggle
-  (fn [db _]
-    (update db :dragging-global not)))
+(reg-event-fx
+  :editing/uid
+  (fn [{:keys [db]} [_ uid index]]
+    {:db            (assoc db :editing/uid uid)
+     :editing/focus [uid index]}))
+
+
+(reg-event-fx
+  :editing/target
+  (fn [{:keys [db]} [_ target]]
+    (let [uid (-> (.. target -id)
+                  (string/split "editable-uid-")
+                  second)]
+      {:db (assoc db :editing/uid uid)})))
 
 
 (reg-event-db
@@ -262,13 +273,7 @@
              (assoc-in db [:loading?] false)))
 
 
-;; Block Events
 
-(reg-event-fx
-  :editing/uid
-  (fn [{:keys [db]} [_ uid index]]
-    {:db            (assoc db :editing/uid uid)
-     :editing/focus [uid index]}))
 
 
 (reg-event-db

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -117,12 +117,6 @@
 
 
 (re-frame/reg-sub
-  :dragging-global
-  (fn-traced [db _]
-             (:dragging-global db)))
-
-
-(re-frame/reg-sub
   :daily-notes/items
   (fn-traced [db _]
              (:daily-notes/items db)))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -83,6 +83,35 @@
     (js->clj (fn target selectionEnd) :keywordize-keys true)))
 
 
+(defn dom-parents
+  "This and common-ancestor taken from https://stackoverflow.com/a/5350888."
+  [node]
+  (loop [nodes [node]
+         node node]
+    (if (nil? node)
+      (reverse nodes)
+      (recur (conj nodes node) (.-parentNode node)))))
+
+
+(defn common-ancestor
+  [node1 node2]
+  (let [p1 (dom-parents node1)
+        p2 (dom-parents node2)]
+    (if (not= (first p1) (first p2))
+      (throw (js/Error. "No common ancestor!"))
+      (let [n (dec (count p1))]
+        (loop [i 0]
+          (cond
+            (not= (nth p1 i nil) (nth p2 i nil))
+            (nth p1 (dec i))
+
+            (= i n)
+            (js/Error. "No common ancestor after n loops!")
+
+            :else
+            (recur (inc i))))))))
+
+
 ;; -- Date and Time ------------------------------------------------------
 
 

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -563,7 +563,8 @@
   [e uid _]
   (.. e stopPropagation)
   (when (false? (.. e -shiftKey))
-    (dispatch [:editing/uid uid])
+    ;;(dispatch [:editing/uid uid])
+    (dispatch [:editing/target (.. e -target)])
     (let [mouse-down @(subscribe [:mouse-down])]
       (when (false? mouse-down)
         (dispatch [:mouse-down/set])

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -560,10 +560,9 @@
 (defn textarea-mouse-down
   "Attach global mouseup listener. Listener can't be local because user might let go of mousedown off of a block.
   See https://javascript.info/mouse-events-basics#events-order"
-  [e uid _]
+  [e _uid _]
   (.. e stopPropagation)
   (when (false? (.. e -shiftKey))
-    ;;(dispatch [:editing/uid uid])
     (dispatch [:editing/target (.. e -target)])
     (let [mouse-down @(subscribe [:mouse-down])]
       (when (false? mouse-down)


### PR DESCRIPTION
Before, editing/uid uses `getElement` which finds an HTML `#element` by tag. However, there can be multiple elements with the same `editing-uid-` HTML id, because a block can show up on the page, under linked references, or in the right sidebar.

https://www.loom.com/share/dd50a1b197ca4f7a851f0204b23d87bb

Now, the DOM filters to find the correct block to move to. TODO: fix linked references so that they act more like block pages than blocks (where pressing enter creates a child instead of a sibling, or don't allow un-indent).