### PR TITLE
fix: arrow down key function in page title and block page title #501

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -463,8 +463,9 @@
   [uid]
   (loop [uid uid]
     (let [sib    (nth-sibling uid +1)
-          parent (get-parent [:block/uid uid])]
-      (if (or sib (:node/title parent))
+          parent (get-parent [:block/uid uid])
+          {node :node/title}   (get-block [:block/uid uid])]
+      (if (or sib (:node/title parent) node)
         sib
         (recur (:block/uid parent))))))
 
@@ -478,10 +479,10 @@
   ([uid]
    (let [block                (->> (get-block [:block/uid uid])
                                    sort-block-children)
-         {:block/keys [children open]} block
+         {:block/keys [children open] node :node/title } block
          next-block-recursive (next-sibling-recursively uid)]
      (cond
-       (and open children) (:block/uid (first children))
+       (and (or open node) children) (:block/uid (first children))
        next-block-recursive (:block/uid next-block-recursive))))
   ([uid selection?]
    (if selection?

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -479,7 +479,7 @@
   ([uid]
    (let [block                (->> (get-block [:block/uid uid])
                                    sort-block-children)
-         {:block/keys [children open] node :node/title } block
+         {:block/keys [children open] node :node/title} block
          next-block-recursive (next-sibling-recursively uid)]
      (cond
        (and (or open node) children) (:block/uid (first children))

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
-    [athens.keybindings :refer [destruct-key-down]]
+    [athens.keybindings :refer [destruct-key-down textarea-key-down]]
     [athens.parse-renderer :as parse-renderer]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color]]
@@ -29,9 +29,10 @@
   {:position        "relative"
    :overflow        "visible"
    :flex-grow       "1"
-   :margin          "0.2em 0"
+   :margin          "0.1em 0"
    :letter-spacing  "-0.03em"
    :word-break      "break-word"
+   :line-height     "1.4em"
    ::stylefy/manual [[:textarea {:display "none"}]
                      [:&:hover [:textarea {:display "block"
                                            :z-index 1}]]
@@ -118,7 +119,7 @@
             :value       (:string/local @state)
             :class       (when (= editing-uid uid) "is-editing")
             :auto-focus  true
-            :on-key-down (fn [e] (block-page-key-down e uid state))
+            :on-key-down (fn [e] (textarea-key-down e uid state))
             :on-change   (fn [e] (block-page-change e uid state))}]
           [:span (:string/local @state)]]
 

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -2,7 +2,7 @@
   (:require
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db :refer [get-linked-references get-unlinked-references]]
-    [athens.keybindings :refer [destruct-key-down]]
+    [athens.keybindings :refer [destruct-key-down, textarea-key-down]]
     [athens.parse-renderer :as parse-renderer :refer [pull-node-from-string]]
     [athens.patterns :as patterns]
     [athens.router :refer [navigate-uid navigate]]
@@ -41,10 +41,11 @@
   {:position "relative"
    :overflow "visible"
    :flex-grow "1"
-   :margin "0.2em 0 0.2em 1rem"
+   :margin "0.10em 0 0.10em 1rem"
    :letter-spacing "-0.03em"
    :white-space "pre-line"
    :word-break "break-word"
+   :line-height "1.40em"
    ::stylefy/manual [[:textarea {:display "none"}]
                      [:&:hover [:textarea {:display "block"
                                            :z-index 1}]]
@@ -388,7 +389,7 @@
               :id            (str "editable-uid-" uid)
               :class         (when (= editing-uid uid) "is-editing")
               :on-blur       (fn [_] (handle-blur node state ref-groups))
-              :on-key-down   (fn [e] (handle-key-down e state))
+              :on-key-down   (fn [e] (textarea-key-down e uid state))
               :on-change     (fn [e] (handle-change e state))}])
           [button {:class    [(when show "active")]
                    :on-click (fn [e]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -151,12 +151,20 @@
                                               :block/string ""}]}]])
     (dispatch [:editing/uid new-uid])))
 
+
+(defn handle-enter
+  [e uid _state]
+  (let [{:keys [start value]} (destruct-key-down e)]
+    (.. e preventDefault)
+    (dispatch [:split-block-to-children uid value start])))
+
+
 (defn handle-page-arrow-key
   [e uid state]
   (let [{:keys [key-code target]} (destruct-key-down e)
         start?          (block-start? e)
         end?            (block-end? e)
-        { caret-position :caret-position} @state
+        {caret-position :caret-position} @state
         textarea-height (.. target -offsetHeight)
         {:keys [top height]} caret-position
         rows            (js/Math.round (/ textarea-height height))
@@ -176,6 +184,7 @@
           (and right? end?)) (do (.. e preventDefault)
                                  (dispatch [:down uid])))))
 
+
 (defn handle-key-down
   [e uid state]
   (let [{:keys [key-code shift]} (destruct-key-down e)
@@ -183,7 +192,7 @@
     (swap! state assoc :caret-position caret-position)
     (cond
       (arrow-key-direction e) (handle-page-arrow-key e uid state)
-      (and (not shift) (= key-code KeyCodes.ENTER)) (.. e -target blur))))
+      (and (not shift) (= key-code KeyCodes.ENTER)) (handle-enter e uid state))))
 
 
 (defn handle-change


### PR DESCRIPTION
Fix for #501

Page Title
![page-title](https://user-images.githubusercontent.com/8164667/100555426-5d9ea400-32d6-11eb-9307-fc3c64104be9.gif)

Block Page Title
![block-page-title](https://user-images.githubusercontent.com/8164667/100555432-67c0a280-32d6-11eb-8d5d-63169f7af80b.gif)
