### PR TITLE
fix(spike): Replace posh with reactive DS

### DIFF
--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -69,7 +69,7 @@
   []
   (when (util/electron?)
     (let [ipcRenderer       (.. (js/require "electron") -ipcRenderer)
-          update-available? (.sendSync ipcRenderer "check-update" "renderer")]
+          update-available? (when-not config/debug? (.sendSync ipcRenderer "check-update" "renderer"))]
       (when update-available?
         (when (js/window.confirm "Update available. Would you like to update and restart to the latest version?")
           (.sendSync ipcRenderer "confirm-update"))))))

--- a/src/cljs/athens/dbrx.cljs
+++ b/src/cljs/athens/dbrx.cljs
@@ -1,0 +1,39 @@
+(ns athens.dbrx
+  (:require
+    [athens.db :as db]))
+
+
+(def pull-many
+  (fn [& args]
+    (try (apply db/pull*-rx args)
+         (catch :default e
+           (throw (js/Error. (str "pull-many problem "
+                                  args)))))))
+
+
+(def pull
+  (fn [& args]
+    (try
+      (apply db/pull-rx args)
+      (catch :default e
+        (throw (js/Error. (str "pull problem "
+                               args)))))))
+
+
+(def q
+  (fn [& args]
+    (try
+      (apply db/q-rx args)
+      (catch :default e
+        (str "q problem: "
+             args)))))
+
+
+(def transact!
+  (fn [& args]
+    (try
+      (apply db/transact! args)
+      (catch :default e
+        (str "transact! problem: "
+             args)))))
+

--- a/src/cljs/athens/devcards.cljs
+++ b/src/cljs/athens/devcards.cljs
@@ -1,6 +1,7 @@
 (ns athens.devcards
   (:require
     [athens.db :refer [dsdb]]
+    [athens.dbrx :refer [transact!]]
     [athens.devcards.alerts]
     [athens.devcards.all-pages]
     [athens.devcards.athena]
@@ -30,7 +31,6 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core]
-    [posh.reagent :refer [transact!]]
     [re-frame.core :refer [dispatch-sync]]
     [stylefy.core :as stylefy]))
 

--- a/src/cljs/athens/devcards/db.cljs
+++ b/src/cljs/athens/devcards/db.cljs
@@ -1,6 +1,7 @@
 (ns athens.devcards.db
   (:require
     [athens.db :as db]
+    [athens.dbrx :refer [transact!]]
     [athens.views.buttons :refer [button]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [go <!]]
@@ -8,7 +9,6 @@
     [cljsjs.react.dom]
     [datascript.core :as d]
     [devcards.core :refer [defcard defcard-rg]]
-    [posh.reagent :refer [transact!]]
     [reagent.core :as r]))
 
 
@@ -21,7 +21,7 @@
     (let [res (<! (http/get db/athens-url {:with-credentials? false}))
           {:keys [success body]} res]
       (if success
-        (transact! db/dsdb (db/str-to-db-tx body))
+        (transact! (db/str-to-db-tx body))
         (js/alert "Failed to retrieve data from GitHub")))))
 
 

