### PR TITLE
feat: Remember Window Size on startup

### DIFF
--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -1,24 +1,24 @@
 (ns athens.core
   (:require
-    ["@sentry/integrations" :as integrations]
-    ["@sentry/react" :as Sentry]
-    ["@sentry/tracing" :as tracing]
-    [athens.coeffects]
-    [athens.config :as config]
-    [athens.effects]
-    [athens.electron]
-    [athens.events]
-    [athens.listeners :as listeners]
-    [athens.router :as router]
-    [athens.style :as style]
-    [athens.subs]
-    [athens.util :as util]
-    [athens.views :as views]
+   ["@sentry/integrations" :as integrations]
+   ["@sentry/react" :as Sentry]
+   ["@sentry/tracing" :as tracing]
+   [athens.coeffects]
+   [athens.config :as config]
+   [athens.effects]
+   [athens.electron]
+   [athens.events]
+   [athens.listeners :as listeners]
+   [athens.router :as router]
+   [athens.style :as style]
+   [athens.subs]
+   [athens.util :as util]
+   [athens.views :as views]
     ;;[athens.ws]
-    [goog.dom :refer [getElement]]
-    [re-frame.core :as rf]
-    [reagent.dom :as r-dom]
-    [stylefy.core :as stylefy]))
+   [goog.dom :refer [getElement]]
+   [re-frame.core :as rf]
+   [reagent.dom :as r-dom]
+   [stylefy.core :as stylefy]))
 
 
 (goog-define SENTRY_DSN "")
@@ -75,11 +75,23 @@
           (.sendSync ipcRenderer "confirm-update"))))))
 
 
