### PR TITLE
feat: Remember Window Size

### DIFF
--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -83,10 +83,9 @@
           remember-ws?     (util/remember-ws?)
           [lastx lasty]    (util/get-window-size)]
       (when remember-ws?
-        (do
-          ;; (prn (str "Window Size on close - " lastx ", " lasty))
-          (.setSize curWindow lastx lasty)
-          (.center curWindow)))
+        (
+         (.setSize curWindow lastx lasty)
+         (.center curWindow)))
       (.on ^js curWindow "resized" (fn [e]
                                      (let [sender (.-sender e)
                                            [x y] (.getSize ^js sender)]

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -83,12 +83,12 @@
           remember-ws?     (util/remember-ws?)
           [lastx lasty]    (util/get-window-size)]
       (when remember-ws?
-        ((.setSize curWindow lastx lasty)
-         (.center curWindow)))
-      (.on ^js curWindow "resized" (fn [e]
-                                     (let [sender (.-sender e)
-                                           [x y] (.getSize ^js sender)]
-                                       (rf/dispatch [:window/set-size [x y]])))))))
+        (.setSize curWindow lastx lasty)
+        (.center curWindow))
+      (.on ^js curWindow "close" (fn [e]
+                                   (let [sender (.-sender e)
+                                         [x y] (.getSize ^js sender)]
+                                     (rf/dispatch [:window/set-size [x y]])))))))
 
 
 (defn init

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -75,11 +75,30 @@
           (.sendSync ipcRenderer "confirm-update"))))))
 
 
