### PR TITLE
feat(references): toggle refs, Link and Link All

### DIFF
--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -9,6 +9,7 @@
                    "|" "(#)" string
                    "|" "(#\\[{2})" string "(\\]{2})")))
 
+
 (defn unlinked
   "Exclude #title or [[title]].
    JavaScript negative lookarounds https://javascript.info/regexp-lookahead-lookbehind

--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -9,7 +9,9 @@
                    "|" "(#)" string
                    "|" "(#\\[{2})" string "(\\]{2})")))
 
-; also excludes [title] :(
 (defn unlinked
+  "Exclude #title or [[title]].
+   JavaScript negative lookarounds https://javascript.info/regexp-lookahead-lookbehind
+   Lookarounds don't consume characters https://stackoverflow.com/questions/27179991/regex-matching-multiple-negative-lookahead "
   [string]
-  (re-pattern (str "(?i)[^\\[|#]" string)))
+  (re-pattern (str "(?i)(?<!#)(?<!\\[\\[)" string "(?!\\]\\])")))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1317,7 +1317,7 @@
   `TEST 10` -> [[test 10]]"
   [string title]
   (let [ignore-case-title (re-pattern (str "(?i)" title))
-        new-str           (string/replace-first string ignore-case-title (str "[[" title "]]"))]
+        new-str           (string/replace string ignore-case-title (str "[[" title "]]"))]
     new-str))
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1311,3 +1311,30 @@
              {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
 
 
+(defn link-unlinked-reference
+  "Ignores case. If title is `test`:
+  `test 1`  -> [[test 1]]
+  `TEST 10` -> [[test 10]]"
+  [string title]
+  (let [ignore-case-title (re-pattern (str "(?i)" title))
+        new-str           (string/replace-first string ignore-case-title (str "[[" title "]]"))]
+    new-str))
+
+
+(reg-event-fx
+  :unlinked-references/link
+  (fn [_ [_ block title]]
+    (let [{:block/keys [string uid]} block
+          new-str (link-unlinked-reference string title)]
+      {:dispatch [:transact [{:db/id [:block/uid uid] :block/string new-str}]]})))
+
+
+(reg-event-fx
+  :unlinked-references/link-all
+  (fn [_ [_ unlinked-refs title]]
+    (let [new-str-tx-data (->> unlinked-refs
+                               (mapcat second unlinked-refs)
+                               (map (fn [{:block/keys [string uid]}]
+                                      (let [new-str (link-unlinked-reference string title)]
+                                        {:db/id [:block/uid uid] :block/string new-str}))))]
+      {:dispatch [:transact new-str-tx-data]})))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1313,8 +1313,9 @@
 
 (defn link-unlinked-reference
   "Ignores case. If title is `test`:
-  `test 1`  -> [[test 1]]
-  `TEST 10` -> [[test 10]]"
+  test 1     -> [[test 1]]
+  TEST 10    -> [[test 10]]
+  [[attest]] -> [[at[[test]]`"
   [string title]
   (let [ignore-case-title (re-pattern (str "(?i)" title))
         new-str           (string/replace string ignore-case-title (str "[[" title "]]"))]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -317,15 +317,17 @@
 
 
 (def init-state
-  {:menu/show        false
-   :menu/x           nil
-   :menu/y           nil
-   :title/initial    nil
-   :title/local      nil
-   :alert/show       nil
-   :alert/message    nil
-   :alert/confirm-fn nil
-   :alert/cancel-fn  nil})
+  {:menu/show            false
+   :menu/x               nil
+   :menu/y               nil
+   :title/initial        nil
+   :title/local          nil
+   :alert/show           nil
+   :alert/message        nil
+   :alert/confirm-fn     nil
+   :alert/cancel-fn      nil
+   "Linked References"   true
+   "Unlinked References" false})
 
 
 (defn menu-dropdown
@@ -463,20 +465,25 @@
              (when (not-empty refs)
                [:section (use-style references-style {:key linked-or-unlinked})
                 [:h4 (use-style references-heading-style)
+                 [button {:on-click (fn [] (swap! state update linked-or-unlinked not))}
+                  (if (get @state linked-or-unlinked)
+                    [:> mui-icons/KeyboardArrowDown]
+                    [:> mui-icons/ChevronRight])]
                  [(r/adapt-react-class mui-icons/Link)]
                  [:span linked-or-unlinked]]
                  ;; Hide button until feature is implemented
                  ;;[button {:disabled true} [(r/adapt-react-class mui-icons/FilterList)]]]
-                [:div (use-style references-list-style)
-                 (doall
-                   (for [[group-title group] refs]
-                     [:div (use-style references-group-style {:key (str "group-" group-title)})
-                      [:h4 (use-style references-group-title-style)
-                       [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
-                      (doall
-                        (for [block group]
-                          [:div (use-style references-group-block-style {:key (str "ref-" (:block/uid block))})
-                           [ref-comp block]]))]))]])))]))))
+                (when (get @state linked-or-unlinked)
+                  [:div (use-style references-list-style)
+                   (doall
+                     (for [[group-title group] refs]
+                       [:div (use-style references-group-style {:key (str "group-" group-title)})
+                        [:h4 (use-style references-group-title-style)
+                         [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
+                        (doall
+                          (for [block group]
+                            [:div (use-style references-group-block-style {:key (str "ref-" (:block/uid block))})
+                             [ref-comp block]]))]))])])))]))))
 
 
 (defn node-page-component
@@ -484,7 +491,6 @@
   (let [{:keys [#_block/uid node/title] :as node} (db/get-node-document ident)
         editing-uid @(subscribe [:editing/uid])]
     (when-not (str/blank? title)
-      ;; TODO: let users toggle open/close references
       (let [ref-groups [["Linked References" (get-linked-references (escape-str title))]
                         ["Unlinked References" (get-unlinked-references (escape-str title))]]]
         [node-page-el node editing-uid ref-groups]))))

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -87,11 +87,10 @@
 (def references-heading-style
   {:font-weight "normal"
    :display "flex"
-   ;;:padding "0 2rem"
+   :padding "0 0.5rem 0 0"
    :align-items "center"
    ::stylefy/manual [[:svg {:margin-right "0.25em"
-                            :font-size "1rem"}]
-                     [:span {:flex "1 1 100%"}]]})
+                            :font-size "1rem"}]]})
 
 
 (def references-list-style
@@ -470,7 +469,14 @@
                     [:> mui-icons/KeyboardArrowDown]
                     [:> mui-icons/ChevronRight])]
                  [(r/adapt-react-class mui-icons/Link)]
-                 [:span linked-or-unlinked]]
+                 [:div {:style {:display "flex"
+                                :flex "1 1 100%"
+                                :justify-content "space-between"}}
+                  [:span linked-or-unlinked]
+                  (when (= linked-or-unlinked "Unlinked References")
+                    [button {:style {:font-size "14px"}
+                             :on-click #(dispatch [:unlinked-references/link-all refs title])}
+                     "Link All"])]]
                  ;; Hide button until feature is implemented
                  ;;[button {:disabled true} [(r/adapt-react-class mui-icons/FilterList)]]]
                 (when (get @state linked-or-unlinked)
@@ -482,8 +488,17 @@
                          [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
                         (doall
                           (for [block group]
-                            [:div (use-style references-group-block-style {:key (str "ref-" (:block/uid block))})
-                             [ref-comp block]]))]))])])))]))))
+                            ^{:key (str "ref-" (:block/uid block))}
+                            [:div {:style {:display "flex"
+                                           :flex "1 1 100%"
+                                           :justify-content "space-between"
+                                           :align-items "flex-start"}}
+                             [:div (use-style references-group-block-style)
+                              [ref-comp block]]
+                             (when (= linked-or-unlinked "Unlinked References")
+                               [button {:style {:margin-top "1.5em"}
+                                        :on-click #(dispatch [:unlinked-references/link block title])}
+                                "Link"])]))]))])])))]))))
 
 
 (defn node-page-component


### PR DESCRIPTION
- [X] toggle links and unlinked references
- [X] unlinked references are closed by default
- [X] implement "Link" and "Link All"
- [ ] don't query for unlinked until they are open
- [ ] parse db to generate links references from normal [[links]]
- [ ] query linked references with `:block/refs`