### PR TITLE
fix: github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
            fetch-depth: 1
            submodules: 'true'
 
-       - uses: DeLaGuardo/setup-clj-kondo@v1
+       - uses: DeLaGuardo/setup-clj-kondo@master
          with:
            version: '2020.05.09'
 
@@ -73,7 +73,7 @@ jobs:
            fetch-depth: 1
            submodules: 'true'
 
-       - uses: DeLaGuardo/setup-clojure@2.0
+       - uses: DeLaGuardo/setup-clojure@master
          with:
            tools-deps: '1.10.1.469'
 


### PR DESCRIPTION
Changes to the github actions due to github fixing a
security vulnerability:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

These were deprecated on 16th Nov 2020:
https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/

The repo for `setup-clj-kondo` has been updated but a new release
version has not be cut yet.

Use master for now but you probably want to use the actual versions once they've been set.