### PR TITLE
feat(alert): add a global alert for uncaught errors

### DIFF
--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -30,8 +30,17 @@
                 (getElement "app")))
 
 
+(defn set-global-alert!
+  "Alerts user if there's an uncaught error.
+  https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror "
+  []
+  (set! js/window.onerror (fn [message, source, lineno, colno, error]
+                            (js/alert (str "message="message "\nsource="source "\nlineno=" lineno "\ncolno=" colno "\nerror="error)))))
+
+
 (defn init
   []
+  (set-global-alert!)
   (style/init)
   (stylefy/tag "body" style/app-styles)
   (listeners/init)

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -35,7 +35,7 @@
   https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror "
   []
   (set! js/window.onerror (fn [message, source, lineno, colno, error]
-                            (js/alert (str "message="message "\nsource="source "\nlineno=" lineno "\ncolno=" colno "\nerror="error)))))
+                            (js/alert (str "message=" message "\nsource=" source "\nlineno=" lineno "\ncolno=" colno "\nerror=" error)))))
 
 
 (defn init


### PR DESCRIPTION
Closes #579 

Before, only datascript transaction errors were getting alerted to users. This alerts any uncaught error with the global `window.onerror` function.

https://www.loom.com/share/0749dfd3255240958915dbf23f75d945