### PR TITLE
feat: hide electron title bar

### DIFF
--- a/src/cljs/athens/main/core.cljs
+++ b/src/cljs/athens/main/core.cljs
@@ -28,6 +28,7 @@
                         (clj->js {:width 800
                                   :height 600
                                   :autoHideMenuBar true
+                                  :toolbarStyle "hiddenInset"
                                   :enableRemoteModule true
                                   :webPreferences {:nodeIntegration true
                                                    :worldSafeExecuteJavaScript true

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -25,13 +25,13 @@
    :align-items "center"
    :display "grid"
    :position "absolute"
-   :top "-0.25rem"
+   :top 0
    :right 0
    :left 0
    :grid-template-columns "auto 1fr auto"
    :z-index "1000"
    :grid-auto-flow "column"
-   :padding "0.25rem 0.75rem"
+   :padding "0 0.75rem"
    ;; TODO: padding (and toolbar height) should be linked
    ;; to zoom level, so zooming out doesn't cause the buttons
    ;; to be hidden by traffic lights.
@@ -43,7 +43,7 @@
 (def app-header-control-section-style
   {:display "grid"
    :grid-auto-flow "column"
-   :background (:color :background-color :opacity-med)
+   :background (color :background-color :opacity-med)
    :backdrop-filter "blur(0.375rem)"
    :padding "0.25rem"
    :border-radius "calc(0.25rem + 0.25rem)" ;; Button corner radius + container padding makes "concentric" container radius

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -16,9 +16,9 @@
 
 ;;; Styles
 
-
 (def app-header-style
   {:grid-area "app-header"
+   :-webkit-app-region "drag"
    :justify-content "flex-start"
    :background-clip "padding-box"
    :align-items "center"
@@ -31,6 +31,10 @@
    :z-index "1000"
    :grid-auto-flow "column"
    :padding "0.25rem 0.75rem"
+   ;; TODO: padding (and toolbar height) should be linked
+   ;; to zoom level, so zooming out doesn't cause the buttons
+   ;; to be hidden by traffic lights.
+   :padding-left "80px"
    ::stylefy/manual [[:svg {:font-size "20px"}]
                      [:button {:justify-self "flex-start"}]]})
 

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -16,6 +16,7 @@
 
 ;;; Styles
 
+
 (def app-header-style
   {:grid-area "app-header"
    :-webkit-app-region "drag"


### PR DESCRIPTION
- Uses 'hidden inset' titlebar style for more integrated appearance.
- Makes app header a window drag handle
- Fixes missing background color in appheader controls

<img width="1496" alt="Screen Shot 2020-11-01 at 11 27 59 AM" src="https://user-images.githubusercontent.com/98312/97808509-4ddb6380-1c35-11eb-9ebf-4398309641b3.png">

