### PR TITLE
feat(save): prevent exiting or refreshing Athens if not saved

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -333,3 +333,9 @@
   :stylefy/tag
   (fn [[tag properties]]
     (stylefy/tag tag properties)))
+
+
+(reg-fx
+  :alert/js!
+  (fn [message]
+    (js/alert message)))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -267,6 +267,13 @@
              (assoc db :alert nil)))
 
 
+;; Use native js/alert rather than custom UI alert
+(reg-event-fx
+  :alert/js
+  (fn [_ [_ message]]
+    {:alert/js! message}))
+
+
 ;; Modal
 
 

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -101,7 +101,13 @@
                   :active   @(subscribe [:athena/open])}
           [:<> [:> mui-icons/Search] [:span "Find or Create a Page"]]]]
 
+
         [:div (use-style app-header-secondary-controls-style)
+         [(reagent.core/adapt-react-class mui-icons/FiberManualRecord)
+          {:style {:color      (color (if @(subscribe [:db/synced])
+                                        :confirmation-color
+                                        :highlight-color))
+                   :align-self "center"}}]
          [button {:on-click #(router/navigate :settings)
                   :active (= @route-name :settings)}
           [:> mui-icons/Settings]]
@@ -110,11 +116,7 @@
             [(r/adapt-react-class mui-icons/FolderOpen)
              {:style {:align-self "center"}}]]
          ;; sync UI
-         #_[(reagent.core/adapt-react-class mui-icons/FiberManualRecord)
-            {:style {:color      (color (if @(subscribe [:db/synced])
-                                          :confirmation-color
-                                          :highlight-color))
-                     :align-self "center"}}]
+
          #_[separator]
          [button {:on-click #(dispatch [:modal/toggle])
                   #_(swap! state assoc :modal :folder)}

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -7,7 +7,7 @@
     #_[athens.util :as util]
     [athens.views.buttons :refer [button]]
     [re-frame.core :refer [subscribe dispatch]]
-    #_[reagent.core :as r]
+    [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style]]))
 
 


### PR DESCRIPTION
Adds the sync icon again. Green if Athens has finished saving to local filesystem, yellow if not.

User is alerted if sync hasn't finished yet and they are trying to refresh or quit Athens. 

# Synced

![image](https://user-images.githubusercontent.com/8952138/106413008-dcf74380-63fd-11eb-8c03-fb0e0f6b3f48.png)

# Not Synced
![image](https://user-images.githubusercontent.com/8952138/106413049-f6988b00-63fd-11eb-9ff8-e3b99f475889.png)

# Message
![image](https://user-images.githubusercontent.com/8952138/106413183-4f682380-63fe-11eb-93ab-48883851e51d.png)