### PR TITLE
feat(refs): linked refs actually found using datalog queries now

### DIFF
--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -9,6 +9,7 @@
                    "|" "(#)" string
                    "|" "(#\\[{2})" string "(\\]{2})")))
 
+
 (defn unlinked
   "Exclude #title or [[title]].
    JavaScript negative lookarounds https://javascript.info/regexp-lookahead-lookbehind

--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -9,10 +9,17 @@
                    "|" "(#)" string
                    "|" "(#\\[{2})" string "(\\]{2})")))
 
-
 (defn unlinked
   "Exclude #title or [[title]].
    JavaScript negative lookarounds https://javascript.info/regexp-lookahead-lookbehind
    Lookarounds don't consume characters https://stackoverflow.com/questions/27179991/regex-matching-multiple-negative-lookahead "
   [string]
   (re-pattern (str "(?i)(?<!#)(?<!\\[\\[)" string "(?!\\]\\])")))
+
+
+(defn update-links-in-block
+  [s old-title new-title]
+  (clojure.string/replace s
+                          (linked old-title)
+                          (str "$1$3$4" new-title "$2$5")))
+

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -107,7 +107,8 @@
 ;; -- Datascript and Posh ------------------------------------------------
 
 (def schema
-  {:block/uid      {:db/unique :db.unique/identity}
+  {:schema/version {}
+   :block/uid      {:db/unique :db.unique/identity}
    :node/title     {:db/unique :db.unique/identity}
    :attrs/lookup   {:db/cardinality :db.cardinality/many}
    :block/children {:db/cardinality :db.cardinality/many

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -562,11 +562,6 @@
   (-> pattern get-ref-ids merge-parents-and-block group-by-parent seq))
 
 
-(defn get-data-by-block
-  [pattern]
-  (-> pattern get-ref-ids merge-parents-and-block seq))
-
-
 (defn get-linked-references
   "For node-page references UI."
   [title]
@@ -576,6 +571,7 @@
        merge-parents-and-block
        group-by-parent
        vec))
+
 
 (defn get-linked-block-references
   "For block-page references UI."
@@ -587,22 +583,22 @@
        vec))
 
 
-(defn get-linked-references-by-block
-  [title]
-  (-> title patterns/linked get-data-by-block))
-
-
 (defn get-unlinked-references
   "For node-page references UI."
   [title]
   (-> title patterns/unlinked get-data))
 
 
-(defn count-linked-references-excl-uid
-  [title uid]
-  (->> (get-linked-references-by-block title)
-       (remove #(= (:block/uid %) uid))
-       count))
+(defn linked-refs-count
+  [title]
+  (d/q '[:find (count ?u) .
+         :in $ ?t
+         :where
+         [?e :node/title ?t]
+         [?r :block/refs ?e]
+         [?r :block/uid ?u]]
+       @dsdb
+       title))
 
 
 (defn replace-linked-refs

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -570,7 +570,21 @@
 (defn get-linked-references
   "For node-page references UI."
   [title]
-  (-> title patterns/linked get-data))
+  (->> @(pull dsdb '[* :block/_refs] [:node/title title])
+       :block/_refs
+       (mapv :db/id)
+       merge-parents-and-block
+       group-by-parent
+       vec))
+
+(defn get-linked-block-references
+  "For block-page references UI."
+  [block]
+  (->> (:block/_refs block)
+       (mapv :db/id)
+       merge-parents-and-block
+       group-by-parent
+       vec))
 
 
 (defn get-linked-references-by-block
@@ -589,15 +603,6 @@
   (->> (get-linked-references-by-block title)
        (remove #(= (:block/uid %) uid))
        count))
-
-
-(defn get-linked-block-references
-  [block]
-  (->> (:block/_refs block)
-       (mapv (fn [x] (:db/id x)))
-       (merge-parents-and-block)
-       (group-by-parent)
-       vec))
 
 
 (defn replace-linked-refs

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -88,7 +88,7 @@
   (let [res         (.showOpenDialogSync dialog (clj->js {:properties ["openDirectory"]}))
         db-location (first res)]
     (when (and db-location (not-empty db-name))
-      (let [db          (d/db-with (d/empty-db db/schema) athens-datoms/datoms)
+      (let [db          (d/empty-db db/schema)
             dir         (.resolve path db-location db-name)
             dir-images  (.resolve path dir IMAGES-DIR-NAME)
             db-filepath (.resolve path dir DB-INDEX)]
@@ -102,6 +102,7 @@
             (dispatch [:fs/watch db-filepath])
             (dispatch [:db/update-filepath db-filepath])
             (dispatch [:reset-conn db])
+            (dispatch [:transact athens-datoms/datoms])
             (dispatch [:loading/unset])))))))
 
 
@@ -216,8 +217,9 @@
         (.mkdirSync fs athens-dir))
       (when (not (.existsSync fs db-images))
         (.mkdirSync fs db-images))
-      {:fs/write!  [db-filepath (write-transit-str athens-datoms/datoms)]
-       :dispatch-n [[:db/update-filepath db-filepath]]})))
+      {:fs/write!  [db-filepath (write-transit-str (d/empty-db db/schema))]
+       :dispatch-n [[:db/update-filepath db-filepath]
+                    [:transact athens-datoms/datoms]]})))
 
 
 (reg-event-fx

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -326,7 +326,7 @@
                                                    (let [schema (d/q '[:find ?e ?v
                                                                        :where [?e :schema/version ?v]]
                                                                      @db/dsdb)]
-                                                     (if (> 1 (count schema))
+                                                     (if (< 1 (count schema))
                                                        (js/alert (js/Error (str "Multiple schema versions: " schema)))
                                                        (case (-> schema first second)
                                                          nil (let [linked-ref-pattern      (patterns/linked ".*")

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -313,12 +313,44 @@
                                                  [:local-storage/navigate]]}
 
                                    ;; whether first or nth time, update athens pages
-                                   {:when       :seen-any-of?
-                                    :events     [:fs/create-new-db :reset-conn]
-                                    :dispatch-n [[:db/retract-athens-pages]
-                                                 [:db/transact-athens-pages]
-                                                 [:loading/unset]]
-                                    :halt?      true}]}}))
+                                   #_{:when       :seen-any-of?
+                                      :events     [:fs/create-new-db :reset-conn]
+                                      :dispatch-n [[:db/retract-athens-pages]
+                                                   [:db/transact-athens-pages]]}
+
+                                   {:when        :seen-any-of?
+                                    :events      [:fs/create-new-db :reset-conn]
+                                    ;; if schema is nil, update to 1 and reparse all block/string's for links
+                                    :dispatch-fn (fn [_]
+                                                   (let [schema (d/q '[:find ?v .
+                                                                       :where [?e :schema/version ?v]]
+                                                                     @db/dsdb)]
+                                                     (case schema
+                                                       nil (let [linked-ref-pattern      (athens.patterns/linked ".*")
+                                                                 blocks-with-plain-links (d/q '[:find ?u ?s
+                                                                                                :keys block/uid block/string
+                                                                                                :in $ ?pattern
+                                                                                                :where
+                                                                                                [?e :block/uid ?u]
+                                                                                                [?e :block/string ?s]
+                                                                                                [(re-find ?pattern ?s)]]
+                                                                                              @db/dsdb
+                                                                                              linked-ref-pattern)
+                                                                 blocks-orig             (map (fn [{:block/keys [uid string]}]
+                                                                                                {:db/id [:block/uid uid] :block/string string})
+                                                                                              blocks-with-plain-links)
+                                                                 blocks-temp             (map (fn [{:block/keys [uid]}]
+                                                                                                {:db/id [:block/uid uid] :block/string ""})
+                                                                                              blocks-with-plain-links)]
+                                                             ;; give all blocks empty string - clears refs
+                                                             ;; give all blocks their original string - adds refs (for the period of time where block/refs were not added to db
+                                                             ;; update schema version, so this doesn't need to happen again
+                                                             (dispatch [:transact blocks-temp])
+                                                             (dispatch [:transact blocks-orig])
+                                                             (dispatch [:transact [[:db/add -1 :schema/version 1]]]))
+                                                       (js/alert (js/Error (str "No matching clause for schema version: " schema))))
+                                                     (dispatch [:loading/unset])))
+                                    :halt?       true}]}}))
 
 
 ;;; Effects

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -352,7 +352,7 @@
                                                                (dispatch [:transact blocks-orig])
                                                                (dispatch [:transact [[:db/add -1 :schema/version 1]]]))
                                                          ;; Do nothing if schema version 1
