### PR TITLE
Add ctrl-down and ctrl-up shortcuts to open/close blocks

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -292,7 +292,7 @@
 
 (defn handle-arrow-key
   [e uid state]
-  (let [{:keys [key-code shift target selection]} (destruct-key-down e)
+  (let [{:keys [key-code shift ctrl target selection]} (destruct-key-down e)
         selection?      (not (blank? selection))
         start?          (block-start? e)
         end?            (block-end? e)
@@ -317,6 +317,11 @@
                   (and down? bottom-row?)) (do
                                              (.. target blur)
                                              (dispatch [:selected/add-item uid])))
+
+      ;; Control: fold or unfold blocks
+      ctrl (cond
+             up? (dispatch [:transact [[:db/add [:block/uid uid] :block/open false]]])
+             down? (dispatch [:transact [[:db/add [:block/uid uid] :block/open true]]]))
 
       ;; Type, one of #{:slash :block :page}: If slash commands or inline search is open, cycle through options
       type (cond

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -319,9 +319,12 @@
                                              (dispatch [:selected/add-item uid])))
 
       ;; Control: fold or unfold blocks
-      ctrl (cond
-             up? (dispatch [:transact [[:db/add [:block/uid uid] :block/open false]]])
-             down? (dispatch [:transact [[:db/add [:block/uid uid] :block/open true]]]))
+      ctrl (let [new-open-state (cond
+                                  up? false
+                                  down? true)
+                 event [:transact [[:db/add [:block/uid uid] :block/open new-open-state]]]]
+             (.. e preventDefault)
+             (dispatch event))
 
       ;; Type, one of #{:slash :block :page}: If slash commands or inline search is open, cycle through options
       type (cond


### PR DESCRIPTION
The desired event is triggered, however it is not perfect:
as the block if opened and closed, the editing pointer moves around.
The movement of the pointer should be freezed as an improvement.