### PR TITLE
fix(ci): ignore windows Sentry variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,9 +210,10 @@ jobs:
          env:
            SENTRY_DSN: ${{ secrets.sentry_dsn }}
 
+       # unable to interpolate Windows environment variables properly. Ignore for Windows for now
        - name: Compile JS Assets (Windows)
          if: matrix.os == 'windows-latest'
-         run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"%SENTRY_DSN%\"}}"
+         run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer
          env:
            SENTRY_DSN: ${{ secrets.sentry_dsn }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,8 +204,15 @@ jobs:
            mkdir -p ~/private_keys/
            echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
 
-       - name: Compile JS Assets
+       - name: Compile JS Assets (*nix)
+         if: matrix.os != "windows-latest"
          run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"${SENTRY_DSN}\"}}"
+         env:
+           SENTRY_DSN: ${{ secrets.sentry_dsn }}
+
+       - name: Compile JS Assets (Windows)
+         if: matrix.os == "windows-latest"
+         run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"%SENTRY_DSN%\"}}"
          env:
            SENTRY_DSN: ${{ secrets.sentry_dsn }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,13 +205,13 @@ jobs:
            echo '${{ secrets.api_key }}' > ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
 
        - name: Compile JS Assets (*nix)
-         if: matrix.os != "windows-latest"
+         if: matrix.os != 'windows-latest'
          run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"${SENTRY_DSN}\"}}"
          env:
            SENTRY_DSN: ${{ secrets.sentry_dsn }}
 
        - name: Compile JS Assets (Windows)
-         if: matrix.os == "windows-latest"
+         if: matrix.os == 'windows-latest'
          run: lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"%SENTRY_DSN%\"}}"
          env:
            SENTRY_DSN: ${{ secrets.sentry_dsn }}


### PR DESCRIPTION
Curious if you know how to interpolate variables from the Windows command line @juniusfree 

In linux/mac it is:

`lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"${SENTRY_DSN}\"}}"`

For Windows, I tried unsuccessfully to do:

`lein run -m shadow.cljs.devtools.cli --npm compile main renderer --config-merge "{:closure-defines {athens.core/SENTRY_DSN \"%SENTRY_DSN%\"}}"`