-                                                         1 (prn "Schema version " (-> schema first second))
+                                                         1 (prn (str "Schema version " (-> schema first second)))
                                                          ;; Alert user if schema isn't 1
                                                          (js/alert (js/Error (str "No matching case clause for schema version: " schema)))))
                                                      (dispatch [:loading/unset])))

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -2,6 +2,7 @@
   (:require
     [athens.athens-datoms :as athens-datoms]
     [athens.db :as db]
+    [athens.patterns :as patterns]
     [athens.util :as util]
     [datascript.core :as d]
     [datascript.transit :as dt :refer [write-transit-str]]
@@ -326,7 +327,7 @@
                                                                        :where [?e :schema/version ?v]]
                                                                      @db/dsdb)]
                                                      (case schema
-                                                       nil (let [linked-ref-pattern      (athens.patterns/linked ".*")
+                                                       nil (let [linked-ref-pattern      (patterns/linked ".*")
                                                                  blocks-with-plain-links (d/q '[:find ?u ?s
                                                                                                 :keys block/uid block/string
                                                                                                 :in $ ?pattern

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -311,7 +311,7 @@
                                    {:when       :seen?
                                     :events     :reset-conn
                                     :dispatch-n [[:local-storage/set-theme]
-                                                 [:local-storage/navigate]]}
+                                                 #_[:local-storage/navigate]]}
 
                                    ;; whether first or nth time, update athens pages
                                    #_{:when       :seen-any-of?

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -323,38 +323,40 @@
                                     :events      [:fs/create-new-db :reset-conn]
                                     ;; if schema is nil, update to 1 and reparse all block/string's for links
                                     :dispatch-fn (fn [_]
-                                                   (let [schema (d/q '[:find ?e ?v
-                                                                       :where [?e :schema/version ?v]]
-                                                                     @db/dsdb)]
-                                                     (if (< 1 (count schema))
-                                                       (js/alert (js/Error (str "Multiple schema versions: " schema)))
-                                                       (case (-> schema first second)
-                                                         nil (let [linked-ref-pattern      (patterns/linked ".*")
-                                                                   blocks-with-plain-links (d/q '[:find ?u ?s
-                                                                                                  :keys block/uid block/string
-                                                                                                  :in $ ?pattern
-                                                                                                  :where
-                                                                                                  [?e :block/uid ?u]
-                                                                                                  [?e :block/string ?s]
-                                                                                                  [(re-find ?pattern ?s)]]
-                                                                                                @db/dsdb
-                                                                                                linked-ref-pattern)
-                                                                   blocks-orig             (map (fn [{:block/keys [uid string]}]
-                                                                                                  {:db/id [:block/uid uid] :block/string string})
-                                                                                                blocks-with-plain-links)
-                                                                   blocks-temp             (map (fn [{:block/keys [uid]}]
-                                                                                                  {:db/id [:block/uid uid] :block/string ""})
-                                                                                                blocks-with-plain-links)]
-                                                               ;; give all blocks empty string - clears refs
-                                                               ;; give all blocks their original string - adds refs (for the period of time where block/refs were not added to db
-                                                               ;; update schema version, so this doesn't need to happen again
-                                                               (dispatch [:transact blocks-temp])
-                                                               (dispatch [:transact blocks-orig])
-                                                               (dispatch [:transact [[:db/add -1 :schema/version 1]]]))
-                                                         ;; Do nothing if schema version 1
-                                                         1 (prn (str "Schema version " (-> schema first second)))
-                                                         ;; Alert user if schema isn't 1
-                                                         (js/alert (js/Error (str "No matching case clause for schema version: " schema)))))
+                                                   (let [schemas    (d/q '[:find ?e ?v
+                                                                           :where [?e :schema/version ?v]]
+                                                                        @db/dsdb)
+                                                         schema-cnt (count schemas)]
+                                                     (cond
+                                                       (= 0 schema-cnt) (let [linked-ref-pattern      (patterns/linked ".*")
+                                                                              blocks-with-plain-links (d/q '[:find ?u ?s
+                                                                                                             :keys block/uid block/string
+                                                                                                             :in $ ?pattern
+                                                                                                             :where
+                                                                                                             [?e :block/uid ?u]
+                                                                                                             [?e :block/string ?s]
+                                                                                                             [(re-find ?pattern ?s)]]
+                                                                                                           @db/dsdb
+                                                                                                           linked-ref-pattern)
+                                                                              blocks-orig             (map (fn [{:block/keys [uid string]}]
+                                                                                                             {:db/id [:block/uid uid] :block/string string})
+                                                                                                           blocks-with-plain-links)
+                                                                              blocks-temp             (map (fn [{:block/keys [uid]}]
+                                                                                                             {:db/id [:block/uid uid] :block/string ""})
+                                                                                                           blocks-with-plain-links)]
+                                                                          ;; give all blocks empty string - clears refs
+                                                                          ;; give all blocks their original string - adds refs (for the period of time where block/refs were not added to db
+                                                                          ;; update schema version, so this doesn't need to happen again
+                                                                          (dispatch [:transact blocks-temp])
+                                                                          (dispatch [:transact blocks-orig])
+                                                                          (dispatch [:transact [[:db/add -1 :schema/version 1]]]))
+                                                       (= 1 schema-cnt) (let [schema-version (-> schemas first second)]
+                                                                          (case schema-version
+                                                                            1 (prn (str "Schema version " schema-version))
+                                                                            (js/alert (js/Error (str "No matching case clause for schema version: " schema-version)))))
+                                                       (< 1 schema-cnt)
+                                                       (js/alert (js/Error (str "Multiple schema versions: " schemas))))
+
                                                      (dispatch [:loading/unset])))
                                     :halt?       true}]}}))
 