+(defn init-windowsize
+  "When the app is initialized, check if we should use the last window size and if so, set the current window size to that value"
+  []
+  (when (util/electron?)
+    (let [curWindow        (.getCurrentWindow athens.electron/remote)
+          remember-ws?     (util/remember-ws?)
+          [lastx lasty]    (util/get-window-size)]
+      (when remember-ws?
+        (do
+          ;; (prn (str "Window Size on close - " lastx ", " lasty))
+          (.setSize curWindow lastx lasty)
+          (.center curWindow)))
+      (.on ^js curWindow "resized" (fn [e]
+                                     (let [sender (.-sender e)
+                                           [x y] (.getSize ^js sender)]
+                                       (rf/dispatch [:window/set-size [x y]])))))))
+
+
 (defn init
   []
   (set-global-alert!)
   (init-sentry)
   (init-ipcRenderer)
+  (init-windowsize)
   (style/init)
   (stylefy/tag "body" style/app-styles)
   (listeners/init)

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -83,8 +83,7 @@
           remember-ws?     (util/remember-ws?)
           [lastx lasty]    (util/get-window-size)]
       (when remember-ws?
-        (
-         (.setSize curWindow lastx lasty)
+        ((.setSize curWindow lastx lasty)
          (.center curWindow)))
       (.on ^js curWindow "resized" (fn [e]
                                      (let [sender (.-sender e)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -290,6 +290,13 @@
     (update db :modal not)))
 
 
+;; Window Size
+
+(reg-event-fx
+  :window/set-size
+  (fn [_ [_ [x y]]]
+    {:local-storage/set! ["ws/window-size" (str x "," y)]}))
+
 ;; Loading
 
 (reg-event-db
@@ -1127,27 +1134,27 @@
 
 
 (reg-event-fx
-  :drop-multi/child
-  (fn [_ [_ source-uid target]]
-    {:dispatch [:transact (drop-multi-child source-uid target)]}))
+ :drop-multi/child
+ (fn [_ [_ source-uid target]]
+   {:dispatch [:transact (drop-multi-child source-uid target)]}))
 
 
 (reg-event-fx
-  :drop-multi/same-all
-  (fn [_ [_ kind source-uids parent target]]
-    {:dispatch [:transact (drop-multi-same-parent-all kind source-uids parent target)]}))
+ :drop-multi/same-all
+ (fn [_ [_ kind source-uids parent target]]
+   {:dispatch [:transact (drop-multi-same-parent-all kind source-uids parent target)]}))
 
 
 (reg-event-fx
-  :drop-multi/diff-source
-  (fn [_ [_ kind source-uids target target-parent]]
-    {:dispatch [:transact (drop-multi-diff-source-parents kind source-uids target target-parent)]}))
+ :drop-multi/diff-source
+ (fn [_ [_ kind source-uids target target-parent]]
+   {:dispatch [:transact (drop-multi-diff-source-parents kind source-uids target target-parent)]}))
 
 
 (reg-event-fx
-  :drop-multi/same-source
-  (fn [_ [_ kind source-uids first-source-parent target target-parent]]
-    {:dispatch [:transact (drop-multi-same-source-parents kind source-uids first-source-parent target target-parent)]}))
+ :drop-multi/same-source
+ (fn [_ [_ kind source-uids first-source-parent target target-parent]]
+   {:dispatch [:transact (drop-multi-same-source-parents kind source-uids first-source-parent target target-parent)]}))
 
 
 (defn drop-bullet-multi
@@ -1172,9 +1179,9 @@
 
 
 (reg-event-fx
-  :drop-multi
-  (fn [_ [_ uids target-uid kind]]
-    (drop-bullet-multi uids target-uid kind)))
+ :drop-multi
+ (fn [_ [_ uids target-uid kind]]
+   (drop-bullet-multi uids target-uid kind)))
 
 
 (defn text-to-blocks
@@ -1247,44 +1254,44 @@
 ;; - Otherwise append after current block.
 
 (reg-event-fx
-  :paste
-  (fn [_ [_ uid text]]
-    (let [block         (db/get-block [:block/uid uid])
-          {:block/keys [order children open]} block
-          {:keys [start value]} (keybindings/destruct-target js/document.activeElement) ; TODO: coeffect
-          empty-block?  (and (string/blank? value)
-                             (empty? children))
-          block-start?  (zero? start)
-          parent?       (and children open)
-          start-idx     (cond
-                          empty-block? order
-                          block-start? order
-                          parent? 0
-                          :else (inc order))
-          root-order    (atom start-idx)
-          parent        (cond
-                          parent? block
-                          :else (db/get-parent [:block/uid uid]))
-          paste-tx-data (text-to-blocks text (:block/uid parent) root-order)
+ :paste
+ (fn [_ [_ uid text]]
+   (let [block         (db/get-block [:block/uid uid])
+         {:block/keys [order children open]} block
+         {:keys [start value]} (keybindings/destruct-target js/document.activeElement) ; TODO: coeffect
+         empty-block?  (and (string/blank? value)
+                            (empty? children))
+         block-start?  (zero? start)
+         parent?       (and children open)
+         start-idx     (cond
+                         empty-block? order
+                         block-start? order
+                         parent? 0
+                         :else (inc order))
+         root-order    (atom start-idx)
+         parent        (cond
+                         parent? block
+                         :else (db/get-parent [:block/uid uid]))
+         paste-tx-data (text-to-blocks text (:block/uid parent) root-order)
           ;; the delta between root-order and start-idx is how many root blocks were added
-          n             (- @root-order start-idx)
-          start-reindex (cond
-                          block-start? (dec order)
-                          parent? -1
-                          :else order)
-          amount        (cond
-                          empty-block? (dec n)
-                          :else n)
-          reindex       (plus-after (:db/id parent) start-reindex amount)
-          tx-data       (concat reindex
-                                paste-tx-data
-                                (when empty-block? [[:db/retractEntity [:block/uid uid]]]))]
-      {:dispatch-n [[:transact tx-data]
-                    (when block-start?
-                      (let [block (-> paste-tx-data first :block/children)
-                            {:block/keys [uid string]} block
-                            n     (count string)]
-                        [:editing/uid uid n]))]})))
+         n             (- @root-order start-idx)
+         start-reindex (cond
+                         block-start? (dec order)
+                         parent? -1
+                         :else order)
+         amount        (cond
+                         empty-block? (dec n)
+                         :else n)
+         reindex       (plus-after (:db/id parent) start-reindex amount)
+         tx-data       (concat reindex
+                               paste-tx-data
+                               (when empty-block? [[:db/retractEntity [:block/uid uid]]]))]
+     {:dispatch-n [[:transact tx-data]
+                   (when block-start?
+                     (let [block (-> paste-tx-data first :block/children)
+                           {:block/keys [uid string]} block
+                           n     (count string)]
+                       [:editing/uid uid n]))]})))
 
 
 (defn left-sidebar-drop-above
@@ -1313,9 +1320,9 @@
 
 
 (reg-event-fx
-  :left-sidebar/drop-above
-  (fn-traced [_ [_ source-order target-order]]
-             {:dispatch [:transact (left-sidebar-drop-above source-order target-order)]}))
+ :left-sidebar/drop-above
+ (fn-traced [_ [_ source-order target-order]]
+            {:dispatch [:transact (left-sidebar-drop-above source-order target-order)]}))
 
 
 (defn left-sidebar-drop-below
@@ -1338,9 +1345,9 @@
 
 
 (reg-event-fx
-  :left-sidebar/drop-below
-  (fn-traced [_ [_ source-order target-order]]
-             {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
+ :left-sidebar/drop-below
+ (fn-traced [_ [_ source-order target-order]]
+            {:dispatch [:transact (left-sidebar-drop-below source-order target-order)]}))
 
 
 (defn link-unlinked-reference
@@ -1355,19 +1362,19 @@
 
 
 (reg-event-fx
-  :unlinked-references/link
-  (fn [_ [_ block title]]
-    (let [{:block/keys [string uid]} block
-          new-str (link-unlinked-reference string title)]
-      {:dispatch [:transact [{:db/id [:block/uid uid] :block/string new-str}]]})))
+ :unlinked-references/link
+ (fn [_ [_ block title]]
+   (let [{:block/keys [string uid]} block
+         new-str (link-unlinked-reference string title)]
+     {:dispatch [:transact [{:db/id [:block/uid uid] :block/string new-str}]]})))
 
 
 (reg-event-fx
-  :unlinked-references/link-all
-  (fn [_ [_ unlinked-refs title]]
-    (let [new-str-tx-data (->> unlinked-refs
-                               (mapcat second unlinked-refs)
-                               (map (fn [{:block/keys [string uid]}]
-                                      (let [new-str (link-unlinked-reference string title)]
-                                        {:db/id [:block/uid uid] :block/string new-str}))))]
-      {:dispatch [:transact new-str-tx-data]})))
+ :unlinked-references/link-all
+ (fn [_ [_ unlinked-refs title]]
+   (let [new-str-tx-data (->> unlinked-refs
+                              (mapcat second unlinked-refs)
+                              (map (fn [{:block/keys [string uid]}]
+                                     (let [new-str (link-unlinked-reference string title)]
+                                       {:db/id [:block/uid uid] :block/string new-str}))))]
+     {:dispatch [:transact new-str-tx-data]})))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -1,11 +1,11 @@
 (ns athens.util
   (:require
-    ["/textarea" :as getCaretCoordinates]
-    [clojure.string :as string]
-    [goog.dom :refer [getElement setProperties]]
-    [posh.reagent :refer [#_pull]]
-    [tick.alpha.api :as t]
-    [tick.locale-en-us]))
+   ["/textarea" :as getCaretCoordinates]
+   [clojure.string :as string]
+   [goog.dom :refer [getElement setProperties]]
+   [posh.reagent :refer [#_pull]]
+   [tick.alpha.api :as t]
+   [tick.locale-en-us]))
 
 
 (defn gen-block-uid
@@ -61,8 +61,8 @@
   (let [el-box (.. element getBoundingClientRect)
         cont-box (.. container getBoundingClientRect)]
     (or
-      (> (.. el-box -bottom) (.. cont-box -bottom))
-      (< (.. el-box -top) (.. cont-box -top)))))
+     (> (.. el-box -bottom) (.. cont-box -bottom))
+     (< (.. el-box -top) (.. cont-box -top)))))
 
 
 (defn scroll-into-view [element container align-top?]
@@ -144,14 +144,14 @@
   ([] (get-day 0))
   ([offset]
    (let [day (t/-
-               (t/date-time)
-               (t/new-duration offset :days))]
+              (t/date-time)
+              (t/new-duration offset :days))]
      {:uid   (t/format US-format day)
       :title (t/format title-format day)}))
   ([date offset]
    (let [day (t/-
-               (-> date (t/at "0"))
-               (t/new-duration offset :days))]
+              (-> date (t/at "0"))
+              (t/new-duration offset :days))]
      {:uid   (t/format US-format day)
       :title (t/format title-format day)})))
 
