### PR TITLE
fix: missing cursor issue #464

### DIFF
--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -385,6 +385,7 @@
           (when-not timeline-page?
             [autosize/textarea
              {:value         (:title/local @state)
+              :id            (str "editable-uid-" uid)
               :class         (when (= editing-uid uid) "is-editing")
               :on-blur       (fn [_] (handle-blur node state ref-groups))
               :on-key-down   (fn [e] (handle-key-down e state))


### PR DESCRIPTION
fix #464 

![464](https://user-images.githubusercontent.com/8164667/99583620-c2c4e080-2a1e-11eb-8dd9-efe694faa230.gif)

I found other issues that might be related to this but I'm not sure if they should be included here.
- arrow down is not working when the cursor is on the top node
- the cursor position is inconsistent when moving up and down the blocks using the arrow key