### PR TITLE
feat(sentry): setup error tracking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,9 +204,10 @@ jobs:
            mkdir -p ~/private_keys/
            echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
 
-      # Using lein directly because Windows doesn't recognize lein when lein is called via yarn
        - name: Compile JS Assets
-         run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer
+         run: ./scripts/compile
+         env:
+           SENTRY_DSN: ${{ secrets.sentry_dsn }}
 
        - name: Build and Publish Electron App
          uses: samuelmeuli/action-electron-builder@v1

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "dev": "shadow-cljs watch main renderer",
-    "build": "shadow-cljs compile main renderer",
+    "compile": "shadow-cljs compile main renderer",
     "clean": "rm -rf resources/public/**/*.js && rm -rf target && rm -rf .shadow-cljs",
     "dist": "electron-builder -p always"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@js-joda/timezone": "2.2.0",
     "@material-ui/core": "^4.10.1",
     "@material-ui/icons": "^4.9.1",
+    "@sentry/react": "^5.27.2",
+    "@sentry/tracing": "^5.27.2",
     "create-react-class": "^15.6.3",
     "electron-log": "^4.2.4",
     "electron-updater": "^4.3.4",

--- a/project.clj
+++ b/project.clj
@@ -46,13 +46,10 @@
 
   :aliases {"dev"          ["with-profile" "dev" "do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "watch" "main" "renderer"]]
-            "build"        ["with-profile" "dev" "do"
-                            ["run" "-m" "shadow.cljs.devtools.cli" "compile" "main" "renderer"]]
+            "compile"        ["with-profile" "dev" "do"
+                              ["run" "-m" "shadow.cljs.devtools.cli" "compile" "main" "renderer"]]
             "devcards"     ["with-profile" "dev" "do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "watch" "devcards"]]
-            "compile"      ["with-profile" "dev" "do"
-                            ["run" "-m" "shadow.cljs.devtools.cli" "compile" "app"]
-                            ["run" "-m" "shadow.cljs.devtools.cli" "compile" "devcards"]]
             "prod"         ["with-profile" "prod" "do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "release" "app"]]
             "build-report" ["with-profile" "prod" "do"

--- a/script/compile
+++ b/script/compile
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+./node_modules/shadow-cljs/cli/runner.js compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"${SENTRY_DSN}\"}}"

--- a/script/deploy
+++ b/script/deploy
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eo pipefail
-
-# Compile App and Devcard bundles
-# Using shadow-cljs directly is faster than lein
-./node_modules/shadow-cljs/cli/runner.js release app --config-merge "{:closure-defines {athens.devcards/spinner/COMMIT_URL \"${COMMIT_URL}\"}}"
-./node_modules/shadow-cljs/cli/runner.js compile devcards --config-merge "{:closure-defines {athens.devcards/spinner/COMMIT_URL \"${COMMIT_URL}\"}}"

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -37,11 +37,14 @@
 
 (defn init-sentry
   []
-  (.init Sentry (clj->js {:dsn              SENTRY_DSN}
-                         :release          (str "athens@" (.. (js/require "electron") -remote -app getVersion))
-                         :integrations     [(new (.-BrowserTracing Integrations))]
-                         :environment      (if config/debug? "development" "production")
-                         :tracesSampleRate 1.0)))
+  (let [sentry (js/localStorage.getItem "sentry")]
+    (if (= sentry "off")
+      (prn "Sentry isn't initialized.")
+      (.init Sentry (clj->js {:dsn              SENTRY_DSN
+                              :release          (str "athens@" (.. (js/require "electron") -remote -app getVersion))
+                              :integrations     [(new (.-BrowserTracing Integrations))]
+                              :environment      (if config/debug? "development" "production")
+                              :tracesSampleRate 1.0})))))
 
 
 (defn init-ipcRenderer

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -44,13 +44,18 @@
         (.sendSync ipcRenderer "confirm-update")))))
 
 
+(defn init-sentry
+  []
+  (.init Sentry (clj->js {:dsn              SENTRY_DSN}
+                         :release          (str "athens@" (.. (js/require "electron") -remote -app getVersion))
+                         :integrations     [(new (.-BrowserTracing Integrations))]
+                         :environment      (if config/debug? "development" "production")
+                         :tracesSampleRate 1.0)))
+
+
 (defn init
   []
-  (.init Sentry (clj->js {:dsn              SENTRY_DSN
-                          :release          (str "athens@" (.. (js/require "electron") -remote -app getVersion))
-                          :integrations     [(new (.-BrowserTracing Integrations))]
-                          :environment      (if config/debug? "development" "production")
-                          :tracesSampleRate 1.0}))
+  (init-sentry)
   (init-ipcRenderer)
   (style/init)
   (stylefy/tag "body" style/app-styles)

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -1,5 +1,7 @@
 (ns athens.core
   (:require
+    ["@sentry/react" :as Sentry]
+    ["@sentry/tracing" :refer (Integrations)]
     [athens.coeffects]
     [athens.config :as config]
     [athens.effects]
@@ -13,9 +15,7 @@
     [goog.dom :refer [getElement]]
     [re-frame.core :as rf]
     [reagent.dom :as r-dom]
-    [stylefy.core :as stylefy]
-    ["@sentry/react" :as Sentry]
-    ["@sentry/tracing" :refer (Integrations)]))
+    [stylefy.core :as stylefy]))
 
 
 (goog-define SENTRY_DSN "")