@@ -161,7 +161,7 @@
   (if (not ts)
     [:span "(unknown date)"]
     (as->
-      (t/instant ts) x
+     (t/instant ts) x
       (t/date-time x)
       (t/format date-col-format x)
       (string/replace x #"AM" "am")
@@ -262,3 +262,21 @@
     (electron?) (.. (js/require "electron") -remote -app getVersion)))
     ;;(not (string/blank? COMMIT_URL)) COMMIT_URL
     ;;:else "Web"))
+
+;; Window
+
+(defn remember-ws?
+  "Checks localStorage to see if we should remember window-size is on. It is disabled/enabled in settings."
+  []
+  (let [rws (js/localStorage.getItem "ws/remember-ws")]
+    (if (nil? rws)
+      false
+      (not= "off" rws))))
+
+(defn get-window-size
+  "Reads window size from local-storage and returns the values as a vector"
+  []
+  (let [ws (js/localStorage.getItem "ws/window-size")]
+    (if (nil? ws)
+      '[800 600]
+      (map #(js/parseInt %) (string/split ws ",")))))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -1,11 +1,11 @@
 (ns athens.util
   (:require
-   ["/textarea" :as getCaretCoordinates]
-   [clojure.string :as string]
-   [goog.dom :refer [getElement setProperties]]
-   [posh.reagent :refer [#_pull]]
-   [tick.alpha.api :as t]
-   [tick.locale-en-us]))
+    ["/textarea" :as getCaretCoordinates]
+    [clojure.string :as string]
+    [goog.dom :refer [getElement setProperties]]
+    [posh.reagent :refer [#_pull]]
+    [tick.alpha.api :as t]
+    [tick.locale-en-us]))
 
 
 (defn gen-block-uid
@@ -182,7 +182,6 @@
   (boolean (uid-to-date uid)))
 
 
-
 ;; -- Regex -----------------------------------------------------------
 
 ;; https://stackoverflow.com/a/11672480
@@ -273,6 +272,7 @@
       false
       (not= "off" rws))))
 
+
 (defn get-window-size
   "Reads window size from local-storage and returns the values as a vector"
   []
@@ -280,3 +280,4 @@
     (if (nil? ws)
       '[800 600]
       (map #(js/parseInt %) (string/split ws ",")))))
+

--- a/src/cljs/athens/views/settings_page.cljs
+++ b/src/cljs/athens/views/settings_page.cljs
@@ -1,11 +1,11 @@
 (ns athens.views.settings-page
   (:require
-   ["@material-ui/icons" :as mui-icons]
-   [athens.electron :as electron]
-   [athens.util :refer [remember-ws?]]
-   [athens.views.buttons :refer [button]]
-   [goog.functions :as goog-functions]
-   [reagent.core :as r]))
+    ["@material-ui/icons" :as mui-icons]
+    [athens.electron :as electron]
+    [athens.util :refer [remember-ws?]]
+    [athens.views.buttons :refer [button]]
+    [goog.functions :as goog-functions]
+    [reagent.core :as r]))
 
 
 (defn opt-out


### PR DESCRIPTION
This PR handles #616. The user can enable this feature via a toggle in the Settings page enabling Athens to "remember" the window size when Athens was last closed.
Technical Details

We add a new `init-windowsize` function that handles all window-size related functionality and is called within `init` in `athens.core`.

* Check if the "Remember Window Size" option is set to "on" in `localStorage`. (This value can be toggle on and off in the Settings Page). If it is, extract the last known window width and height from `localStorage` and set the size of the current window to those values. We also center the window in the current screen to avoid misalignment.
* Create an event handler to handle the "resize" event for the current window. This event handler gets the current size of the window and dispatches a re-frame event, `:window/set-size` which stores the provided values in `localStorage`.
* We also add some utility functions for reading the required values from `localStorage` and provide sane defaults if the values don't exist in `localStorage`.

Close #616