### PR TITLE
rfct(dropdown): use react portal for dropdowns

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -13,8 +13,8 @@
       </script>
   </head>
   <body>
-    <div id="app">
-    </div>
+    <div id="app"></div>
+    <div id="portal"></div>
     <!-- <script src="js/compiled/shared.js"></script> -->
     <!-- <script>athens.views.spinner.init_spinner()</script> -->
     <!-- <script src="js/compiled/app.js"></script> -->

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -641,6 +641,27 @@
         (dispatch [:backspace next-block-uid (:block/string next-block)])))))
 
 
+(defn textarea-position
+  "By default, get-caret-position finds caret position *relative* to a textarea."
+  [target]
+  (let [rect (.. target getBoundingClientRect)]
+    {:left  (.. rect -x)
+     :top (.. rect -y)}))
+
+
+(defn dropdown-position
+  "By default, get-caret-position finds caret position *relative* to a textarea."
+  []
+  (let [target (.. js/document -activeElement)]
+    (when (= (.. target -nodeName) "TEXTAREA")
+      (let [abs-position (textarea-position target)
+            rel-position (get-caret-position target)
+            offset {:left 0 :top 24}]
+        (merge-with +
+                    abs-position
+                    rel-position
+                    offset)))))
+
 (defn textarea-key-down
   [e uid state]
   (let [d-event (destruct-key-down e)
@@ -648,11 +669,6 @@
 
     ;; used for paste, to determine if shift key was held down
     (swap! state assoc :last-keydown d-event)
-
-    ;; update caret position for search dropdowns and for up/down
-    (when (nil? (:search/type @state))
-      (let [caret-position (get-caret-position (.. e -target))]
-        (swap! state assoc :caret-position caret-position)))
 
     ;; dispatch center
     (cond

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -662,6 +662,7 @@
                     rel-position
                     offset)))))
 
+
 (defn textarea-key-down
   [e uid state]
   (let [d-event (destruct-key-down e)

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -670,6 +670,11 @@
     ;; used for paste, to determine if shift key was held down
     (swap! state assoc :last-keydown d-event)
 
+    ;; update caret position for search dropdowns and for up/down
+    (when (nil? (:search/type @state))
+      (let [caret-position (get-caret-position (.. e -target))]
+        (swap! state assoc :caret-position caret-position)))
+
     ;; dispatch center
     (cond
       (arrow-key-direction e)         (handle-arrow-key e uid state)

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -64,7 +64,6 @@
     (.readAsText fr file)))
 
 
-
 ;; Panels
 
 

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -64,6 +64,7 @@
     (.readAsText fr file)))
 
 
+
 ;; Panels
 
 
@@ -95,11 +96,6 @@
        [:span "Analytics are anonymized and delivered by "
         [:a {:href "https://posthog.com" :target "_blank"} "Posthog"]
         ", an open-source provider of product analytics. This lets the designers and engineers at Athens know if we're really making something people love!"]])))
