### PR TITLE
feat(sidebar): smaller and truncated titles for pages in sidebar

### DIFF
--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -92,7 +92,8 @@
                            :-webkit-line-clamp 1
                            :line-clamp 1
                            :overflow "hidden"
-                           :text-overflow "ellipsis"}]]})
+                           :text-overflow "ellipsis"}]
+                     [:.node-page {:margin-top 0}]]})
 
 
 (def sidebar-item-heading-style

--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -85,7 +85,14 @@
    :font-size "15px"
    :position "relative"
    :z-index 1
-   :width "32vw"})
+   :width "32vw"
+   ::stylefy/manual [[:h1 {:font-size "1.5em"
+                           :display "-webkit-box"
+                           :-webkit-box-orient "vertical"
+                           :-webkit-line-clamp 1
+                           :line-clamp 1
+                           :overflow "hidden"
+                           :text-overflow "ellipsis"}]]})
 
 
 (def sidebar-item-heading-style

--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -93,7 +93,7 @@
                            :line-clamp 1
                            :overflow "hidden"
                            :text-overflow "ellipsis"}]
-                     [:.node-page {:margin-top 0}]]})
+                     [:.node-page :.block-page {:margin-top 0}]]})
 
 
 (def sidebar-item-heading-style


### PR DESCRIPTION
- Truncate page titles in sidebar items to one line.
- Smaller text size for item titles in sidebar
- Remove extra spacing from top of sidebar items

<img width="1579" alt="Screen Shot 2020-11-15 at 11 23 54 AM" src="https://user-images.githubusercontent.com/98312/99190535-0d9bdb00-2735-11eb-81b9-5d9ef3c347f8.png">
