### PR TITLE
fix: re-find issue in fs-watch

### DIFF
--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -278,7 +278,7 @@
         (.. fs (watch dirpath (fn [_event filename]
                                 ;; when filename matches last part of filepath
                                 ;; e.g. "first-db.transit" matches "home/u/Documents/athens/first-db.transit"
-                                (when (re-find #"conflict" filename)
+                                (when (re-find #"conflict" (or filename ""))
                                   (throw "Conflict file created by Dropbox"))
                                 (when (re-find (re-pattern (str "\\b" filename "$")) filepath)
                                   (debounce-sync-db-from-fs filepath filename))))))


### PR DESCRIPTION
To fix this issue: https://discord.com/channels/708122962422792194/802652338619285594/813943745271300117

The `filename` is `nil` sometimes that's why `re-find` is failing.

This change is so that when the `filename` is nil, `re-find` will use the empty string.
