### PR TITLE
perf(electron): debounce save 15 secs

### DIFF
--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -330,7 +330,7 @@
   [filepath data]
   (.writeFile fs filepath data (fn [err]
                                  (when err
-                                   (js/console.error err))))
+                                   (throw (js/Error. err)))))
   (dispatch [:db/sync])
   (dispatch [:db/update-mtime (js/Date.)]))
 

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -325,8 +325,20 @@
 ;;(def r (.. stream -Readable (from (dt/write-transit-str @db/dsdb))))
 ;;(def w (.createWriteStream fs "./data/my-db.transit"))
 ;;(.pipe r w)
+
+(defn write-file
+  [filepath data]
+  (.writeFile fs filepath data (fn [err]
+                                 (when err
+                                   (js/console.error err))))
+  (dispatch [:db/sync])
+  (dispatch [:db/update-mtime (js/Date.)]))
+
+
+(def debounce-write (debounce write-file 15000))
+
+
 (reg-fx
   :fs/write!
   (fn [[filepath data]]
-    (.writeFileSync fs filepath data)))
-
+    (debounce-write filepath data)))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -405,10 +405,10 @@
   :transact
   (fn [_ [_ tx-data]]
     ;; always stay synced for now because auto-saving
-    #_(let [synced? @(subscribe [:db/synced])])
-    {:fx [(when false [:dispatch [:db/not-synced]])
-          [:dispatch [:save]]
-          [:transact! tx-data]]}))
+    (let [synced? @(subscribe [:db/synced])]
+      {:fx [(when synced? [:dispatch [:db/not-synced]])
+            [:dispatch [:save]]
+            [:transact! tx-data]]})))
 
 
 (reg-event-fx
@@ -458,9 +458,7 @@
   :save
   (fn [_ _]
     (let [db-filepath (subscribe [:db/filepath])]
-      {:fs/write!  [@db-filepath (dt/write-transit-str @db/dsdb)]
-       :dispatch-n [#_[:db/sync] ;; stay synced because auto-saving
-                    [:db/update-mtime (js/Date.)]]})))
+      {:fs/write!  [@db-filepath (dt/write-transit-str @db/dsdb)]})))
 
 
 (reg-event-fx

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -6,8 +6,8 @@
     [athens.subs]
     #_[athens.util :as util]
     [athens.views.buttons :refer [button]]
-    [reagent.core :as r]
     [re-frame.core :refer [subscribe dispatch]]
+    #_[reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style]]))
 
 
@@ -79,8 +79,8 @@
   (let [left-open?  (subscribe [:left-sidebar/open])
         right-open? (subscribe [:right-sidebar/open])
         route-name  (subscribe [:current-route/name])
-        theme-dark  (subscribe [:theme/dark])
-        db-synced   (subscribe [:db/synced])]
+        theme-dark  (subscribe [:theme/dark])]
+        ;;db-synced   (subscribe [:db/synced])]
     (fn []
       [:<>
        [:header (use-style app-header-style)

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -6,6 +6,7 @@
     [athens.subs]
     #_[athens.util :as util]
     [athens.views.buttons :refer [button]]
+    [reagent.core :as r]
     [re-frame.core :refer [subscribe dispatch]]
     [stylefy.core :as stylefy :refer [use-style]]))
 
@@ -78,7 +79,8 @@
   (let [left-open?  (subscribe [:left-sidebar/open])
         right-open? (subscribe [:right-sidebar/open])
         route-name  (subscribe [:current-route/name])
-        theme-dark  (subscribe [:theme/dark])]
+        theme-dark  (subscribe [:theme/dark])
+        db-synced   (subscribe [:db/synced])]
     (fn []
       [:<>
        [:header (use-style app-header-style)


### PR DESCRIPTION
- also use `writeFile` instead of `writeFileSync` instead. wasn't using async version before because got  errors, but this was when there was no debounce, meaning the error was almost certainly because multiple  attempts of writing at the same time. this can no longer happen with the async version.
- got a similar error when using pipes. pipes are even better than async, so can eventually go that