### PR TITLE
fix(electron): debounce was "blocking"; perf(electron): use streams

### DIFF
--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -22,6 +22,7 @@
 
 (def fs (js/require "fs"))
 (def path (js/require "path"))
+(def stream (js/require "stream"))
 
 
 (def DB-INDEX "index.transit")
@@ -245,7 +246,7 @@
 
 
 (def debounce-sync-db-from-fs
-  (debounce sync-db-from-fs 100))
+  (debounce sync-db-from-fs 1000))
 
 
 ;; Watches directory that db is located in. If db file is updated, sync-db-from-fs.
@@ -323,18 +324,14 @@
 ;;; Effects
 
 
-;; TODO: implement with streams
-;;(def r (.. stream -Readable (from (dt/write-transit-str @db/dsdb))))
-;;(def w (.createWriteStream fs "./data/my-db.transit"))
-;;(.pipe r w)
-
 (defn write-file
   [filepath data]
   (.writeFile fs filepath data (fn [err]
-                                 (when err
-                                   (throw (js/Error. err)))))
-  (dispatch [:db/sync])
-  (dispatch [:db/update-mtime (js/Date.)]))
+                                 (if err
+                                   (throw (js/Error. err))
+                                   (do
+                                     (dispatch [:db/sync])
+                                     (dispatch [:db/update-mtime (js/Date.)]))))))
 
 
 (def debounce-write (debounce write-file 15000))

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -80,7 +80,6 @@
         right-open? (subscribe [:right-sidebar/open])
         route-name  (subscribe [:current-route/name])
         theme-dark  (subscribe [:theme/dark])]
-        ;;db-synced   (subscribe [:db/synced])]
     (fn []
       [:<>
        [:header (use-style app-header-style)
@@ -108,11 +107,11 @@
             [(r/adapt-react-class mui-icons/FolderOpen)
              {:style {:align-self "center"}}]]
          ;; sync UI
-         #_[(r/adapt-react-class mui-icons/FiberManualRecord)
-            {:style {:color      (color (if @db-synced
-                                          :confirmation-color
-                                          :highlight-color))
-                     :align-self "center"}}]
+         [(reagent.core/adapt-react-class mui-icons/FiberManualRecord)
+          {:style {:color      (color (if @(subscribe [:db/synced])
+                                        :confirmation-color
+                                        :highlight-color))
+                   :align-self "center"}}]
          #_[separator]
          [button {:on-click #(dispatch [:modal/toggle])
                   #_(swap! state assoc :modal :folder)}

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -107,11 +107,11 @@
             [(r/adapt-react-class mui-icons/FolderOpen)
              {:style {:align-self "center"}}]]
          ;; sync UI
-         [(reagent.core/adapt-react-class mui-icons/FiberManualRecord)
-          {:style {:color      (color (if @(subscribe [:db/synced])
-                                        :confirmation-color
-                                        :highlight-color))
-                   :align-self "center"}}]
+         #_[(reagent.core/adapt-react-class mui-icons/FiberManualRecord)
+            {:style {:color      (color (if @(subscribe [:db/synced])
+                                          :confirmation-color
+                                          :highlight-color))
+                     :align-self "center"}}]
          #_[separator]
          [button {:on-click #(dispatch [:modal/toggle])
                   #_(swap! state assoc :modal :folder)}


### PR DESCRIPTION
Previously thought there was an issue with node's `fs.writeFile` because it seemed like it was blocking. In actuality, I had messed up the order for the `update-mtime`. The condition in `sync-db-from-fs` was always true, even when writing to the filesystem. This would cause each write to also trigger a read from the filesystem, when we only want that to happen if, for instance, Dropbox updates the db.

Also use streams, which should reduce memory significantly.