-
-
-;;(prn (.. js/window -posthog opt_out_capturing))
-;;(prn (.. js/window -posthog opt_in_capturing))
-
 
 
 (defn pages-panel

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -231,7 +231,6 @@
 
 ;;; Components
 
-
 (defn athena-prompt-el
   []
   [button {:on-click #(dispatch [:athena/toggle])
@@ -268,65 +267,76 @@
 
 (defn athena-component
   []
-  (let [open?          @(subscribe [:athena/open])
-        s              (r/atom {:index   0
-                                :query   nil
-                                :results []})
-        search-handler (create-search-handler s)]
-    (when open?
-      [athens.views.portal/portal
-       [:div.athena (use-style container-style)
-        [:header {:style {:position "relative"}}
-         [:input (use-style athena-input-style
-                            {:type        "search"
-                             :id          "athena-input"
-                             :auto-focus  true
-                             :required    true
-                             :placeholder "Find or Create Page"
-                             :on-change   (fn [e] (search-handler (.. e -target -value)))
-                             :on-key-down (fn [e] (key-down-handler e s))})]
-         [:button (use-style search-cancel-button-style
-                             {:on-click #(set! (.-value (getElement "athena-input")))})
-          [:> mui-icons/Close]]]
-        [results-el s]
-        [(fn []
-           (let [{:keys [results query index]} @s]
-             [:div (use-style results-list-style)
-              (doall
-                (for [[i x] (map-indexed list results)
-                      :let [parent (:block/parent x)
-                            title  (or (:node/title parent) (:node/title x))
-                            uid    (or (:block/uid parent) (:block/uid x))
-                            string (:block/string x)]]
-                  (if (nil? x)
-                    ^{:key i}
-                    [:div (use-style result-style {:on-click (fn [_]
-                                                               (let [uid (gen-block-uid)]
-                                                                 (dispatch [:athena/toggle])
-                                                                 (dispatch [:page/create query uid])
-                                                                 (navigate-uid uid)))
-                                                   :class    (when (= i index) "selected")})
+  (let [ref                  (atom nil)
+        handle-click-outside (fn [e]
+                               (when (and @(subscribe [:athena/open])
+                                          (not (.. @ref (contains (.. e -target)))))
+                                 (dispatch [:athena/toggle])))]
+    (r/create-class
+      {:display-name           "athena"
+       :component-did-mount    (fn [_this] (events/listen js/document "mousedown" handle-click-outside))
+       :component-will-unmount (fn [_this] (events/unlisten js/document "mousedown" handle-click-outside))
+       :reagent-render         (fn []
+                                 (let [open?          @(subscribe [:athena/open])
+                                       s              (r/atom {:index   0
+                                                               :query   nil
+                                                               :results []})
+                                       search-handler (create-search-handler s)]
+                                   (when open?
+                                     [:div.athena (use-style container-style
+                                                             {:ref #(reset! ref %)})
+                                      [:header {:style {:position "relative"}}
+                                       [:input (use-style athena-input-style
+                                                          {:type        "search"
+                                                           :id          "athena-input"
+                                                           :auto-focus  true
+                                                           :required    true
+                                                           :placeholder "Find or Create Page"
+                                                           :on-change   (fn [e] (search-handler (.. e -target -value)))
+                                                           :on-key-down (fn [e] (key-down-handler e s))})]
+                                       [:button (use-style search-cancel-button-style
+                                                           {:on-click #(set! (.-value (getElement "athena-input")))})
+                                        [:> mui-icons/Close]]]
+                                      [results-el s]
+                                      [(fn []
+                                         (let [{:keys [results query index]} @s]
+                                           [:div (use-style results-list-style)
+                                            (doall
+                                              (for [[i x] (map-indexed list results)
+                                                    :let [parent (:block/parent x)
+                                                          title  (or (:node/title parent) (:node/title x))
+                                                          uid    (or (:block/uid parent) (:block/uid x))
+                                                          string (:block/string x)]]
+                                                (if (nil? x)
+                                                  ^{:key i}
+                                                  [:div (use-style result-style {:on-click (fn [_]
+                                                                                             (let [uid (gen-block-uid)]
+                                                                                               (dispatch [:athena/toggle])
+                                                                                               (dispatch [:page/create query uid])
+                                                                                               (navigate-uid uid)))
+                                                                                 :class    (when (= i index) "selected")})
 
-                     [:div (use-style result-body-style)
-                      [:h4.title (use-sub-style result-style :title)
-                       [:b "Create Page: "]
-                       query]]
-                     [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
+                                                   [:div (use-style result-body-style)
+                                                    [:h4.title (use-sub-style result-style :title)
+                                                     [:b "Create Page: "]
+                                                     query]]
+                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
 
-                    [:div (use-style result-style {:key      i
-                                                   :on-click (fn []
-                                                               (let [selected-page {:node/title   title
-                                                                                    :block/uid    uid
-                                                                                    :block/string string
-                                                                                    :query        query}]
-                                                                 (dispatch [:athena/toggle])
-                                                                 (dispatch [:athena/update-recent-items selected-page])
-                                                                 (navigate-uid uid)))
-                                                   :class    (when (= i index) "selected")})
-                     [:div (use-style result-body-style)
+                                                  [:div (use-style result-style {:key      i
+                                                                                 :on-click (fn []
+                                                                                             (let [selected-page {:node/title   title
+                                                                                                                  :block/uid    uid
+                                                                                                                  :block/string string
+                                                                                                                  :query        query}]
+                                                                                               (dispatch [:athena/toggle])
+                                                                                               (dispatch [:athena/update-recent-items selected-page])
+                                                                                               (navigate-uid uid)))
+                                                                                 :class    (when (= i index) "selected")})
+                                                   [:div (use-style result-body-style)
 
-                      [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
-                      (when string
-                        [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
-                     [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]]
-       #(dispatch [:athena/toggle])])))
+                                                    [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
+                                                    (when string
+                                                      [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
+                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]])))})))
+
+

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -417,7 +417,7 @@
                         :on-click (fn [_] (inline-item-click state (:block/uid block) (or title uid)))
                         :style    {:text-align "left"}}
                 (or title string)])))]]
-       #(swap! state :search/type nil)])))
+       #(swap! state assoc :search/type nil)])))
 
 
 
@@ -444,7 +444,7 @@
                       :active   (= i index)
                       :on-click (fn [_] (slash-item-click state block item))}
               [:<> [(r/adapt-react-class icon)] [:span text] (when kbd [:kbd kbd])]]))]]
-       #(swap! state :search/type nil)])))
+       #(swap! state assoc :search/type nil)])))
 
 
 (defn textarea-paste
@@ -697,13 +697,17 @@
   (let [{:block/keys [uid]} block
         {:context-menu/keys [show x y]} @state]
     (when show
-      [portal/portal-dropdown
-       [:<>
-        [button {:on-mouse-down (fn [e] (copy-refs-mouse-down e uid state))}
-         (case show
-           :one "Copy block ref"
-           :many "Copy block refs")]]
-       x y #(swap! state assoc :context-menu/show false)])))
+      [portal/portal
+       [:div (merge (use-style dropdown-style)
+                    {:style {:position "fixed"
+                             :left     (str x "px")
+                             :top      (str y "px")}})
+        [:div (use-style menu-style)
+         [button {:on-mouse-down (fn [e] (copy-refs-mouse-down e uid state))}
+          (case show
+            :one "Copy block ref"
+            :many "Copy block refs")]]]
+       #(swap! state assoc :context-menu/show false)])))
 
 
 (defn block-refs-count-el
@@ -849,7 +853,6 @@
 
           [inline-search-el block state]
           [slash-menu-el block state]
-          ;;[slash-menu-comp block state]
 
 
           ;; Children

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -1,7 +1,6 @@
 (ns athens.views.blocks
   (:require
     ["@material-ui/icons" :as mui-icons]
-    [athens.views.portal :as portal]
     [athens.db :as db]
     [athens.electron :as electron]
     [athens.events :refer [select-up select-down]]
@@ -12,6 +11,7 @@
     [athens.util :as util :refer [get-dataset-uid mouse-offset vertical-center]]
     [athens.views.buttons :refer [button]]
     [athens.views.dropdown :refer [menu-style dropdown-style]]
+    [athens.views.portal :as portal]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as str]
@@ -418,7 +418,6 @@
                         :style    {:text-align "left"}}
                 (or title string)])))]]
        #(swap! state assoc :search/type nil)])))
-
 
 
 (defn slash-item-click

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -329,73 +329,30 @@
 
 
 (defn menu-dropdown
-  [_node state]
-  (let [ref                  (atom nil)
-        handle-click-outside (fn [e]
-                               (when (and (:menu/show @state)
-                                          (not (.. @ref (contains (.. e -target)))))
-                                 (swap! state assoc :menu/show false)))]
-    (r/create-class
-      {:display-name           "node-page-menu"
-       :component-did-mount    (fn [_this] (listen js/document "mousedown" handle-click-outside))
-       :component-will-unmount (fn [_this] (unlisten js/document "mousedown" handle-click-outside))
-       :reagent-render         (fn [node state]
-                                 (let [{:block/keys [uid] sidebar :page/sidebar title :node/title} node
-                                       {:menu/keys [show x y]} @state
-                                       timeline-page? (is-timeline-page uid)]
-                                   (when show
-                                     [:div (merge (use-style dropdown-style
-                                                             {:ref #(reset! ref %)})
-                                                  {:style {:font-size "14px"
-                                                           :position  "fixed"
-                                                           :left      (str x "px")
-                                                           :top       (str y "px")}})
-                                      [:div (use-style menu-style)
-                                       (if sidebar
-                                         [button {:on-click #(dispatch [:page/remove-shortcut uid])}
-                                          [:<>
-                                           [:> mui-icons/BookmarkBorder]
-                                           [:span "Remove Shortcut"]]]
-                                         [button {:on-click #(dispatch [:page/add-shortcut uid])}
-                                          [:<>
-                                           [:> mui-icons/Bookmark]
-                                           [:span "Add Shortcut"]]])
-                                       (when-not timeline-page?
-                                         [:hr (use-style menu-separator-style)])
-                                       (when-not timeline-page?
-                                         [button {:on-click #(do
-                                                               (navigate :pages)
-                                                               (dispatch [:page/delete uid title]))}
-                                          [:<> [:> mui-icons/Delete] [:span "Delete Page"]]])]])))})))
-
-
-(defn menu-drop
-  [_node state]
-  (fn [node state]
-    (let [{:block/keys [uid] sidebar :page/sidebar title :node/title} node
-          {:menu/keys [show x y]} @state
-          timeline-page? (is-timeline-page uid)]
-      (when show
-        [athens.views.portal/portal-dropdown
-         [:<>
-          (if sidebar
-            [button {:on-click #(dispatch [:page/remove-shortcut uid])}
-             [:<>
-              [:> mui-icons/BookmarkBorder]
-              [:span "Remove Shortcut"]]]
-            [button {:on-click #(dispatch [:page/add-shortcut uid])}
-             [:<>
-              [:> mui-icons/Bookmark]
-              [:span "Add Shortcut"]]])
-          (when-not timeline-page?
-            [:hr (use-style menu-separator-style)])
-          (when-not timeline-page?
-            [button {:on-click #(do
-                                  (navigate :pages)
-                                  (dispatch [:page/delete uid title]))}
-             [:<> [:> mui-icons/Delete] [:span "Delete Page"]]])]
-         state x y :menu/show]))))
-
+  [node state]
+  (let [{:block/keys [uid] sidebar :page/sidebar title :node/title} node
+        {:menu/keys [show x y]} @state
+        timeline-page? (is-timeline-page uid)]
+    (when show
+      [athens.views.portal/portal-dropdown
+       [:<>
+        (if sidebar
+          [button {:on-click #(dispatch [:page/remove-shortcut uid])}
+           [:<>
+            [:> mui-icons/BookmarkBorder]
+            [:span "Remove Shortcut"]]]
+          [button {:on-click #(dispatch [:page/add-shortcut uid])}
+           [:<>
+            [:> mui-icons/Bookmark]
+            [:span "Add Shortcut"]]])
+        (when-not timeline-page?
+          [:hr (use-style menu-separator-style)])
+        (when-not timeline-page?
+          [button {:on-click #(do
+                                (navigate :pages)
+                                (dispatch [:page/delete uid title]))}
+           [:<> [:> mui-icons/Delete] [:span "Delete Page"]]])]
+       state x y :menu/show])))
 
 
 
@@ -485,8 +442,7 @@
           ;;(parse-renderer/parse-and-render title uid)]
 
          ;; Dropdown
-         ;;[menu-dropdown node state]
-         [menu-drop node state]
+         [menu-dropdown node state]
 
          ;; Children
          (if (empty? children)

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -13,6 +13,7 @@
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
     [athens.views.buttons :refer [button]]
     [athens.views.dropdown :refer [dropdown-style menu-style menu-separator-style]]
+    [athens.views.portal :as portal]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as str]
@@ -334,27 +335,29 @@
         {:menu/keys [show x y]} @state
         timeline-page? (is-timeline-page uid)]
     (when show
-      [athens.views.portal/portal-dropdown
-       [:<>
-        (if sidebar
-          [button {:on-click #(dispatch [:page/remove-shortcut uid])}
-           [:<>
-            [:> mui-icons/BookmarkBorder]
-            [:span "Remove Shortcut"]]]
-          [button {:on-click #(dispatch [:page/add-shortcut uid])}
-           [:<>
-            [:> mui-icons/Bookmark]
-            [:span "Add Shortcut"]]])
-        (when-not timeline-page?
-          [:hr (use-style menu-separator-style)])
-        (when-not timeline-page?
-          [button {:on-click #(do
-                                (navigate :pages)
-                                (dispatch [:page/delete uid title]))}
-           [:<> [:> mui-icons/Delete] [:span "Delete Page"]]])]
-       state x y :menu/show])))
-
-
+      [portal/portal
+       [:div (merge (use-style dropdown-style)
+                    {:style {:position "fixed"
+                             :left     (str x "px")
+                             :top      (str y "px")}})
+        [:div (use-style menu-style)
+         (if sidebar
+           [button {:on-click #(dispatch [:page/remove-shortcut uid])}
+            [:<>
+             [:> mui-icons/BookmarkBorder]
+             [:span "Remove Shortcut"]]]
+           [button {:on-click #(dispatch [:page/add-shortcut uid])}
+            [:<>
+             [:> mui-icons/Bookmark]
+             [:span "Add Shortcut"]]])
+         (when-not timeline-page?
+           [:hr (use-style menu-separator-style)])
+         (when-not timeline-page?
+           [button {:on-click #(do
+                                 (navigate :pages)
+                                 (dispatch [:page/delete uid title]))}
+            [:<> [:> mui-icons/Delete] [:span "Delete Page"]]])]]
+       #(swap! state assoc :menu/show false)])))
 
 
 (defn ref-comp

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -19,7 +19,6 @@
     [clojure.string :as str]
     [datascript.core :as d]
     [garden.selectors :as selectors]
-    [goog.events :refer [listen unlisten]]
     [komponentit.autosize :as autosize]
     [re-frame.core :refer [dispatch subscribe]]
     [reagent.core :as r]
@@ -381,6 +380,7 @@
                                             (swap! state assoc :block new-B :parents new-P)))}
                (or title string)]))]
          [block-el block linked-ref-data]]))))
+
 
 (defn get-click-position
   [target]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -382,15 +382,6 @@
          [block-el block linked-ref-data]]))))
 
 
-(defn get-click-position
-  [target]
-  (let [rect (.. target getBoundingClientRect)
-        left (+ (.. rect -x) (/ (.. rect -width) 2))
-        top (+ (.. rect -y) (.. js/window -scrollY))]
-    {:left left
-     :top top}))
-
-
 ;; TODO: where to put page-level link filters?
 (defn node-page-el
   "title/initial is the title when a page is first loaded.

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -7,13 +7,13 @@
 
 
 (defn portal
-  [children state open-key]
+  [children click-outside-handler]
   (let [mount (js/document.getElementById "portal")
         el    (js/document.createElement "div")
         ref                  (atom nil)
         handle-click-outside (fn [e]
                                (when (not (.. @ref (contains (.. e -target))))
-                                 (swap! state assoc open-key false)))]
+                                 (click-outside-handler)))]
     (r/create-class
       {:display-name           "portal"
        :component-did-mount    (fn [_this]
@@ -31,13 +31,13 @@
 
 
 (defn portal-dropdown
-  [children state x y open-key]
+  [children x y click-outside-handler]
   (let [mount                (js/document.getElementById "portal")
         el                   (js/document.createElement "div")
         ref                  (atom nil)
         handle-click-outside (fn [e]
                                (when (not (.. @ref (contains (.. e -target))))
-                                 (swap! state assoc open-key false)))]
+                                 (click-outside-handler)))]
     (r/create-class
       {:display-name           "portal"
        :component-did-mount    (fn [_this]

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -7,9 +7,10 @@
 
 
 (defn portal
+  "Update-in expects a hiccup form with a property map, e.g. [:div {}]"
   [children click-outside-handler]
-  (let [mount (js/document.getElementById "portal")
-        el    (js/document.createElement "div")
+  (let [mount                (js/document.getElementById "portal")
+        el                   (js/document.createElement "div")
         ref                  (atom nil)
         handle-click-outside (fn [e]
                                (when (not (.. @ref (contains (.. e -target))))
@@ -28,34 +29,3 @@
                                                                            {:on-mouse-down (fn [e] (.. e preventDefault))
                                                                             :ref           (fn [e] (reset! ref e))}))]
                                    (createPortal (r/as-element wrapped-children) el)))})))
-
-
-(defn portal-dropdown
-  [children x y click-outside-handler]
-  (let [mount                (js/document.getElementById "portal")
-        el                   (js/document.createElement "div")
-        ref                  (atom nil)
-        handle-click-outside (fn [e]
-                               (when (not (.. @ref (contains (.. e -target))))
-                                 (click-outside-handler)))]
-    (r/create-class
-      {:display-name           "portal"
-       :component-did-mount    (fn [_this]
-                                 (.. mount (appendChild el))
-                                 (events/listen js/document "mousedown" handle-click-outside))
-       :component-will-unmount (fn [_this]
-                                 (.. mount (removeChild el))
-                                 (events/unlisten js/document "mousedown" handle-click-outside))
-       :reagent-render         (fn [children]
-                                 (createPortal (r/as-element [:div (merge (stylefy/use-style dropdown/dropdown-style)
-                                                                          {:style {:position  "fixed"
-                                                                                   :left      (str x "px")
-                                                                                   :top       (str y "px")}}
-                                                                          {:on-mouse-down (fn [e] (.. e preventDefault))
-                                                                           :ref           (fn [e] (reset! ref e))})
-                                                              [:div (stylefy/use-style dropdown/menu-style) children]]) el))})))
-
-
-
-
-

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -1,7 +1,7 @@
 (ns athens.views.portal
   (:require
-    [goog.events :as events]
     ["react-dom" :refer [createPortal]]
+    [goog.events :as events]
     [reagent.core :as r]))
 
 

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -1,13 +1,12 @@
 (ns athens.views.portal
-  (:require ["react-dom" :refer [createPortal]]
-            [reagent.core :as r]
-            [goog.events :as events]
-            [athens.views.dropdown :as dropdown]
-            [stylefy.core :as stylefy]))
+  (:require
+    [goog.events :as events]
+    ["react-dom" :refer [createPortal]]
+    [reagent.core :as r]))
 
 
 (defn portal
-  [children click-outside-handler]
+  [_children click-outside-handler]
   (let [mount                (js/document.getElementById "portal")
         el                   (js/document.createElement "div")
         ref                  (atom nil)

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -1,0 +1,61 @@
+(ns athens.views.portal
+  (:require ["react-dom" :refer [createPortal]]
+            [reagent.core :as r]
+            [goog.events :as events]
+            [athens.views.dropdown :as dropdown]
+            [stylefy.core :as stylefy]))
+
+
+(defn portal
+  [children state open-key]
+  (let [mount (js/document.getElementById "portal")
+        el    (js/document.createElement "div")
+        ref                  (atom nil)
+        handle-click-outside (fn [e]
+                               (when (not (.. @ref (contains (.. e -target))))
+                                 (swap! state assoc open-key false)))]
+    (r/create-class
+      {:display-name           "portal"
+       :component-did-mount    (fn [_this]
+                                 (.. mount (appendChild el))
+                                 (events/listen js/document "mousedown" handle-click-outside))
+       :component-will-unmount (fn [_this]
+                                 (.. mount (removeChild el))
+                                 (events/unlisten js/document "mousedown" handle-click-outside))
+       :reagent-render         (fn [children]
+                                 (let [wrapped-children (update-in children [1]
+                                                                   #(merge %
+                                                                           {:on-mouse-down (fn [e] (.. e preventDefault))
+                                                                            :ref           (fn [e] (reset! ref e))}))]
+                                   (createPortal (r/as-element wrapped-children) el)))})))
+
+
+(defn portal-dropdown
+  [children state x y open-key]
+  (let [mount                (js/document.getElementById "portal")
+        el                   (js/document.createElement "div")
+        ref                  (atom nil)
+        handle-click-outside (fn [e]
+                               (when (not (.. @ref (contains (.. e -target))))
+                                 (swap! state assoc open-key false)))]
+    (r/create-class
+      {:display-name           "portal"
+       :component-did-mount    (fn [_this]
+                                 (.. mount (appendChild el))
+                                 (events/listen js/document "mousedown" handle-click-outside))
+       :component-will-unmount (fn [_this]
+                                 (.. mount (removeChild el))
+                                 (events/unlisten js/document "mousedown" handle-click-outside))
+       :reagent-render         (fn [children]
+                                 (createPortal (r/as-element [:div (merge (stylefy/use-style dropdown/dropdown-style)
+                                                                          {:style {:position  "fixed"
+                                                                                   :left      (str x "px")
+                                                                                   :top       (str y "px")}}
+                                                                          {:on-mouse-down (fn [e] (.. e preventDefault))
+                                                                           :ref           (fn [e] (reset! ref e))})
+                                                              [:div (stylefy/use-style dropdown/menu-style) children]]) el))})))
+
+
+
+
+

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -7,7 +7,6 @@
 
 
 (defn portal
-  "Update-in expects a hiccup form with a property map, e.g. [:div {}]"
   [children click-outside-handler]
   (let [mount                (js/document.getElementById "portal")
         el                   (js/document.createElement "div")
@@ -24,8 +23,10 @@
                                  (.. mount (removeChild el))
                                  (events/unlisten js/document "mousedown" handle-click-outside))
        :reagent-render         (fn [children]
-                                 (let [wrapped-children (update-in children [1]
-                                                                   #(merge %
-                                                                           {:on-mouse-down (fn [e] (.. e preventDefault))
-                                                                            :ref           (fn [e] (reset! ref e))}))]
-                                   (createPortal (r/as-element wrapped-children) el)))})))
+                                 (if (not (map? (second children)))
+                                   (throw (js/Error "Portal expects a hiccup form with a property map as the second item, e.g. [:div {}]"))
+                                   (let [wrapped-children (update-in children [1]
+                                                                     #(merge %
+                                                                             {:on-mouse-down (fn [e] (.. e preventDefault))
+                                                                              :ref           (fn [e] (reset! ref e))}))]
+                                     (createPortal (r/as-element wrapped-children) el))))})))

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -1,3 +1,4 @@
+^:cljstyle/ignore
 (ns athens.views.portal
   (:require
     ["react-dom" :refer [createPortal]]

--- a/src/cljs/athens/views/portal.cljs
+++ b/src/cljs/athens/views/portal.cljs
@@ -13,7 +13,8 @@
         ref                  (atom nil)
         handle-click-outside (fn [e]
                                (when (not (.. @ref (contains (.. e -target))))
-                                 (click-outside-handler)))]
+                                 (when (fn? click-outside-handler)
+                                   (click-outside-handler))))]
     (r/create-class
       {:display-name           "portal"
        :component-did-mount    (fn [_this]


### PR DESCRIPTION
- Used for slash-menu, inline (keyboard-based)
- Used for context-menu, node-page-menu (click-based)
- Couldn't get it to work with Athena, Input wouldn't focus for some reason. Not sure why