### PR TITLE
fix(events): Check for stale parent when deleting block (#567)

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -502,6 +502,7 @@
 
 (defn backspace
   "If root and 0th child, 1) if value, no-op, 2) if blank value, delete only block.
+  No-op if parent is missing.
   No-op if parent is prev-block and block has children.
   No-op if prev-sibling-block has children.
   Otherwise delete block and join with previous block
@@ -526,6 +527,7 @@
         retract-block  [:db/retractEntity (:db/id block)]
         new-parent     {:db/id (:db/id parent) :block/children reindex}]
     (cond
+      (not parent) nil
       (and (empty? children) (:node/title parent) (zero? order) (clojure.string/blank? value)) (let [tx-data [retract-block new-parent]]
                                                                                                  {:dispatch-n [[:transact tx-data]
                                                                                                                [:editing/uid nil]]})


### PR DESCRIPTION
Holding down backspace when deleting text can enqueue multiple `:backspace` reg-event-fxes. The first will correctly delete and merge the parent blocks, but the next events in the queue will still be processed.

This is a surgical fix that just checks for an invalid parent and fixes #567, but a more heavy-handed approach may be appropriate to handle other unreported edge-cases of event queueing.