+(defn init-windowsize
+  []
+  (when (util/electron?)
+    (let [curWindow (.getCurrentWindow athens.electron/remote)
+          size (.getSize curWindow)]
+      (.on ^js curWindow "resize" (fn [e]
+                                    (let [sender (.-sender e)
+                                          [x y] (.getSize ^js sender)]
+                                      (prn (str "Size is - " x ", " y)))))
+      (prn (str "Startup size is - " size)))))
+
 (defn init
   []
   (set-global-alert!)
   (init-sentry)
   (init-ipcRenderer)
+  (init-windowsize)
   (style/init)
   (stylefy/tag "body" style/app-styles)
   (listeners/init)

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -78,13 +78,18 @@
 (defn init-windowsize
   []
   (when (util/electron?)
-    (let [curWindow (.getCurrentWindow athens.electron/remote)
-          size (.getSize curWindow)]
+    (let [curWindow        (.getCurrentWindow athens.electron/remote)
+          remember-ws?     (util/remember-ws?)
+          [lastx lasty]    (util/get-window-size)]
+      (when remember-ws?
+        (do
+          (prn (str "Window Size on close - " lastx ", " lasty))
+          (.setSize curWindow lastx lasty)))
       (.on ^js curWindow "resize" (fn [e]
                                     (let [sender (.-sender e)
                                           [x y] (.getSize ^js sender)]
-                                      (prn (str "Size is - " x ", " y)))))
-      (prn (str "Startup size is - " size)))))
+                                      (rf/dispatch [:window/set-size [x y]])
+                                      (prn (str "Size is - " x ", " y))))))))
 
 (defn init
   []

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -76,6 +76,7 @@
 
 
 (defn init-windowsize
+  "When the app is initialized, check if we should use the last window size and if so, set the current window size to that value"
   []
   (when (util/electron?)
     (let [curWindow        (.getCurrentWindow athens.electron/remote)
@@ -85,11 +86,10 @@
         (do
           (prn (str "Window Size on close - " lastx ", " lasty))
           (.setSize curWindow lastx lasty)))
-      (.on ^js curWindow "resize" (fn [e]
-                                    (let [sender (.-sender e)
-                                          [x y] (.getSize ^js sender)]
-                                      (rf/dispatch [:window/set-size [x y]])
-                                      (prn (str "Size is - " x ", " y))))))))
+      (.on ^js curWindow "resized" (fn [e]
+                                     (let [sender (.-sender e)
+                                           [x y] (.getSize ^js sender)]
+                                       (rf/dispatch [:window/set-size [x y]])))))))
 
 (defn init
   []

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -84,7 +84,7 @@
           [lastx lasty]    (util/get-window-size)]
       (when remember-ws?
         (do
-          (prn (str "Window Size on close - " lastx ", " lasty))
+          ;; (prn (str "Window Size on close - " lastx ", " lasty))
           (.setSize curWindow lastx lasty)
           (.center curWindow)))
       (.on ^js curWindow "resized" (fn [e]

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -85,7 +85,8 @@
       (when remember-ws?
         (do
           (prn (str "Window Size on close - " lastx ", " lasty))
-          (.setSize curWindow lastx lasty)))
+          (.setSize curWindow lastx lasty)
+          (.center curWindow)))
       (.on ^js curWindow "resized" (fn [e]
                                      (let [sender (.-sender e)
                                            [x y] (.getSize ^js sender)]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -293,8 +293,8 @@
 
 (reg-event-fx
   :window/set-size
-  (fn [_ [_ size]]
-    {:local-storage/set! ["ws/window-size" size]}))
+  (fn [_ [_ [x y]]]
+    {:local-storage/set! ["ws/window-size" (str x "," y)]}))
 
 
 ;; Loading

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -289,6 +289,13 @@
   (fn [db _]
     (update db :modal not)))
 
+;; Window Size
+
+(reg-event-fx
+  :window/set-size
+  (fn [_ [_ size]]
+    {:local-storage/set! ["ws/window-size" size]}))
+
 
 ;; Loading
 
@@ -1128,27 +1135,27 @@
 
 
 (reg-event-fx
-  :drop-multi/child
-  (fn [_ [_ source-uid target]]
-    {:dispatch [:transact (drop-multi-child source-uid target)]}))
+ :drop-multi/child
+ (fn [_ [_ source-uid target]]
+   {:dispatch [:transact (drop-multi-child source-uid target)]}))
 
 
 (reg-event-fx
-  :drop-multi/same-all
-  (fn [_ [_ kind source-uids parent target]]
-    {:dispatch [:transact (drop-multi-same-parent-all kind source-uids parent target)]}))
+ :drop-multi/same-all
+ (fn [_ [_ kind source-uids parent target]]
+   {:dispatch [:transact (drop-multi-same-parent-all kind source-uids parent target)]}))
 
 
 (reg-event-fx
-  :drop-multi/diff-source
-  (fn [_ [_ kind source-uids target target-parent]]
-    {:dispatch [:transact (drop-multi-diff-source-parents kind source-uids target target-parent)]}))
+ :drop-multi/diff-source
+ (fn [_ [_ kind source-uids target target-parent]]
+   {:dispatch [:transact (drop-multi-diff-source-parents kind source-uids target target-parent)]}))
 
 
 (reg-event-fx
-  :drop-multi/same-source
-  (fn [_ [_ kind source-uids first-source-parent target target-parent]]
-    {:dispatch [:transact (drop-multi-same-source-parents kind source-uids first-source-parent target target-parent)]}))
+ :drop-multi/same-source
+ (fn [_ [_ kind source-uids first-source-parent target target-parent]]
+   {:dispatch [:transact (drop-multi-same-source-parents kind source-uids first-source-parent target target-parent)]}))
 
 
 (defn drop-bullet-multi
@@ -1173,9 +1180,9 @@
 
 
 (reg-event-fx
-  :drop-multi
-  (fn [_ [_ uids target-uid kind]]
-    (drop-bullet-multi uids target-uid kind)))
+ :drop-multi
+ (fn [_ [_ uids target-uid kind]]
+   (drop-bullet-multi uids target-uid kind)))
 
 
 (defn text-to-blocks
@@ -1248,44 +1255,44 @@
 ;; - Otherwise append after current block.
 
 (reg-event-fx
-  :paste
-  (fn [_ [_ uid text]]
-    (let [block         (db/get-block [:block/uid uid])
-          {:block/keys [order children open]} block
-          {:keys [start value]} (keybindings/destruct-target js/document.activeElement) ; TODO: coeffect
-          empty-block?  (and (string/blank? value)
-                             (empty? children))
-          block-start?  (zero? start)
-          parent?       (and children open)
-          start-idx     (cond
-                          empty-block? order
-                          block-start? order
-                          parent? 0
-                          :else (inc order))
-          root-order    (atom start-idx)
-          parent        (cond
-                          parent? block
-                          :else (db/get-parent [:block/uid uid]))
-          paste-tx-data (text-to-blocks text (:block/uid parent) root-order)
+ :paste
+ (fn [_ [_ uid text]]
+   (let [block         (db/get-block [:block/uid uid])
+         {:block/keys [order children open]} block
+         {:keys [start value]} (keybindings/destruct-target js/document.activeElement) ; TODO: coeffect
+         empty-block?  (and (string/blank? value)
+                            (empty? children))
+         block-start?  (zero? start)
+         parent?       (and children open)
+         start-idx     (cond
+                         empty-block? order
+                         block-start? order
+                         parent? 0
+                         :else (inc order))
+         root-order    (atom start-idx)
+         parent        (cond
+                         parent? block
+                         :else (db/get-parent [:block/uid uid]))
+         paste-tx-data (text-to-blocks text (:block/uid parent) root-order)
           ;; the delta between root-order and start-idx is how many root blocks were added
-          n             (- @root-order start-idx)
-          start-reindex (cond
-                          block-start? (dec order)
-                          parent? -1
-                          :else order)
-          amount        (cond
-                          empty-block? (dec n)
-                          :else n)
-          reindex       (plus-after (:db/id parent) start-reindex amount)
-          tx-data       (concat reindex
-                                paste-tx-data
-                                (when empty-block? [[:db/retractEntity [:block/uid uid]]]))]
-      {:dispatch-n [[:transact tx-data]
-                    (when block-start?
-                      (let [block (-> paste-tx-data first :block/children)
-                            {:block/keys [uid string]} block
-                            n     (count string)]
-                        [:editing/uid uid n]))]})))
+         n             (- @root-order start-idx)
+         start-reindex (cond
+                         block-start? (dec order)
+                         parent? -1
+                         :else order)
+         amount        (cond
+                         empty-block? (dec n)
+                         :else n)
+         reindex       (plus-after (:db/id parent) start-reindex amount)
+         tx-data       (concat reindex
+                               paste-tx-data
+                               (when empty-block? [[:db/retractEntity [:block/uid uid]]]))]
+     {:dispatch-n [[:transact tx-data]
+                   (when block-start?
+                     (let [block (-> paste-tx-data first :block/children)
+                           {:block/keys [uid string]} block
+                           n     (count string)]
+                       [:editing/uid uid n]))]})))
 
 
 (defn left-sidebar-drop-above
@@ -1314,9 +1321,9 @@
 
 
 (reg-event-fx
-  :left-sidebar/drop-above
-  (fn-traced [_ [_ source-order target-order]]
-             {:dispatch [:transact (left-sidebar-drop-above source-order target-order)]}))
+ :left-sidebar/drop-above
+ (fn-traced [_ [_ source-order target-order]]
+            {:dispatch [:transact (left-sidebar-drop-above source-order target-order)]}))
 
 
 (defn left-sidebar-drop-below
@@ -1339,9 +1346,9 @@
 
 
 (reg-event-fx
-  :left-sidebar/drop-below
-  (fn-traced [_ [_ source-order target-order]]
-             {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
+ :left-sidebar/drop-below
+ (fn-traced [_ [_ source-order target-order]]
+            {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
 
 
 (defn link-unlinked-reference
@@ -1356,19 +1363,19 @@
 
 
 (reg-event-fx
-  :unlinked-references/link
-  (fn [_ [_ block title]]
-    (let [{:block/keys [string uid]} block
-          new-str (link-unlinked-reference string title)]
-      {:dispatch [:transact [{:db/id [:block/uid uid] :block/string new-str}]]})))
+ :unlinked-references/link
+ (fn [_ [_ block title]]
+   (let [{:block/keys [string uid]} block
+         new-str (link-unlinked-reference string title)]
+     {:dispatch [:transact [{:db/id [:block/uid uid] :block/string new-str}]]})))
 
 
 (reg-event-fx
-  :unlinked-references/link-all
-  (fn [_ [_ unlinked-refs title]]
-    (let [new-str-tx-data (->> unlinked-refs
-                               (mapcat second unlinked-refs)
-                               (map (fn [{:block/keys [string uid]}]
-                                      (let [new-str (link-unlinked-reference string title)]
-                                        {:db/id [:block/uid uid] :block/string new-str}))))]
-      {:dispatch [:transact new-str-tx-data]})))
+ :unlinked-references/link-all
+ (fn [_ [_ unlinked-refs title]]
+   (let [new-str-tx-data (->> unlinked-refs
+                              (mapcat second unlinked-refs)
+                              (map (fn [{:block/keys [string uid]}]
+                                     (let [new-str (link-unlinked-reference string title)]
+                                       {:db/id [:block/uid uid] :block/string new-str}))))]
+     {:dispatch [:transact new-str-tx-data]})))

--- a/src/cljs/athens/main/core.cljs
+++ b/src/cljs/athens/main/core.cljs
@@ -38,10 +38,6 @@
   ; Path is relative to the compiled js file (main.js in our case)
   (.loadURL ^js @main-window (str "file://" js/__dirname "/public/index.html"))
   (.on ^js @main-window "closed" #(reset! main-window nil))
-  ;; (.on ^js @main-window "resize" (fn [e]
-  ;;                                  (let [sender (.-sender e)
-  ;;                                        [x y] (.getSize ^js sender)]
-  ;;                                    (prn (str "Size is - " x ", " y)))))
   (.. ^js @main-window -webContents (on "new-window" (fn [e url]
                                                        (.. e preventDefault)
                                                        (.. shell (openExternal url))))))

--- a/src/cljs/athens/main/core.cljs
+++ b/src/cljs/athens/main/core.cljs
@@ -1,7 +1,7 @@
 (ns athens.main.core
   (:require
-    ["electron" :refer [app BrowserWindow ipcMain shell]]
-    ["electron-updater" :refer [autoUpdater]]))
+   ["electron" :refer [app BrowserWindow ipcMain shell]]
+   ["electron-updater" :refer [autoUpdater]]))
 
 
 (def log (js/require "electron-log"))
@@ -24,21 +24,24 @@
   (.. log (info text))
   (.. ^js @main-window -webContents (send text)))
 
-
 (defn init-browser
   []
   (reset! main-window (BrowserWindow.
-                        (clj->js {:width 800
-                                  :height 600
-                                  :autoHideMenuBar true
-                                  :enableRemoteModule true
-                                  :webPreferences {:nodeIntegration true
-                                                   :worldSafeExecuteJavaScript true
-                                                   :enableRemoteModule true
-                                                   :nodeIntegrationWorker true}})))
+                       (clj->js {:width 800
+                                 :height 600
+                                 :autoHideMenuBar true
+                                 :enableRemoteModule true
+                                 :webPreferences {:nodeIntegration true
+                                                  :worldSafeExecuteJavaScript true
+                                                  :enableRemoteModule true
+                                                  :nodeIntegrationWorker true}})))
   ; Path is relative to the compiled js file (main.js in our case)
   (.loadURL ^js @main-window (str "file://" js/__dirname "/public/index.html"))
   (.on ^js @main-window "closed" #(reset! main-window nil))
+  (.on ^js @main-window "resize" (fn [e]
+                                   (let [sender (.-sender e)
+                                         [x y] (.getSize ^js sender)]
+                                     (prn (str "Size is - " x ", " y)))))
   (.. ^js @main-window -webContents (on "new-window" (fn [e url]
                                                        (.. e preventDefault)
                                                        (.. shell (openExternal url))))))

--- a/src/cljs/athens/main/core.cljs
+++ b/src/cljs/athens/main/core.cljs
@@ -38,10 +38,10 @@
   ; Path is relative to the compiled js file (main.js in our case)
   (.loadURL ^js @main-window (str "file://" js/__dirname "/public/index.html"))
   (.on ^js @main-window "closed" #(reset! main-window nil))
-  (.on ^js @main-window "resize" (fn [e]
-                                   (let [sender (.-sender e)
-                                         [x y] (.getSize ^js sender)]
-                                     (prn (str "Size is - " x ", " y)))))
+  ;; (.on ^js @main-window "resize" (fn [e]
+  ;;                                  (let [sender (.-sender e)
+  ;;                                        [x y] (.getSize ^js sender)]
+  ;;                                    (prn (str "Size is - " x ", " y)))))
   (.. ^js @main-window -webContents (on "new-window" (fn [e url]
                                                        (.. e preventDefault)
                                                        (.. shell (openExternal url))))))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -1,11 +1,11 @@
 (ns athens.util
   (:require
-    ["/textarea" :as getCaretCoordinates]
-    [clojure.string :as string]
-    [goog.dom :refer [getElement setProperties]]
-    [posh.reagent :refer [#_pull]]
-    [tick.alpha.api :as t]
-    [tick.locale-en-us]))
+   ["/textarea" :as getCaretCoordinates]
+   [clojure.string :as string]
+   [goog.dom :refer [getElement setProperties]]
+   [posh.reagent :refer [#_pull]]
+   [tick.alpha.api :as t]
+   [tick.locale-en-us]))
 
 
 (defn gen-block-uid
@@ -61,8 +61,8 @@
   (let [el-box (.. element getBoundingClientRect)
         cont-box (.. container getBoundingClientRect)]
     (or
-      (> (.. el-box -bottom) (.. cont-box -bottom))
-      (< (.. el-box -top) (.. cont-box -top)))))
+     (> (.. el-box -bottom) (.. cont-box -bottom))
+     (< (.. el-box -top) (.. cont-box -top)))))
 
 
 (defn scroll-into-view [element container align-top?]
@@ -144,14 +144,14 @@
   ([] (get-day 0))
   ([offset]
    (let [day (t/-
-               (t/date-time)
-               (t/new-duration offset :days))]
+              (t/date-time)
+              (t/new-duration offset :days))]
      {:uid   (t/format US-format day)
       :title (t/format title-format day)}))
   ([date offset]
    (let [day (t/-
-               (-> date (t/at "0"))
-               (t/new-duration offset :days))]
+              (-> date (t/at "0"))
+              (t/new-duration offset :days))]
      {:uid   (t/format US-format day)
       :title (t/format title-format day)})))
 