@@ -35,15 +35,6 @@
                 (getElement "app")))
 
 
-(defn init-ipcRenderer
-  []
-  (let [ipcRenderer       (.. (js/require "electron") -ipcRenderer)
-        update-available? (.sendSync ipcRenderer "check-update" "renderer")]
-    (when update-available?
-      (when (js/window.confirm "Update available. Would you like to update and restart to the latest version?")
-        (.sendSync ipcRenderer "confirm-update")))))
-
-
 (defn init-sentry
   []
   (.init Sentry (clj->js {:dsn              SENTRY_DSN}
@@ -51,6 +42,15 @@
                          :integrations     [(new (.-BrowserTracing Integrations))]
                          :environment      (if config/debug? "development" "production")
                          :tracesSampleRate 1.0)))
+
+
+(defn init-ipcRenderer
+  []
+  (let [ipcRenderer       (.. (js/require "electron") -ipcRenderer)
+        update-available? (.sendSync ipcRenderer "check-update" "renderer")]
+    (when update-available?
+      (when (js/window.confirm "Update available. Would you like to update and restart to the latest version?")
+        (.sendSync ipcRenderer "confirm-update")))))
 
 
 (defn init

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -13,7 +13,12 @@
     [goog.dom :refer [getElement]]
     [re-frame.core :as rf]
     [reagent.dom :as r-dom]
-    [stylefy.core :as stylefy]))
+    [stylefy.core :as stylefy]
+    ["@sentry/react" :as Sentry]
+    ["@sentry/tracing" :refer (Integrations)]))
+
+
+(goog-define SENTRY_DSN "")
 
 
 (defn dev-setup
@@ -41,6 +46,11 @@
 
 (defn init
   []
+  (.init Sentry (clj->js {:dsn              SENTRY_DSN
+                          :release          (str "athens@" (.. (js/require "electron") -remote -app getVersion))
+                          :integrations     [(new (.-BrowserTracing Integrations))]
+                          :environment      (if config/debug? "development" "production")
+                          :tracesSampleRate 1.0}))
   (init-ipcRenderer)
   (style/init)
   (stylefy/tag "body" style/app-styles)

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,81 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
+"@sentry/browser@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.27.2.tgz#2bad4b9d2f0047c314a72fb7a50f64b1c34f846f"
+  integrity sha512-x6Sh4gBnAbI8gCma7DOTkjFIGPvDIOVN4oxfeY7ikU0446CLp6V+CYjlc4CoVgGpfWs4Zd/Og9V9WiysAl/nDg==
+  dependencies:
+    "@sentry/core" "5.27.2"
+    "@sentry/types" "5.27.2"
+    "@sentry/utils" "5.27.2"
+    tslib "^1.9.3"
+
+"@sentry/core@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.27.2.tgz#94d62364e3d0bf9d0b9b891699ad35d31cd69da3"
+  integrity sha512-FMX0Aignhi9Rk4tZkjwSXCsFFQc8FIOgUTvfIKCdayLhKxfbY0H37b0fFNzaQ9v15SFzIZJ9uzw4PTmjzEh6Uw==
+  dependencies:
+    "@sentry/hub" "5.27.2"
+    "@sentry/minimal" "5.27.2"
+    "@sentry/types" "5.27.2"
+    "@sentry/utils" "5.27.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.27.2.tgz#06923e0b7b5e96cd2cd8b1d44cb83dbd8b8eed26"
+  integrity sha512-KCAWF5oDXd/Pjzbcmfj53F5ZzOX53Rzi23a2mWyUXMdPXoXIiMrIcdC/DqrqKV787LvOJcSFaTychJCH3t15/A==
+  dependencies:
+    "@sentry/types" "5.27.2"
+    "@sentry/utils" "5.27.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.27.2.tgz#c9b90d71383891e69f4abecf32fdba9d91d3328a"
+  integrity sha512-n9SssI30rpS1tw6hH0ylxVlONdmZCqiPy60fotxUzql6mCo/nW7tcADsW15fvQlUQ160VaGf3iMj+hpHkRBerw==
+  dependencies:
+    "@sentry/hub" "5.27.2"
+    "@sentry/types" "5.27.2"
+    tslib "^1.9.3"
+
+"@sentry/react@^5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.27.2.tgz#87cfe2a4a57ecb24c605b9481f48606f22723057"
+  integrity sha512-xfV/hmCS+BhJjMRvkz66teHzbQ2t9pEI/LMmwJp5ygIktx+4ZREwdJ4cCnlx0BVrGDMxdp0ZZ6d92ncqbuc8Rw==
+  dependencies:
+    "@sentry/browser" "5.27.2"
+    "@sentry/minimal" "5.27.2"
+    "@sentry/types" "5.27.2"
+    "@sentry/utils" "5.27.2"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.27.2.tgz#a87bed1d96dacdb443894732abb5828e950b14ed"
+  integrity sha512-5Lptd32VtKBzIzTmFqcKgcetTMRraMvjPFTX8kFVX4aGDaUGOx0cCZeAURNoHDfHfjCazYK8yV6BkJfi6YJNww==
+  dependencies:
+    "@sentry/hub" "5.27.2"
+    "@sentry/minimal" "5.27.2"
+    "@sentry/types" "5.27.2"
+    "@sentry/utils" "5.27.2"
+    tslib "^1.9.3"
+
+"@sentry/types@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.27.2.tgz#606e973cee865e83e75491e33e9b2732a0f79c94"
+  integrity sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg==
+
+"@sentry/utils@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.27.2.tgz#9d52a2ad73aaab41c45202c289c4a63127ce4ebb"
+  integrity sha512-ZrdRgcFapi1NACbtvnPLOIXKjBPVTlhGzmXNCVao0uRBBRNJa5i2Mjp/U/Xy/fT0K1MGJQ+F9YZjZPnAMsDNbw==
+  dependencies:
+    "@sentry/types" "5.27.2"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -3454,6 +3529,11 @@ truncate-utf8-bytes@^1.0.0:
   integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
   dependencies:
     utf8-byte-length "^1.0.1"
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Re-opening #474.

- user can opt-out by putting `sentry`: `off` in localStorage. can give easier opt-out in the future, but Sentry pretty important