--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -1,18 +1,18 @@
 (ns athens.devcards.left-sidebar
   (:require
     [athens.db :as db]
+    [athens.dbrx :refer [transact!]]
     [athens.views.buttons :refer [button]]
     [athens.views.left-sidebar :refer [left-sidebar]]
-    [devcards.core :refer [defcard-rg]]
-    [posh.reagent :refer [transact!]]))
+    [devcards.core :refer [defcard-rg]]))
 
 
 (defcard-rg Create-Shortcut
   [button {:on-click (fn []
                        (let [n (:max-eid @db/dsdb)]
-                         (transact! db/dsdb [{:page/sidebar n
-                                              :node/title   (str "Page " n)
-                                              :block/uid    (str "uid" n)}])))} "Create Shortcut"])
+                         (transact! [{:page/sidebar n
+                                      :node/title   (str "Page " n)
+                                      :block/uid    (str "uid" n)}])))} "Create Shortcut"])
 
 
 (defcard-rg Left-Sidebar

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -1,6 +1,7 @@
 (ns athens.effects
   (:require
     [athens.db :as db]
+    [athens.dbrx :as p :refer [transact!]]
     [athens.util :as util]
     [athens.walk :as walk]
     [cljs-http.client :as http]
@@ -11,7 +12,6 @@
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
     [goog.dom.selection :refer [setCursorPosition]]
-    [posh.reagent :as p :refer [transact!]]
     [re-frame.core :refer [dispatch reg-fx]]
     [stylefy.core :as stylefy]))
 
@@ -224,7 +224,7 @@
         (pprint more-tx-data)
         (prn "TX FINAL INPUTS")                             ;; parsing block/string (and node/title) to derive asserted or retracted titles and block refs
         (pprint final-tx-data)
-        (let [outputs (:tx-data (transact! db/dsdb final-tx-data))]
+        (let [outputs (:tx-data (transact! final-tx-data))]
           (ph-link-created! outputs)
           (prn "TX OUTPUTS")
           (pprint outputs))))

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -2,12 +2,12 @@
   (:require
     [athens.components :as components]
     [athens.db :as db]
+    [athens.dbrx :refer [pull #_q]]
     [athens.parser :as parser]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color OPACITIES]]
     [clojure.string :as str]
     [instaparse.core :as insta]
-    [posh.reagent :refer [pull #_q]]
     [stylefy.core :as stylefy :refer [use-style]]))
 
 

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -3,7 +3,6 @@
     ["/textarea" :as getCaretCoordinates]
     [clojure.string :as string]
     [goog.dom :refer [getElement setProperties]]
-    [posh.reagent :refer [#_pull]]
     [tick.alpha.api :as t]
     [tick.locale-en-us]))
 
@@ -16,7 +15,8 @@
 ;; -- DOM ----------------------------------------------------------------
 
 ;; TODO: move all these DOM utilities to a .cljs file instead of cljc
-(defn scroll-top! [element pos]
+(defn scroll-top!
+  [element pos]
   (when pos
     (set! (.. element -scrollTop) pos)))
 
@@ -65,7 +65,8 @@
       (< (.. el-box -top) (.. cont-box -top)))))
 
 
-(defn scroll-into-view [element container align-top?]
+(defn scroll-into-view
+  [element container align-top?]
   (when (is-beyond-rect? element container)
     (.. element (scrollIntoView align-top? {:behavior "auto"}))))
 

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -183,7 +183,6 @@
   (boolean (uid-to-date uid)))
 
 
-
 ;; -- Regex -----------------------------------------------------------
 
 ;; https://stackoverflow.com/a/11672480
@@ -261,5 +260,5 @@
   []
   (cond
     (electron?) (.. (js/require "electron") -remote -app getVersion)))
-    ;;(not (string/blank? COMMIT_URL)) COMMIT_URL
-    ;;:else "Web"))
+;;(not (string/blank? COMMIT_URL)) COMMIT_URL
+;;:else "Web"))

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -1,6 +1,7 @@
 (ns athens.views
   (:require
     [athens.db :as db]
+    [athens.dbrx :refer [pull]]
     [athens.subs]
     [athens.views.all-pages :refer [table]]
     [athens.views.app-toolbar :refer [app-toolbar]]
@@ -15,7 +16,6 @@
     [athens.views.right-sidebar :refer [right-sidebar-component]]
     [athens.views.settings-page :as settings-page]
     [athens.views.spinner :refer [initial-spinner-component]]
-    [posh.reagent :refer [pull]]
     [re-frame.core :refer [subscribe dispatch]]
     [stylefy.core :as stylefy :refer [use-style]]))
 

--- a/src/cljs/athens/views/all_pages.cljs
+++ b/src/cljs/athens/views/all_pages.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.all-pages
   (:require
     [athens.db :as db]
+    [athens.dbrx :as p]
     [athens.router :refer [navigate-uid]]
     [athens.style :as style :refer [color OPACITIES]]
     [athens.util :refer [date-string]]
@@ -9,7 +10,6 @@
     [clojure.string :as str]
     [datascript.core :as d]
     [garden.selectors :as selectors]
-    [posh.reagent :as p]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
 
@@ -76,7 +76,7 @@
                                   :where
                                   [?e :node/title ?t]]
                                 @db/dsdb)
-                           (p/pull-many db/dsdb '["*" :block/_refs {:block/children [:block/string] :limit 5}])
+                           (p/pull-many '["*" :block/_refs {:block/children [:block/string] :limit 5}])
                            deref
                            (sort-by (fn [x] (count (:block/_refs x))))
                            reverse))]

--- a/src/cljs/athens/views/daily_notes.cljs
+++ b/src/cljs/athens/views/daily_notes.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.daily-notes
   (:require
     [athens.db :as db]
+    [athens.dbrx :refer [q pull-many]]
     [athens.style :refer [DEPTH-SHADOWS]]
     [athens.util :refer [get-day uid-to-date]]
     [athens.views.node-page :refer [node-page-component]]
@@ -8,7 +9,6 @@
     [cljsjs.react.dom]
     [goog.dom :refer [getElement]]
     [goog.functions :refer [debounce]]
-    [posh.reagent :refer [q pull-many]]
     [re-frame.core :refer [dispatch subscribe]]
     [stylefy.core :refer [use-style]]))
 
