### PR TITLE
WIP: real-time collaboration

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -224,11 +224,16 @@
         (pprint more-tx-data)
         (prn "TX FINAL INPUTS")                             ;; parsing block/string (and node/title) to derive asserted or retracted titles and block refs
         (pprint final-tx-data)
-        (let [outputs (:tx-data (transact! db/dsdb final-tx-data))]
-          (ph-link-created! outputs)
-          (prn "TX OUTPUTS")
-          (pprint outputs))))
-
+        (let [outputs (:tx-data (d/with @db/dsdb final-tx-data))]
+           (ph-link-created! outputs)
+           (prn "TX OUTPUTS")
+           (pprint outputs)
+           (reset! a outputs)
+           (dispatch [:fs/write-log outputs]))
+        #_(let [outputs (:tx-data (transact! db/dsdb final-tx-data))]
+            (ph-link-created! outputs)
+            (prn "TX OUTPUTS")
+            (pprint outputs))))
     (catch js/Error e
       (js/alert (str e))
       (prn "EXCEPTION" e))))

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -228,7 +228,7 @@
            (ph-link-created! outputs)
            (prn "TX OUTPUTS")
            (pprint outputs)
-           (reset! a outputs)
+           ;;(reset! a outputs)
            (dispatch [:fs/write-log outputs]))
         #_(let [outputs (:tx-data (transact! db/dsdb final-tx-data))]
             (ph-link-created! outputs)

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -345,6 +345,7 @@
 (reg-event-fx
   :fs/watch
   (fn [_ [_ dir]]
+    (create-dir-if-needed! dir)
     (fs.watch dir (fn [_event filename]
                     ;;(re-find #"\d+-\w+.log" "123123-jeff.log")
                     (when (re-find #".log" filename)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -420,7 +420,7 @@
     ;; always stay synced for now because auto-saving
     (let [synced? @(subscribe [:db/synced])]
       {:fx [(when synced? [:dispatch [:db/not-synced]])
-            [:dispatch [:save]]
+            ;;[:dispatch [:save]]
             [:transact! tx-data]]})))
 
 
@@ -467,12 +467,11 @@
     {:fx [[:dispatch [:transact [[:db/retract [:block/uid uid] :page/sidebar]]]]]}))
 
 
-(reg-event-fx
-  :save
-  (fn [_ _]
-    (let [db-filepath (subscribe [:db/filepath])]
-      {:fs/write!  [@db-filepath (dt/write-transit-str @db/dsdb)]})))
-
+;;(reg-event-fx
+;;  :save
+;;  (fn [_ _]
+;;    (let [db-filepath (subscribe [:db/filepath])]
+;;      {:fs/write!  [@db-filepath (dt/write-transit-str @db/dsdb)]})))
 
 (reg-event-fx
   :undo

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -413,15 +413,21 @@
 ;; Datascript
 
 
-
 (reg-event-fx
   :transact
   (fn [_ [_ tx-data]]
-    ;; always stay synced for now because auto-saving
-    (let [synced? @(subscribe [:db/synced])]
+    (let [synced?       @(subscribe [:db/synced])
+          final-tx-data (athens.effects/walk-transact tx-data)]
       {:fx [(when synced? [:dispatch [:db/not-synced]])
-            ;;[:dispatch [:save]]
-            [:transact! tx-data]]})))
+            [:transact/write-log! tx-data]
+            [:transact! final-tx-data]]})))
+
+
+;;(reg-event-fx
+;;  :save
+;;  (fn [_ _]
+;;    (let [db-filepath (subscribe [:db/filepath])]
+;;      {:fs/write!  [@db-filepath (dt/write-transit-str @db/dsdb)]})))
 
 
 (reg-event-fx
@@ -466,12 +472,6 @@
   (fn [_ [_ uid]]
     {:fx [[:dispatch [:transact [[:db/retract [:block/uid uid] :page/sidebar]]]]]}))
 
-
-;;(reg-event-fx
-;;  :save
-;;  (fn [_ _]
-;;    (let [db-filepath (subscribe [:db/filepath])]
-;;      {:fs/write!  [@db-filepath (dt/write-transit-str @db/dsdb)]})))
 
 (reg-event-fx
   :undo


### PR DESCRIPTION
Some conversation on Discord: https://discord.com/channels/708122962422792194/714804822909517935/808779175413678171

Value:
1. Requested by our potential first enterprise customer
2. Enables Athens team to use a db together to share knowledge

Specs
- uses filesystem to communicate real-time changes
	- therefore requires a filesync service like Dropbox or Syncthing
- on startup, read `db/path/index.transit`
- on change, update in-memory db and write a log to `db/path/tx-logs/{timestamp}-{os-username}.log`
	- edge case: same os-username, different computers/clients
- watch `db/path/tx-logs/`. on new log from another username, update in-memory db
- when no new logs detected for 60 seconds, write `{timestamp}-index.transit.bkp` file and copy to `index.transit`, same as current saving flow
	- but when the new db is written to client A and then db is synced, client B believes that `index.transit` is wrong, and overwrites the changes that just happened