--- a/src/cljs/athens/views/all_pages.cljs
+++ b/src/cljs/athens/views/all_pages.cljs
@@ -77,8 +77,7 @@
                         @db/dsdb)
                    (p/pull-many db/dsdb '["*" :block/_refs {:block/children [:block/string] :limit 5}])
                    deref
-                   (sort-by (fn [{:keys [edit/time]}]
-                              time))
+                   (sort-by :edit/time)
                    reverse)]
     [:div (use-style page-style)
      [:table (use-style table-style)

--- a/src/cljs/athens/views/all_pages.cljs
+++ b/src/cljs/athens/views/all_pages.cljs
@@ -7,8 +7,9 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :as str]
+    [datascript.core :as d]
     [garden.selectors :as selectors]
-    [posh.reagent :refer [pull-many q]]
+    [posh.reagent :as p]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
 
 
@@ -36,7 +37,8 @@
                                     :font-weight "500"
                                     :font-size "1.3125em"
                                     :line-height "1.28"}
-                         :td-links {:font-size "1em"}
+                         :td-links {:font-size "1em"
+                                    :text-align "center"}
                          :body-preview {:white-space "wrap"
                                         :word-break "break-word"
                                         :overflow "hidden"
@@ -69,11 +71,11 @@
 
 (defn table
   []
-  (let [pages (->> (datascript.core/q '[:find [?e ...]
-                                        :where
-                                        [?e :node/title ?t]]
-                                      @db/dsdb)
-                   (pull-many db/dsdb '["*" :block/_refs {:block/children [:block/string] :limit 5}])
+  (let [pages (->> (d/q '[:find [?e ...]
+                          :where
+                          [?e :node/title ?t]]
+                        @db/dsdb)
+                   (p/pull-many db/dsdb '["*" :block/_refs {:block/children [:block/string] :limit 5}])
                    deref
                    (sort-by (fn [{:keys [edit/time]}]
                               time))

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -110,8 +110,8 @@
 
          ;; Refs
          (when (not-empty refs)
-           [:div
-            [:section (use-style node-page/references-style {:key "Linked References"})
+           [:div (use-style node-page/references-style {:key "Linked References"})
+            [:section
              [:h4 (use-style node-page/references-heading-style)
               [(r/adapt-react-class mui-icons/Link)]
               [:span "Linked References"]]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -417,6 +417,7 @@
                     [:div (use-style references-group-block-style)
                      [ref-comp block]]]))]))])])))
 
+
 (defn unlinked-ref-el
   [state daily-notes? unlinked-refs title]
   (let [unlinked? "Unlinked References"]
@@ -543,8 +544,6 @@
          ;; References
          [linked-ref-el state daily-notes? linked-refs]
          [unlinked-ref-el state daily-notes? unlinked-refs title]]))))