@@ -161,7 +161,7 @@
   (if (not ts)
     [:span "(unknown date)"]
     (as->
-      (t/instant ts) x
+     (t/instant ts) x
       (t/date-time x)
       (t/format date-col-format x)
       (string/replace x #"AM" "am")
@@ -262,3 +262,21 @@
     (electron?) (.. (js/require "electron") -remote -app getVersion)))
     ;;(not (string/blank? COMMIT_URL)) COMMIT_URL
     ;;:else "Web"))
+
+
+;; Window
+
+(defn remember-ws?
+  "Checks localStorage to see if we should remember window-size is on. It is disabled/enabled in settings."
+  []
+  (let [rws (js/localStorage.getItem "ws/remember-ws")]
+    (if (nil? rws)
+      false
+      (not= "off" rws))))
+
+(defn get-window-size
+  []
+  (let [ws (js/localStorage.getItem "ws/window-size")]
+    (if (nil? ws)
+      '[800 600]
+      (map #(js/parseInt %) (string/split ws ",")))))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -275,6 +275,7 @@
       (not= "off" rws))))
 
 (defn get-window-size
+  "Reads window size from local-storage and returns the values as a vector"
   []
   (let [ws (js/localStorage.getItem "ws/window-size")]
     (if (nil? ws)

--- a/src/cljs/athens/views/settings_page.cljs
+++ b/src/cljs/athens/views/settings_page.cljs
@@ -1,8 +1,8 @@
 (ns athens.views.settings-page
   (:require
-   ["@material-ui/icons" :as mui-icons]
-   [athens.views.buttons :refer [button]]
-   [reagent.core :as r]))
+    ["@material-ui/icons" :as mui-icons]
+    [athens.views.buttons :refer [button]]
+    [reagent.core :as r]))
 
 
 (defn opt-out
@@ -23,13 +23,13 @@
 
 (defn remember-ws
   [remember-window-size?]
-  (js/localStorage.setItem "rememberws" "on")
+  (js/localStorage.setItem "ws/remember-ws" "on")
   (reset! remember-window-size? true))
 
 
 (defn dont-remember-ws
   [remember-window-size?]
-  (js/localStorage.setItem "rememberws" "off")
+  (js/localStorage.setItem "ws/remember-ws" "off")
   (reset! remember-window-size? false))
 
 

--- a/src/cljs/athens/views/settings_page.cljs
+++ b/src/cljs/athens/views/settings_page.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.settings-page
   (:require
     ["@material-ui/icons" :as mui-icons]
+    [athens.util :refer [remember-ws?]]
     [athens.views.buttons :refer [button]]
     [reagent.core :as r]))
 
@@ -50,7 +51,7 @@
 (defn settings-page
   []
   (let [opted-out? (r/atom (.. js/window -posthog has_opted_out_capturing))
-        remember-window-size? (r/atom false)]
+        remember-window-size? (r/atom (remember-ws?))]
     (fn []
       [:div {:style {:display "flex"
                      :margin "0vh 5vw"

--- a/src/cljs/athens/views/settings_page.cljs
+++ b/src/cljs/athens/views/settings_page.cljs
@@ -1,8 +1,8 @@
 (ns athens.views.settings-page
   (:require
-    ["@material-ui/icons" :as mui-icons]
-    [athens.views.buttons :refer [button]]
-    [reagent.core :as r]))
+   ["@material-ui/icons" :as mui-icons]
+   [athens.views.buttons :refer [button]]
+   [reagent.core :as r]))
 
 
 (defn opt-out
@@ -21,6 +21,25 @@
   (reset! opted-out? false))
 
 
+(defn remember-ws
+  [remember-window-size?]
+  (js/localStorage.setItem "rememberws" "on")
+  (reset! remember-window-size? true))
+
+
+(defn dont-remember-ws
+  [remember-window-size?]
+  (js/localStorage.setItem "rememberws" "off")
+  (reset! remember-window-size? false))
+
+
+(defn handle-ws
+  [remember-window-size?]
+  (if @remember-window-size?
+    (dont-remember-ws remember-window-size?)
+    (remember-ws remember-window-size?)))
+
+
 (defn handle-click
   [opted-out?]
   (if @opted-out?
@@ -30,7 +49,8 @@
 
 (defn settings-page
   []
-  (let [opted-out? (r/atom (.. js/window -posthog has_opted_out_capturing))]
+  (let [opted-out? (r/atom (.. js/window -posthog has_opted_out_capturing))
+        remember-window-size? (r/atom false)]
     (fn []
       [:div {:style {:display "flex"
                      :margin "0vh 5vw"
@@ -53,6 +73,18 @@
         [:a {:href "https://posthog.com" :target "_blank"} "Posthog"]
         " and " [:a {:href "https://sentry.io" :target "_blank"} "Sentry"]
         ", open-source solutions to measure retention, performance, and crashes.
-         This lets the designers and engineers at Athens know if we're really making something people love!"]])))
+         This lets the designers and engineers at Athens know if we're really making something people love!"]
+       [:br]
+       [:h5 "Remember the last Window Size on Athens Startup"]
+       [:div {:style {:margin "10px 0"}}
+        [button {:primary (true? @remember-window-size?)
+                 :on-click #(handle-ws remember-window-size?)}
+         (if @remember-window-size?
+           [:div {:style {:display "flex"}}
+            [:> mui-icons/ToggleOff]
+            [:span "\uD83D\uDE00 Yes!"]]
+           [:div {:style {:display "flex"}}
+            [:> mui-icons/ToggleOn]
+            [:span "\uD83D\uDE41 No."]])]]])))
 
 


### PR DESCRIPTION
This PR handles #616. The user can enable this feature via a toggle in the Settings page enabling Athens to "remember" the window size when Athens was last closed.

## Technical Details

We add a new `init-windowsize` function that handles all window-size related functionality and is called within `init` in `athens.core`.

* Check if the "Remember Window Size" option is set to "on" in `localStorage`. (This value can be toggle on and off in the Settings Page). If it is, extract the last known window width and height from `localStorage` and set the size of the current window to those values. We also center the window in the current screen to avoid misalignment.
* Create an event handler to handle the "resize" event for the current window. This event handler gets the current size of the window and dispatches a re-frame event, `:window/set-size` which stores the provided values in `localStorage`.
* We also add some utility functions for reading the required values from `localStorage` and provide sane defaults if the values don't exist in `localStorage`.