### PR TITLE
feat: added  linux "category" office

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "linux": {
       "target": [
         "AppImage"
-      ]
+      ],
+      "category": "Office"
     },
     "publish": {
       "provider": "s3",


### PR DESCRIPTION
this warning is recived when compiling under linux
```
application Linux category is set to default "Utility"  reason=linux.category is not set and cannot map from macOS docs=https://www.electron.build/configuration/linux
```
Adding it as "Office" > https://specifications.freedesktop.org/menu-spec/latest/apa.html