-
-
 
 
 (defn node-page-component

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -81,7 +81,7 @@
                      [(selectors/+ :.is-editing :span) {:opacity 0}]]})
 
 
-(def references-style {:margin-block "3em"})
+(def references-style {:margin-top "3em"})
 
 
 (def references-heading-style
@@ -206,14 +206,6 @@
     (swap! state assoc :title/local value)))
 
 
-(defn get-linked-refs
-  [ref-groups]
-  (->> ref-groups
-       first
-       second
-       (mapcat second)))
-
-
 (defn map-new-refs
   "Find and replace linked ref with new linked ref, based on title change."
   [linked-refs old-title new-title]
@@ -258,13 +250,13 @@
      - confirm-fn: delete current page, rewrite linked refs, merge blocks, and navigate to existing page
      - cancel-fn: reset state
   The current blocks will be at the end of the existing page."
-  [node state ref-groups]
+  [node state linked-refs]
   (let [{dbid :db/id children :block/children} node
         {:keys [title/initial title/local]} @state]
     (when (not= initial local)
-      (let [existing-page   (get-existing-page local)
-            linked-refs     (get-linked-refs ref-groups)
-            new-linked-refs (map-new-refs linked-refs initial local)]
+      (let [existing-page     (get-existing-page local)
+            linked-ref-blocks (mapcat second linked-refs)
+            new-linked-refs   (map-new-refs linked-ref-blocks initial local)]
         (if (empty? existing-page)
           (let [new-page   {:db/id dbid :node/title local}
                 new-datoms (concat [new-page] new-linked-refs)]
@@ -392,18 +384,110 @@
          [block-el block linked-ref-data]]))))
 
 
+(defn linked-ref-el
+  [state daily-notes? linked-refs]
+  (let [linked? "Linked References"]
+    (when (or (and daily-notes? (not-empty linked-refs))
+              (not daily-notes?))
+      [:section (use-style references-style)
+       [:h4 (use-style references-heading-style)
+        [button {:on-click (fn [] (swap! state update linked? not))}
+         (if (get @state linked?)
+           [:> mui-icons/KeyboardArrowDown]
+           [:> mui-icons/ChevronRight])]
+        [(r/adapt-react-class mui-icons/Link)]
+        [:div {:style {:display "flex"
+                       :flex "1 1 100%"
+                       :justify-content "space-between"}}
+         [:span linked?]]]
+       (when (get @state linked?)
+         [:div (use-style references-list-style)
+          (doall
+            (for [[group-title group] linked-refs]
+              [:div (use-style references-group-style {:key (str "group-" group-title)})
+               [:h4 (use-style references-group-title-style)
+                [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
+               (doall
+                 (for [block group]
+                   ^{:key (str "ref-" (:block/uid block))}
+                   [:div {:style {:display "flex"
+                                  :flex "1 1 100%"
+                                  :justify-content "space-between"
+                                  :align-items "flex-start"}}
+                    [:div (use-style references-group-block-style)
+                     [ref-comp block]]]))]))])])))
+
+(defn unlinked-ref-el
+  [state daily-notes? unlinked-refs title]
+  (let [unlinked? "Unlinked References"]
+    (when (not daily-notes?)
+      [:section (use-style references-style)
+       [:h4 (use-style references-heading-style)
+        [button {:on-click (fn []
+                             (if (get @state unlinked?)
+                               (swap! state assoc unlinked? false)
+                               (let [un-refs (get-unlinked-references (escape-str title))]
+                                 (swap! state assoc unlinked? true)
+                                 (reset! unlinked-refs un-refs))))}
+         (if (get @state unlinked?)
+           [:> mui-icons/KeyboardArrowDown]
+           [:> mui-icons/ChevronRight])]
+        [(r/adapt-react-class mui-icons/Link)]
+        [:div {:style {:display         "flex"
+                       :flex            "1 1 100%"
+                       :justify-content "space-between"}}
+         [:span unlinked?]
+         (when (and unlinked? (not-empty @unlinked-refs))
+           [button {:style    {:font-size "14px"}
+                    :on-click (fn []
+                                (dispatch [:unlinked-references/link-all @unlinked-refs title])
+                                (swap! state assoc unlinked? false)
+                                (reset! unlinked-refs []))}
+            "Link All"])]]
+       (when (get @state unlinked?)
+         [:div (use-style references-list-style)
+          (doall
+            (for [[group-title group] @unlinked-refs]
+              [:div (use-style references-group-style {:key (str "group-" group-title)})
+               [:h4 (use-style references-group-title-style)
+                [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
+               (doall
+                 (for [block group]
+                   ^{:key (str "ref-" (:block/uid block))}
+                   [:div {:style {:display         "flex"
+                                  :flex            "1 1 100%"
+                                  :justify-content "space-between"
+                                  :align-items     "flex-start"}}
+                    [:div (use-style references-group-block-style)
+                     [ref-comp block]]
+                    (when unlinked?
+                      [button {:style    {:margin-top "1.5em"}
+                               :on-click (fn []
+                                           (let [hm                (into (hash-map) @unlinked-refs)
+                                                 new-unlinked-refs (->> (update-in hm [group-title] #(filter (fn [{:keys [block/uid]}]
+                                                                                                               (= uid (:block/uid block)))
+                                                                                                             %))
+                                                                        seq)]
+                                             ;; ctrl-z doesn't work though, because Unlinked Refs aren't reactive to datascript.
+                                             (reset! unlinked-refs new-unlinked-refs)
+                                             (dispatch [:unlinked-references/link block title])))}
+                       "Link"])]))]))])])))
+
 ;; TODO: where to put page-level link filters?
 (defn node-page-el
   "title/initial is the title when a page is first loaded.
   title/local is the value of the textarea.
   We have both, because we want to be able to change the local title without transacting to the db until user confirms.
   Similar to atom-string in blocks. Hacky, but state consistency is hard!"
-  [_ _ _]
-  (let [state (r/atom init-state)]
-    (fn [node editing-uid ref-groups]
+  [_ _ _ _]
+  (let [state         (r/atom init-state)
+        unlinked-refs (r/atom [])]
+    (fn [node editing-uid linked-refs]
       (let [{:block/keys [children uid] title :node/title} node
             {:menu/keys [show] :alert/keys [message confirm-fn cancel-fn] alert-show :alert/show} @state
-            timeline-page? (is-timeline-page uid)]
+            timeline-page? (is-timeline-page uid)
+            daily-notes?   (= :home @(subscribe [:current-route/name]))]
+
 
         (sync-title title state)
 
@@ -428,7 +512,7 @@
              {:value         (:title/local @state)
               :id            (str "editable-uid-" uid)
               :class         (when (= editing-uid uid) "is-editing")
-              :on-blur       (fn [_] (handle-blur node state ref-groups))
+              :on-blur       (fn [_] (handle-blur node state linked-refs))
               :on-key-down   (fn [e] (handle-key-down e uid state children))
               :on-change     (fn [e] (handle-change e state))}])
           [button {:class    [(when show "active")]
@@ -456,55 +540,16 @@
               ^{:key uid}
               [block-el child])])
 
-
          ;; References
-         (doall
-           (for [[linked-or-unlinked refs] ref-groups]
-             (when (not-empty refs)
-               [:section (use-style references-style {:key linked-or-unlinked})
-                [:h4 (use-style references-heading-style)
-                 [button {:on-click (fn [] (swap! state update linked-or-unlinked not))}
-                  (if (get @state linked-or-unlinked)
-                    [:> mui-icons/KeyboardArrowDown]
-                    [:> mui-icons/ChevronRight])]
-                 [(r/adapt-react-class mui-icons/Link)]
-                 [:div {:style {:display "flex"
-                                :flex "1 1 100%"
-                                :justify-content "space-between"}}
-                  [:span linked-or-unlinked]
-                  (when (= linked-or-unlinked "Unlinked References")
-                    [button {:style {:font-size "14px"}
-                             :on-click #(dispatch [:unlinked-references/link-all refs title])}
-                     "Link All"])]]
-                 ;; Hide button until feature is implemented
-                 ;;[button {:disabled true} [(r/adapt-react-class mui-icons/FilterList)]]]
-                (when (get @state linked-or-unlinked)
-                  [:div (use-style references-list-style)
-                   (doall
-                     (for [[group-title group] refs]
-                       [:div (use-style references-group-style {:key (str "group-" group-title)})
-                        [:h4 (use-style references-group-title-style)
-                         [:a {:on-click #(navigate-uid (:block/uid @(pull-node-from-string group-title)))} group-title]]
-                        (doall
-                          (for [block group]
-                            ^{:key (str "ref-" (:block/uid block))}
-                            [:div {:style {:display "flex"
-                                           :flex "1 1 100%"
-                                           :justify-content "space-between"
-                                           :align-items "flex-start"}}
-                             [:div (use-style references-group-block-style)
-                              [ref-comp block]]
-                             (when (= linked-or-unlinked "Unlinked References")
-                               [button {:style {:margin-top "1.5em"}
-                                        :on-click #(dispatch [:unlinked-references/link block title])}
-                                "Link"])]))]))])])))]))))
+         [linked-ref-el state daily-notes? linked-refs]
+         [unlinked-ref-el state daily-notes? unlinked-refs title]]))))
+
+
 
 
 (defn node-page-component
   [ident]
   (let [{:keys [#_block/uid node/title] :as node} (db/get-node-document ident)
-        editing-uid @(subscribe [:editing/uid])]
-    (when-not (str/blank? title)
-      (let [ref-groups [["Linked References" (get-linked-references (escape-str title))]
-                        ["Unlinked References" (get-unlinked-references (escape-str title))]]]
-        [node-page-el node editing-uid ref-groups]))))
+        editing-uid   @(subscribe [:editing/uid])
+        linked-refs   (get-linked-references title)]
+    [node-page-el node editing-uid linked-refs]))

