### PR TITLE
fix(re-frame): db->fx didn't update params correctly

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -21,7 +21,7 @@
 
 (reg-event-fx
   :db/update-filepath
-  (fn [db [_ filepath]]
+  (fn [{:keys [db]} [_ filepath]]
     {:db (assoc db :db/filepath filepath)
      :local-storage/set! ["db/filepath" filepath]}))
 


### PR DESCRIPTION
- fixes bug introduced in https://github.com/tangjeff0/athens/blob/1bdc7647a851692c48e54db4958cd5cd85e72ede/src/cljs/athens/events.cljs#L22-L26
- interestingly, this was detected because global re-frame key-val `:mouse-down` was `nil`, rather than `false`... `false?` is strong!