### PR TITLE
feat(walk): parse and transact for :page/refs

### DIFF
--- a/src/cljc/athens/walk.cljc
+++ b/src/cljc/athens/walk.cljc
@@ -1,8 +1,6 @@
 (ns athens.walk
   (:require
-    [athens.db :as db]
     [athens.parser :as parser]
-    [athens.util :as util]
     [clojure.string :as str]
     [datascript.core :as d]
     [instaparse.core :as parse]))
@@ -16,139 +14,14 @@
       {:page-link (fn [& title]
                     (let [inner-title (str/join "" title)]
                       (swap! data update :node/titles #(conj % inner-title))
+                      (swap! data update :page/refs #(conj % [:node/title inner-title]))
                       (str "[[" inner-title "]]")))
        :hashtag   (fn [& title]
                     (let [inner-title (str/join "" title)]
                       (swap! data update :node/titles #(conj % inner-title))
+                      (swap! data update :page/refs #(conj % [:node/title inner-title]))
                       (str "#" inner-title)))
        :block-ref (fn [uid] (swap! data update :block/refs #(conj % uid)))}
       (parser/parse-to-ast string))
     @data))
-
-
-(defn new-titles-to-tx-data
-  "Filter: node/title doesn't exist yet in the db or in the titles being asserted (e.g. when renaming a page and changing it's references).
-  Map: new node/title entity."
-  [new-titles assert-titles]
-  (let [now (util/now-ts)]
-    (->> new-titles
-         (filter (fn [x]
-                   (and (nil? (db/search-exact-node-title x))
-                        (not (contains? assert-titles x)))))
-         (map (fn [t]
-                {:node/title  t
-                 :block/uid   (util/gen-block-uid)
-                 :create/time now
-                 :edit/time   now})))))
-
-
-(defn old-titles-to-tx-data
-  "Filter: new-str doesn't include link, page exists, page has no children, and has no other [[linked refs]].
-  Map: retractEntity"
-  [old-titles uid new-str]
-  (->> old-titles
-       (filter (fn [title]
-                 (let [node (db/get-block [:node/title title])]
-                   (and (not (clojure.string/includes? new-str title))
-                        node
-                        (empty? (:block/children node))
-                        (zero? (db/count-linked-references-excl-uid title uid))))))
-       (map (fn [title]
-              (when-let [eid (:db/id (db/get-block [:node/title title]))]
-                [:db/retractEntity eid])))))
-
-
-(defn new-refs-to-tx-data
-  "Filter: ((ref-uid)) points to an actual block (without a title), and block/ref relationship doesn't exist yet.
-  Map: add block/ref relationship."
-  [new-block-refs e]
-  (->> new-block-refs
-       (filter (fn [ref-uid]
-                 (let [block (d/pull @db/dsdb '[*] [:block/uid ref-uid])
-                       {:keys [node/title db/id]} block
-                       refs  (-> e db/get-block-refs set)]
-                   (and block
-                        (nil? title)
-                        (not (contains? refs id))))))
-       (map (fn [ref-uid] [:db/add e :block/refs [:block/uid ref-uid]]))))
-
-
-(defn old-refs-to-tx-data
-  "Filter: new-str doesn't include block ref anymore, ((ref-uid)) points to an actual block, and block/ref relationship exists.
-  Map: retract relationship."
-  [old-block-refs e new-str]
-  (->> old-block-refs
-       (filter (fn [ref-uid]
-                 (when-not (str/includes? new-str (str "((" ref-uid "))"))
-                   (let [eid  (db/e-by-av :block/uid ref-uid)
-                         refs (-> e db/get-block-refs set)]
-                     (contains? refs eid)))))
-       (map (fn [ref-uid] [:db/retract e :block/refs [:block/uid ref-uid]]))))
-
-
-(defn parse-for-links
-  "When block/string is asserted, parse for links and block refs to add.
-  When block/string is retracted, parse for links and block refs to remove.
-  Retractions need to look at asserted block/string.
-
-  TODO: when user edits title, parse for new pages."
-  [with-tx-data]
-  (let [assert-titles (->> with-tx-data
-                           (filter #(and (= (second %) :node/title)
-                                         (true? (last %))))
-                           (map #(nth % 2))
-                           set)]
-    (->> with-tx-data
-         (filter #(= (second %) :block/string))
-         ;; group-by entity
-         (group-by first)
-         ;; map sort-by so [true false] gives us [assertion retraction], [assertion], or [retraction]
-         (mapv (fn [[_eid datoms]]
-                 (sort-by #(-> % last not) datoms)))
-         (mapcat (fn [[assertion retraction]]
-                   (cond
-                     ;; [assertion retraction]
-                     (and (true? (last assertion)) (false? (last retraction)))
-                     (let [eid            (first assertion)
-                           uid            (db/v-by-ea eid :block/uid)
-                           assert-string  (nth assertion 2)
-                           retract-string (nth retraction 2)
-                           assert-data    (walk-string assert-string)
-                           retract-data   (walk-string retract-string)
-                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
-                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
-                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
-                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
-                           tx-data        (concat []
-                                                  new-titles
-                                                  new-block-refs
-                                                  old-titles
-                                                  old-block-refs)]
-                       tx-data)
-
-                     ;; [assertion]
-                     (and (true? (last assertion)) (nil? retraction))
-                     (let [eid            (first assertion)
-                           assert-string  (nth assertion 2)
-                           assert-data    (walk-string assert-string)
-                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
-                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
-                           tx-data        (concat []
-                                                  new-titles
-                                                  new-block-refs)]
-                       tx-data)
-
-                     ;; [retraction]
-                     (and (false? (last assertion)) (nil? retraction))
-                     (let [eid            (first retraction)
-                           uid            (db/v-by-ea eid :block/uid)
-                           assert-string  ""
-                           retract-string (nth retraction 2)
-                           retract-data   (walk-string retract-string)
-                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
-                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
-                           tx-data        (concat []
-                                                  old-titles
-                                                  old-block-refs)]
-                       tx-data)))))))
 

--- a/src/cljc/athens/walk.cljc
+++ b/src/cljc/athens/walk.cljc
@@ -2,7 +2,6 @@
   (:require
     [athens.parser :as parser]
     [clojure.string :as str]
-    [datascript.core :as d]
     [instaparse.core :as parse]))
 
 

--- a/src/cljc/athens/walk.cljc
+++ b/src/cljc/athens/walk.cljc
@@ -1,0 +1,154 @@
+(ns athens.walk
+  (:require
+    [athens.db :as db]
+    [athens.parser :as parser]
+    [athens.util :as util]
+    [clojure.string :as str]
+    [datascript.core :as d]
+    [instaparse.core :as parse]))
+
+
+(defn walk-string
+  "Walk previous and new strings to delete or add links, block references, etc. to datascript."
+  [string]
+  (let [data (atom {})]
+    (parse/transform
+      {:page-link (fn [& title]
+                    (let [inner-title (str/join "" title)]
+                      (swap! data update :node/titles #(conj % inner-title))
+                      (str "[[" inner-title "]]")))
+       :hashtag   (fn [& title]
+                    (let [inner-title (str/join "" title)]
+                      (swap! data update :node/titles #(conj % inner-title))
+                      (str "#" inner-title)))
+       :block-ref (fn [uid] (swap! data update :block/refs #(conj % uid)))}
+      (parser/parse-to-ast string))
+    @data))
+
+
+(defn new-titles-to-tx-data
+  "Filter: node/title doesn't exist yet in the db or in the titles being asserted (e.g. when renaming a page and changing it's references).
+  Map: new node/title entity."
+  [new-titles assert-titles]
+  (let [now (util/now-ts)]
+    (->> new-titles
+         (filter (fn [x]
+                   (and (nil? (db/search-exact-node-title x))
+                        (not (contains? assert-titles x)))))
+         (map (fn [t]
+                {:node/title  t
+                 :block/uid   (util/gen-block-uid)
+                 :create/time now
+                 :edit/time   now})))))
+
+
+(defn old-titles-to-tx-data
+  "Filter: new-str doesn't include link, page exists, page has no children, and has no other [[linked refs]].
+  Map: retractEntity"
+  [old-titles uid new-str]
+  (->> old-titles
+       (filter (fn [title]
+                 (let [node (db/get-block [:node/title title])]
+                   (and (not (clojure.string/includes? new-str title))
+                        node
+                        (empty? (:block/children node))
+                        (zero? (db/count-linked-references-excl-uid title uid))))))
+       (map (fn [title]
+              (when-let [eid (:db/id (db/get-block [:node/title title]))]
+                [:db/retractEntity eid])))))
+
+
+(defn new-refs-to-tx-data
+  "Filter: ((ref-uid)) points to an actual block (without a title), and block/ref relationship doesn't exist yet.
+  Map: add block/ref relationship."
+  [new-block-refs e]
+  (->> new-block-refs
+       (filter (fn [ref-uid]
+                 (let [block (d/pull @db/dsdb '[*] [:block/uid ref-uid])
+                       {:keys [node/title db/id]} block
+                       refs  (-> e db/get-block-refs set)]
+                   (and block
+                        (nil? title)
+                        (not (contains? refs id))))))
+       (map (fn [ref-uid] [:db/add e :block/refs [:block/uid ref-uid]]))))
+
+
+(defn old-refs-to-tx-data
+  "Filter: new-str doesn't include block ref anymore, ((ref-uid)) points to an actual block, and block/ref relationship exists.
+  Map: retract relationship."
+  [old-block-refs e new-str]
+  (->> old-block-refs
+       (filter (fn [ref-uid]
+                 (when-not (str/includes? new-str (str "((" ref-uid "))"))
+                   (let [eid  (db/e-by-av :block/uid ref-uid)
+                         refs (-> e db/get-block-refs set)]
+                     (contains? refs eid)))))
+       (map (fn [ref-uid] [:db/retract e :block/refs [:block/uid ref-uid]]))))
+
+
+(defn parse-for-links
+  "When block/string is asserted, parse for links and block refs to add.
+  When block/string is retracted, parse for links and block refs to remove.
+  Retractions need to look at asserted block/string.
+
+  TODO: when user edits title, parse for new pages."
+  [with-tx-data]
+  (let [assert-titles (->> with-tx-data
+                           (filter #(and (= (second %) :node/title)
+                                         (true? (last %))))
+                           (map #(nth % 2))
+                           set)]
+    (->> with-tx-data
+         (filter #(= (second %) :block/string))
+         ;; group-by entity
+         (group-by first)
+         ;; map sort-by so [true false] gives us [assertion retraction], [assertion], or [retraction]
+         (mapv (fn [[_eid datoms]]
+                 (sort-by #(-> % last not) datoms)))
+         (mapcat (fn [[assertion retraction]]
+                   (cond
+                     ;; [assertion retraction]
+                     (and (true? (last assertion)) (false? (last retraction)))
+                     (let [eid            (first assertion)
+                           uid            (db/v-by-ea eid :block/uid)
+                           assert-string  (nth assertion 2)
+                           retract-string (nth retraction 2)
+                           assert-data    (walk-string assert-string)
+                           retract-data   (walk-string retract-string)
+                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
+                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
+                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
+                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
+                           tx-data        (concat []
+                                                  new-titles
+                                                  new-block-refs
+                                                  old-titles
+                                                  old-block-refs)]
+                       tx-data)
+
+                     ;; [assertion]
+                     (and (true? (last assertion)) (nil? retraction))
+                     (let [eid            (first assertion)
+                           assert-string  (nth assertion 2)
+                           assert-data    (walk-string assert-string)
+                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
+                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
+                           tx-data        (concat []
+                                                  new-titles
+                                                  new-block-refs)]
+                       tx-data)
+
+                     ;; [retraction]
+                     (and (false? (last assertion)) (nil? retraction))
+                     (let [eid            (first retraction)
+                           uid            (db/v-by-ea eid :block/uid)
+                           assert-string  ""
+                           retract-string (nth retraction 2)
+                           retract-data   (walk-string retract-string)
+                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
+                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
+                           tx-data        (concat []
+                                                  old-titles
+                                                  old-block-refs)]
+                       tx-data)))))))
+

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -226,7 +226,7 @@
 
 
 (def block-document-pull-vector
-  '[:db/id :block/uid :block/string :block/open :block/order {:block/children ...} :block/_refs])
+  '[:db/id :block/uid :block/string :block/open :block/order {:block/children ...} :block/refs :block/_refs])
 
 
 (def node-document-pull-vector

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -20,26 +20,201 @@
 
 ;;; Effects
 
+(defn new-titles-to-tx-data
+  "Filter: node/title doesn't exist yet in the db or in the titles being asserted (e.g. when renaming a page and changing it's references).
+  Map: new node/title entity."
+  [new-titles assert-titles]
+  (let [now (util/now-ts)]
+    (->> new-titles
+         (filter (fn [x]
+                   (and (nil? (db/search-exact-node-title x))
+                        (not (contains? assert-titles x)))))
+         (map (fn [t]
+                {:node/title  t
+                 :block/uid   (util/gen-block-uid)
+                 :create/time now
+                 :edit/time   now})))))
+
+
+(defn old-titles-to-tx-data
+  "Filter: new-str doesn't include link, page exists, page has no children, and has no other [[linked refs]].
+  Map: retractEntity"
+  [old-titles uid new-str]
+  (->> old-titles
+       (filter (fn [title]
+                 (let [node (db/get-block [:node/title title])]
+                   (and (not (clojure.string/includes? new-str title))
+                        node
+                        (empty? (:block/children node))
+                        (zero? (db/count-linked-references-excl-uid title uid))))))
+       (map (fn [title]
+              (when-let [eid (:db/id (db/get-block [:node/title title]))]
+                [:db/retractEntity eid])))))
+
+
+(defn new-refs-to-tx-data
+  "Filter: ((ref-uid)) points to an actual block (without a title), and block/ref relationship doesn't exist yet.
+  Map: add block/ref relationship."
+  [new-block-refs e]
+  (->> new-block-refs
+       (filter (fn [ref-uid]
+                 (let [block (d/q '[:find (pull ?e [*])
+                                    :in $ ?uid
+                                    :where [?e :block/uid ?uid]]
+                                  @db/dsdb
+                                  ref-uid)
+                       {:keys [node/title db/id]} block
+                       refs  (-> e db/get-block-refs set)]
+                   (and block
+                        (nil? title)
+                        (not (contains? refs id))))))
+       (map (fn [ref-uid] [:db/add e :block/refs [:block/uid ref-uid]]))))
+
+
+(defn new-page-refs-to-tx-data
+  "Filter: [[node]] points to a real page (has :node/title) and block/ref relationship doesn't exist yet.
+  Map: add block/ref relationship."
+  [new-page-refs source-eid]
+  (->> new-page-refs
+       (map #(apply db/e-by-av %))
+       (filter (fn [target-eid]
+                 (let [block (d/pull @db/dsdb '[*] target-eid)
+                       {:keys [db/id]} block
+                       refs  (-> source-eid db/get-block-refs set)]
+                   (and block
+                        (not (contains? refs id))))))
+       (map (fn [page-id] [:db/add source-eid :block/refs page-id]))))
+
+
+(defn old-refs-to-tx-data
+  "Filter: new-str doesn't include block ref anymore, ((ref-uid)) points to an actual block, and block/ref relationship exists.
+  Map: retract relationship."
+  [old-block-refs e new-str]
+  (->> old-block-refs
+       (filter (fn [ref-uid]
+                 (let [eid  (db/e-by-av :block/uid ref-uid)
+                       refs (-> e db/get-block-refs set)]
+                   (and (not (str/includes? new-str (str "((" ref-uid "))")))
+                        (contains? refs eid)))))
+       (map (fn [ref-uid] [:db/retract e :block/refs [:block/uid ref-uid]]))))
+
+
+(defn old-page-refs-to-tx-data
+  "Filter: [[page]] points to a page and block/ref relationship does exist.
+  Map: retract block/ref relationship."
+  [old-page-refs source-eid new-str]
+  (->> old-page-refs
+       (filter (fn [page-id]
+                 (let [page (d/pull @db/dsdb '[*] page-id)
+                       {:keys [node/title db/id]} page
+                       refs  (-> source-eid db/get-block-refs set)]
+                   (and (not (str/includes? new-str (str "[[" title "]]")))
+                        page
+                        title
+                        (contains? refs id)))))
+       (map (fn [page-id] [:db/retract source-eid :block/refs page-id]))))
+
+
+(defn parse-for-links
+  "When block/string is asserted, parse for links and block refs to add.
+  When block/string is retracted, parse for links and block refs to remove.
+  Retractions need to look at asserted block/string.
+
+  TODO: when user edits title, parse for new pages."
+  [with-tx-data]
+  (let [assert-titles (->> with-tx-data
+                           (filter #(and (= (second %) :node/title)
+                                         (true? (last %))))
+                           (map #(nth % 2))
+                           set)]
+    (->> with-tx-data
+         (filter #(= (second %) :block/string))
+         ;; group-by entity
+         (group-by first)
+         ;; map sort-by so [true false] gives us [assertion retraction], [assertion], or [retraction]
+         (mapv (fn [[_eid datoms]]
+                 (sort-by #(-> % last not) datoms)))
+         (mapcat (fn [[assertion retraction]]
+                   (cond
+                     ;; [assertion retraction]
+                     (and (true? (last assertion)) (false? (last retraction)))
+                     (let [eid            (first assertion)
+                           uid            (db/v-by-ea eid :block/uid)
+                           assert-string  (nth assertion 2)
+                           retract-string (nth retraction 2)
+                           assert-data    (walk/walk-string assert-string)
+                           retract-data   (walk/walk-string retract-string)
+                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
+                           new-page-refs  (new-page-refs-to-tx-data (:page/refs assert-data) eid)
+                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
+                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
+                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
+                           old-page-refs  (old-page-refs-to-tx-data (:page/refs retract-data) eid assert-string)
+                           tx-data        (concat []
+                                                  new-titles
+                                                  new-block-refs
+                                                  new-page-refs
+                                                  old-titles
+                                                  old-block-refs
+                                                  old-page-refs)]
+                       tx-data)
+
+                     ;; [assertion]
+                     (and (true? (last assertion)) (nil? retraction))
+                     (let [eid            (first assertion)
+                           assert-string  (nth assertion 2)
+                           assert-data    (walk/walk-string assert-string)
+                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
+                           new-page-refs  (new-page-refs-to-tx-data (:page/refs assert-data) eid)
+                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
+                           tx-data        (concat []
+                                                  new-titles
+                                                  new-block-refs)]
+                                                  ;;new-page-refs)]
+                       tx-data)
+
+                     ;; [retraction]
+                     (and (false? (last assertion)) (nil? retraction))
+                     (let [eid            (first retraction)
+                           uid            (db/v-by-ea eid :block/uid)
+                           assert-string  ""
+                           retract-string (nth retraction 2)
+                           retract-data   (walk/walk-string retract-string)
+                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
+                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
+                           old-page-refs  (old-page-refs-to-tx-data (:page/refs retract-data) eid assert-string)
+                           tx-data        (concat []
+                                                  old-titles
+                                                  old-block-refs)]
+                                                  ;;old-page-refs)]
+                       tx-data)))))))
+
+
+(defn walk-transact
+  [tx-data]
+  (prn "TX RAW INPUTS")                                     ;; event tx-data
+  (pprint tx-data)
+  (try
+    (let [with-tx-data  (:tx-data (d/with @db/dsdb tx-data))
+          more-tx-data  (parse-for-links with-tx-data)
+          final-tx-data (vec (concat tx-data more-tx-data))]
+      ;;(prn "TX WITH")                                       ;; tx-data normalized by datascript to flat datoms
+      ;;(pprint with-tx-data)
+      ;;(prn "TX FINAL INPUTS")                               ;; parsing block/string (and node/title) to derive asserted or retracted titles and block refs
+      (pprint final-tx-data)
+      (prn "TX OUTPUTS")
+      (let [outputs (:tx-data (transact! db/dsdb final-tx-data))]
+        (pprint outputs)))
+    (catch js/Error e
+      (js/alert (str e))
+      (prn "EXCEPTION" e))))
+
 
 (reg-fx
   :transact!
   (fn [tx-data]
-    (prn "TX RAW INPUTS") ;; event tx-data
-    (pprint tx-data)
-    (try
-      (let [with-tx-data  (:tx-data (d/with @db/dsdb tx-data))
-            more-tx-data  (walk/parse-for-links with-tx-data)
-            final-tx-data (vec (concat tx-data more-tx-data))]
-        ;;(prn "TX WITH") ;; tx-data normalized by datascript to flat datoms
-        ;;(pprint with-tx-data)
-        (prn "TX FINAL INPUTS")                             ;; parsing block/string (and node/title) to derive asserted or retracted titles and block refs
-        (pprint final-tx-data)
-        (prn "TX OUTPUTS")
-        (let [outputs (:tx-data (transact! db/dsdb final-tx-data))]
-          (pprint outputs)))
-      (catch js/Error e
-        (js/alert (str e))
-        (prn "EXCEPTION" e)))))
+    (walk-transact tx-data)))
+
 
 
 (reg-fx

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -14,154 +14,11 @@
     [instaparse.core :as parse]
     [posh.reagent :as p :refer [transact!]]
     [re-frame.core :refer [dispatch reg-fx]]
-    [stylefy.core :as stylefy]))
+    [stylefy.core :as stylefy]
+    [athens.walk :as walk]))
 
 
 ;;; Effects
-
-(defn walk-string
-  "Walk previous and new strings to delete or add links, block references, etc. to datascript."
-  [string]
-  (let [data (atom {})]
-    (parse/transform
-      {:page-link (fn [& title]
-                    (let [inner-title (str/join "" title)]
-                      (swap! data update :node/titles #(conj % inner-title))
-                      (str "[[" inner-title "]]")))
-       :hashtag   (fn [& title]
-                    (let [inner-title (str/join "" title)]
-                      (swap! data update :node/titles #(conj % inner-title))
-                      (str "#" inner-title)))
-       :block-ref (fn [uid] (swap! data update :block/refs #(conj % uid)))}
-      (parser/parse-to-ast string))
-    @data))
-
-
-(defn new-titles-to-tx-data
-  "Filter: node/title doesn't exist yet in the db or in the titles being asserted (e.g. when renaming a page and changing it's references).
-  Map: new node/title entity."
-  [new-titles assert-titles]
-  (let [now (now-ts)]
-    (->> new-titles
-         (filter (fn [x]
-                   (and (nil? (db/search-exact-node-title x))
-                        (not (contains? assert-titles x)))))
-         (map (fn [t]
-                {:node/title  t
-                 :block/uid   (gen-block-uid)
-                 :create/time now
-                 :edit/time   now})))))
-
-
-(defn old-titles-to-tx-data
-  "Filter: new-str doesn't include link, page exists, page has no children, and has no other [[linked refs]].
-  Map: retractEntity"
-  [old-titles uid new-str]
-  (->> old-titles
-       (filter (fn [title]
-                 (let [node (db/get-block [:node/title title])]
-                   (and (not (clojure.string/includes? new-str title))
-                        node
-                        (empty? (:block/children node))
-                        (zero? (db/count-linked-references-excl-uid title uid))))))
-       (map (fn [title]
-              (when-let [eid (:db/id (db/get-block [:node/title title]))]
-                [:db/retractEntity eid])))))
-
-
-(defn new-refs-to-tx-data
-  "Filter: ((ref-uid)) points to an actual block (without a title), and block/ref relationship doesn't exist yet.
-  Map: add block/ref relationship."
-  [new-block-refs e]
-  (->> new-block-refs
-       (filter (fn [ref-uid]
-                 (let [block @(p/pull db/dsdb '[*] [:block/uid ref-uid])
-                       {:keys [node/title db/id]} block
-                       refs  (-> e db/get-block-refs set)]
-                   (and block
-                        (nil? title)
-                        (not (contains? refs id))))))
-       (map (fn [ref-uid] [:db/add e :block/refs [:block/uid ref-uid]]))))
-
-
-(defn old-refs-to-tx-data
-  "Filter: new-str doesn't include block ref anymore, ((ref-uid)) points to an actual block, and block/ref relationship exists.
-  Map: retract relationship."
-  [old-block-refs e new-str]
-  (->> old-block-refs
-       (filter (fn [ref-uid]
-                 (when-not (str/includes? new-str (str "((" ref-uid "))"))
-                   (let [eid  (db/e-by-av :block/uid ref-uid)
-                         refs (-> e db/get-block-refs set)]
-                     (contains? refs eid)))))
-       (map (fn [ref-uid] [:db/retract e :block/refs [:block/uid ref-uid]]))))
-
-
-(defn parse-for-links
-  "When block/string is asserted, parse for links and block refs to add.
-  When block/string is retracted, parse for links and block refs to remove.
-  Retractions need to look at asserted block/string.
-
-  TODO: when user edits title, parse for new pages."
-  [with-tx-data]
-  (let [assert-titles (->> with-tx-data
-                           (filter #(and (= (second %) :node/title)
-                                         (true? (last %))))
-                           (map #(nth % 2))
-                           set)]
-    (->> with-tx-data
-         (filter #(= (second %) :block/string))
-         ;; group-by entity
-         (group-by first)
-         ;; map sort-by so [true false] gives us [assertion retraction], [assertion], or [retraction]
-         (mapv (fn [[_eid datoms]]
-                 (sort-by #(-> % last not) datoms)))
-         (mapcat (fn [[assertion retraction]]
-                   (cond
-                     ;; [assertion retraction]
-                     (and (true? (last assertion)) (false? (last retraction)))
-                     (let [eid            (first assertion)
-                           uid            (db/v-by-ea eid :block/uid)
-                           assert-string  (nth assertion 2)
-                           retract-string (nth retraction 2)
-                           assert-data    (walk-string assert-string)
-                           retract-data   (walk-string retract-string)
-                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
-                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
-                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
-                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
-                           tx-data        (concat []
-                                                  new-titles
-                                                  new-block-refs
-                                                  old-titles
-                                                  old-block-refs)]
-                       tx-data)
-
-                     ;; [assertion]
-                     (and (true? (last assertion)) (nil? retraction))
-                     (let [eid            (first assertion)
-                           assert-string  (nth assertion 2)
-                           assert-data    (walk-string assert-string)
-                           new-titles     (new-titles-to-tx-data (:node/titles assert-data) assert-titles)
-                           new-block-refs (new-refs-to-tx-data (:block/refs assert-data) eid)
-                           tx-data        (concat []
-                                                  new-titles
-                                                  new-block-refs)]
-                       tx-data)
-
-                     ;; [retraction]
-                     (and (false? (last assertion)) (nil? retraction))
-                     (let [eid            (first retraction)
-                           uid            (db/v-by-ea eid :block/uid)
-                           assert-string  ""
-                           retract-string (nth retraction 2)
-                           retract-data   (walk-string retract-string)
-                           old-titles     (old-titles-to-tx-data (:node/titles retract-data) uid assert-string)
-                           old-block-refs (old-refs-to-tx-data (:block/refs retract-data) eid assert-string)
-                           tx-data        (concat []
-                                                  old-titles
-                                                  old-block-refs)]
-                       tx-data)))))))
 
 
 (reg-fx
@@ -171,7 +28,7 @@
     (pprint tx-data)
     (try
       (let [with-tx-data  (:tx-data (d/with @db/dsdb tx-data))
-            more-tx-data  (parse-for-links with-tx-data)
+            more-tx-data  (walk/parse-for-links with-tx-data)
             final-tx-data (vec (concat tx-data more-tx-data))]
         ;;(prn "TX WITH") ;; tx-data normalized by datascript to flat datoms
         ;;(pprint with-tx-data)

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -1,8 +1,8 @@
 (ns athens.effects
   (:require
     [athens.db :as db]
-    [athens.parser :as parser]
-    [athens.util :as util :refer [now-ts gen-block-uid]]
+    [athens.util :as util]
+    [athens.walk :as walk]
     [cljs-http.client :as http]
     [cljs.core.async :refer [go <!]]
     [cljs.pprint :refer [pprint]]
@@ -11,11 +11,9 @@
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
     [goog.dom.selection :refer [setCursorPosition]]
-    [instaparse.core :as parse]
     [posh.reagent :as p :refer [transact!]]
     [re-frame.core :refer [dispatch reg-fx]]
-    [stylefy.core :as stylefy]
-    [athens.walk :as walk]))
+    [stylefy.core :as stylefy]))
 
 
 ;;; Effects
@@ -217,7 +215,6 @@
   :transact!
   (fn [tx-data]
     (walk-transact tx-data)))
-
 
 
 (reg-fx

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -369,7 +369,7 @@
 
 (defn tooltip-el
   [block state]
-  (let [{:block/keys [uid order open] dbid :db/id} block
+  (let [{:block/keys [uid order open refs] dbid :db/id} block
         {:keys [dragging tooltip]} @state]
     ;; if re-frame-10x is hidden, don't show tooltip. see style.cljs
     (when (and tooltip (not dragging) (util/re-frame-10x-open?))
@@ -380,7 +380,8 @@
        [:div [:b "db/id"] [:span dbid]]
        [:div [:b "uid"] [:span uid]]
        [:div [:b "order"] [:span order]]
-       [:div [:b "open"] [:span (str open)]]])))
+       [:div [:b "open"] [:span (str open)]]
+       [:div [:b "refs"] [:span (str refs)]]])))
 
 
 (defn inline-item-click

--- a/test/athens/walk_test.clj
+++ b/test/athens/walk_test.clj
@@ -1,2 +1,27 @@
 (ns athens.walk-test
-  (:require [clojure.test :refer :all]))
+  (:require [clojure.test :refer [deftest is are run-tests]]
+            [datascript.core :as d]
+            [athens.walk :as walk]))
+
+
+(deftest db-test
+  (are [x y] (= (walk/walk-string x) y)
+
+             "[[hey]]"
+             {:node/titles ["hey"] :page/refs [[:node/title "hey"]]}
+
+             "#hola"
+             {:node/titles ["hola"] :page/refs [[:node/title "hola"]]}
+
+             ;; order matters
+             ;; ["ma" "ni hao"] != ["ni hao" "ma"]
+             ;;"[[ni hao]] #ma"
+             ;;{:node/titles ["ma" "ni hao"]}
+
+             "#[[aloha]]"
+             {:node/titles ["aloha"]}
+
+             "((uid123))"
+             {:block/refs ["uid123"]}))
+
+(run-tests)

--- a/test/athens/walk_test.clj
+++ b/test/athens/walk_test.clj
@@ -1,27 +1,29 @@
 (ns athens.walk-test
-  (:require [clojure.test :refer [deftest is are run-tests]]
-            [datascript.core :as d]
-            [athens.walk :as walk]))
+  (:require
+    [athens.walk :as walk]
+    [clojure.test :refer [deftest is are run-tests]]
+    [datascript.core :as d]))
 
 
 (deftest db-test
   (are [x y] (= (walk/walk-string x) y)
 
-             "[[hey]]"
-             {:node/titles ["hey"] :page/refs [[:node/title "hey"]]}
+    "[[hey]]"
+    {:node/titles ["hey"] :page/refs [[:node/title "hey"]]}
 
-             "#hola"
-             {:node/titles ["hola"] :page/refs [[:node/title "hola"]]}
+    "#hola"
+    {:node/titles ["hola"] :page/refs [[:node/title "hola"]]}
 
              ;; order matters
              ;; ["ma" "ni hao"] != ["ni hao" "ma"]
              ;;"[[ni hao]] #ma"
              ;;{:node/titles ["ma" "ni hao"]}
 
-             "#[[aloha]]"
-             {:node/titles ["aloha"]}
+    "#[[aloha]]"
+    {:node/titles ["aloha"]}
 
-             "((uid123))"
-             {:block/refs ["uid123"]}))
+    "((uid123))"
+    {:block/refs ["uid123"]}))
+
 
 (run-tests)

--- a/test/athens/walk_test.clj
+++ b/test/athens/walk_test.clj
@@ -20,10 +20,7 @@
              ;;{:node/titles ["ma" "ni hao"]}
 
     "#[[aloha]]"
-    {:node/titles ["aloha"]}
+    {:node/titles ["aloha"] :page/refs [[:node/title "aloha"]]}
 
     "((uid123))"
     {:block/refs ["uid123"]}))
-
-
-(run-tests)

--- a/test/athens/walk_test.clj
+++ b/test/athens/walk_test.clj
@@ -1,0 +1,2 @@
+(ns athens.walk-test
+  (:require [clojure.test :refer :all]))


### PR DESCRIPTION
The attribute is still technically `:block/refs`, even though we are creating references to a [[page]], not a block, to follow Roam spec.

First in a series of PRs. Next up:

- Remove unnecessary functions like `old-block-refs-to-tx-data` and `old-page-refs-to-tx-data`. DataScript `d/with` handles cleanup of references.
- Purpose of `old-titles-to-tx-data` is slightly different: remove orphan pages.