--- a/test/athens/patterns_test.clj
+++ b/test/athens/patterns_test.clj
@@ -1,15 +1,7 @@
 (ns athens.patterns-test
   (:require
     [athens.patterns :as patterns]
-    [clojure.string :as str]
     [clojure.test :refer [deftest is]]))
-
-
-(defn update-links-in-block
-  [s old-title new-title]
-  (str/replace s
-               (patterns/linked old-title)
-               (str "$1$3$4" new-title "$2$5")))
 
 
 (def text
@@ -31,4 +23,22 @@
          (first (re-find (patterns/linked "Page Title")
                          "Some text with a #[[Page Title]]"))))
   (is (= new-text
-         (update-links-in-block text "AnotherPage" "AwesomePage"))))
+         (patterns/update-links-in-block text "AnotherPage" "AwesomePage"))))
+
+
+;; The results of these tests may surprise you.
+;; We use .* to detect if a link exists. Can't actually find capture any arbitrary link, because regex is greedy.
+;; Instead, use the Instaparse parser to actually capture the [[inner content]] of strings.
+(deftest wildcard-tests
+  (is (= nil
+         (re-find (patterns/linked ".*") "no link")))
+
+  (is (= "[[a link]]"
+         (first (re-find (patterns/linked ".*") "[[a link]]"))))
+
+  (is (= "[[link 1]] [[link 2]]"
+         (first (re-find (patterns/linked ".*") "[[link 1]] [[link 2]]"))))
+
+  (is (= "#[[link 1]] #hashtag"
+         (first (re-find (patterns/linked ".*") "#[[link 1]] #hashtag")))))
+


### PR DESCRIPTION
- separate linked/unlinked components, unlinked refs now has its own state
	- linked refs open by default
	- unlinked refs closed by default, does a regex when user tries to open
- query :block/refs for linked references rather than using regex
- introduce `:schema/version`, which attempts to create `:block/refs` links if version is `nil`, then updates to version 1, on `:desktop/boot`
- create link count column, sort All Pages by link count
- no longer retract and assert Welcome page with `:db/retract-athens-pages` and `:db/transact-athens-pages`
- actually transact `athens-datoms` on new db creation (initial start or Create Modal) such that links are transacted to db
- no longer try to go to last page; always go to Daily Notes on start up. Close #558 