@@ -77,12 +77,12 @@
         (let [notes (some->> @(q '[:find [?uid ...]
                                    :in $ [?uid ...]
                                    :where [?e :block/uid ?uid]]
-                                 db/dsdb @note-refs)
+                                 @note-refs)
                              not-empty
                              sort
                              reverse
                              (map (fn [x] [:block/uid x]))
-                             (pull-many db/dsdb '[*])
+                             (pull-many '[*])
                              deref)]
           [:div#daily-notes (use-style daily-notes-scroll-area-style)
            #_[:div (use-style (merge daily-notes-page-style {:box-shadow (:4 DEPTH-SHADOWS)

--- a/src/cljs/athens/views/devtool.cljs
+++ b/src/cljs/athens/views/devtool.cljs
@@ -385,12 +385,12 @@
 
 (defn listener
   [tx-report]
-  (swap! state* update :tx-reports conj tx-report)
+  #_(swap! state* update :tx-reports conj tx-report)
   (when (not (:error @state*))
     (eval-box!)))
 
 
-(d/listen! dsdb :devtool/open listener)
+#_(d/listen! dsdb :devtool/open listener)
 
 
 (defn handle-box-change!

--- a/src/cljs/athens/views/graph_page.cljs
+++ b/src/cljs/athens/views/graph_page.cljs
@@ -1,7 +1,7 @@
 ^:cljstyle/ignore
 (ns athens.views.graph-page
   (:require
-    ["react-force-graph" :as rfg]
+    #_["react-force-graph" :as rfg]
     [athens.db :as db]
     [athens.style :as styles]
     [clojure.set :as set]
@@ -59,7 +59,8 @@
 (defn graph-page
   []
   (fn []
-    (let [dark? @(rf/subscribe [:theme/dark])
+    [:div "graph page!"]
+    #_(let [dark? @(rf/subscribe [:theme/dark])
           nodes (build-nodes)
           links (build-links)
           theme (if dark? styles/THEME-DARK

--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -1,13 +1,13 @@
 (ns athens.views.left-sidebar
   (:require
     [athens.db :as db]
+    [athens.dbrx :refer [q]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color OPACITIES]]
     [athens.util :refer [mouse-offset vertical-center]]
     ;;[athens.views.buttons :refer [button]]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [posh.reagent :refer [q]]
     [re-frame.core :refer [dispatch subscribe]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
@@ -150,7 +150,7 @@
                              :where
                              [?e :page/sidebar ?order]
                              [?e :node/title ?title]
-                             [?e :block/uid ?uid]] db/dsdb)
+                             [?e :block/uid ?uid]])
                        seq
                        (sort-by first))]
     ;; (when @open?

--- a/src/cljs/athens/ws.cljs
+++ b/src/cljs/athens/ws.cljs
@@ -7,7 +7,7 @@
 ;;    [datascript.transit :as dt :refer [write-transit-str]]
 ;;    [day8.re-frame.async-flow-fx]
 ;;    [goog.functions :refer [debounce]]
-;;    [posh.reagent :as p]
+;;    [athens.dbrx :as p]
 ;;    [re-frame.core :as rf :refer [reg-event-db reg-event-fx inject-cofx reg-fx dispatch dispatch-sync subscribe reg-sub]]))
 ;;
 ;;
@@ -57,7 +57,7 @@
 ;;  [data]
 ;;  (prn "UPDATE" data)
 ;;  (case (:type data)
-;;    :tx  (p/transact! db/dsdb (:message data))
+;;    :tx  (p/transact! (:message data))
 ;;    :connect (dispatch [:ws/on-connect data])))
 ;;
 ;;


### PR DESCRIPTION
Proposed changes to eliminate posh from the code base since it has known performance issues. This replaces with reactive datascript. `athens.rxdb` is meant to be a drop in replacement for posh with the exception that `db/dsdb` doesn't need provided as argument. 

There seems to be a lot of regression errors that result from posh functions returning different spec than datascript, these can be fixed if it is determined that the performance upgrade is worth it. Seemed like a good point to stop and check before going any further.

@tangjeff0 Please pull down branch and run performance tests or tell me a method of reproducing a performance test so I can try it out myself. 