### PR TITLE
Outdated welcome page

### DIFF
--- a/src/cljs/athens/athens_datoms.cljs
+++ b/src/cljs/athens/athens_datoms.cljs
@@ -183,11 +183,11 @@
                                                 :open false,
                                                 :order 0,
                                                 :children [#:block{:uid "58803d15f",
-                                                                   :string "Athens is persisted to your filesystem at `documents/athens`.",
+                                                                   :string "Athens is persisted to your filesystem at `documents/athens` by default.",
                                                                    :open true,
                                                                    :order 0}
                                                            #:block{:uid "0f62fecbc",
-                                                                   :string "Soon you will be able to choose any folder for your db (including folders synced to Dropbox or Google Drive).",
+                                                                   :string "Database can be changed through settings button on the top right corner.",
                                                                    :open true,
                                                                    :order 1}]}
                                         #:block{:uid "68246ce0a",


### PR DESCRIPTION
With the current beta version, it is possible to change database location using settings button at the top right corner. 

For that reason, current welcome page is outdated since it have the following:
![Athens Screenshot](https://user-images.githubusercontent.com/42651056/106516199-c1686780-64e7-11eb-91f1-66fa2235922d.png)

- [x] Add instruction on how to change database