### PR TITLE
fix(keybindings): Disable ctrl-i from adding underscores to text

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -450,13 +450,18 @@
                                   (do (setStart target (+ 2 start))
                                       (setEnd target (+ 2 end)))
                                   (set-cursor-position target (+ 2 start))))
-      (and (not shift) (= key-code KeyCodes.I)) (let [new-str (str head (surround selection "__") tail)]
-                                                  (swap! state assoc :string/local new-str)
-                                                  (set! (.-value target) new-str)
-                                                  (if selection?
-                                                    (do (setStart target (+ 2 start))
-                                                        (setEnd target (+ 2 end)))
-                                                    (set-cursor-position target (+ 2 start))))
+
+      ;; Disabling keybinding for now https://github.com/athensresearch/athens/issues/556
+      ;; TODO fix to make keybinding ("Ctrl-i") change font-style to italic
+
+      #_ (and (not shift) (= key-code KeyCodes.I))
+      #_(let [new-str (str head (surround selection "__") tail)]
+        (swap! state assoc :string/local new-str)
+        (set! (.-value target) new-str)
+        (if selection?
+          (do (setStart target (+ 2 start))
+              (setEnd target (+ 2 end)))
+          (set-cursor-position target (+ 2 start))))
 
       ;; if caret within [[brackets]] or #[[brackets]], navigate to that page
       ;; if caret on a #hashtag, navigate to that page

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -427,7 +427,7 @@
 ;; TODO: put text caret in correct position
 (defn handle-shortcuts
   [e uid state]
-  (let [{:keys [key-code head tail selection shift start end target value]} (destruct-key-down e)
+  (let [{:keys [key-code head tail selection start end target value]} (destruct-key-down e)
         selection? (not= start end)]
 
     (cond


### PR DESCRIPTION
Simple fix for https://github.com/athensresearch/athens/issues/556 

This disables `command/ctrl+i` from adding `___text___` 

Future updates should re enable with correct behavior `font-style: italic` 