### PR TITLE
fix(title): Empty title and regex in block query

### DIFF
--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -3,7 +3,7 @@
     ["@material-ui/icons" :as mui-icons]
     [athens.db :as db]
     [athens.router :as router]
-    [athens.util :refer [scroll-if-needed get-day get-caret-position shortcut-key?]]
+    [athens.util :refer [scroll-if-needed get-day get-caret-position shortcut-key? escape-str]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [clojure.string :refer [replace-first blank?]]
@@ -205,6 +205,7 @@
          expansion    (or title uid)
          block?       (= type :block)
          page?        (= type :page)
+         query        (escape-str query)
          ;; rewrite this more cleanly
          head-pattern (cond block? (re-pattern (str "(?s)(.*)\\(\\(" query))
                             page? (re-pattern (str "(?s)(.*)\\[\\[" query)))
@@ -228,6 +229,7 @@
          {:keys [start head tail]} (destruct-target target)
          block?       (= type :block)
          page?        (= type :page)
+         query        (escape-str query)
          ;; rewrite this more cleanly
          head-pattern (cond block? (re-pattern (str "(?s)(.*)\\(\\(" query))
                             page? (re-pattern (str "(?s)(.*)\\[\\[" query)))

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -135,7 +135,9 @@
             :on-blur     (fn [_] (persist-textarea-string @state block))
             :on-key-down (fn [e] (node-page/handle-key-down e uid state nil))
             :on-change   (fn [e] (block-page-change e uid state))}]
-          [:span [parse-renderer/parse-and-render (:string/local @state) uid]]]
+          (if (clojure.string/blank? (:string/local @state))
+            [:wbr]
+            [:span [parse-renderer/parse-and-render (:string/local @state) uid]])]
 
          ;; Children
          [:div (for [child children]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -201,6 +201,19 @@
       (and (not shift) (= key-code KeyCodes.ENTER)) (handle-enter e uid state children))))
 
 
+(defn auto-inc-untitled
+  ([] (auto-inc-untitled nil))
+  ([n]
+   (if (empty? (d/q '[:find [?e ...]
+                      :in $ ?t
+                      :where
+                      [?e :node/title ?t]]
+                    @db/dsdb (str "Untitled" (when n (str "-" n)))))
+     (str "Untitled" (when n (str "-" n)))
+     (auto-inc-untitled (+ n 1)))))
+
+
+
 (defn handle-change
   [e state]
   (let [value (.. e -target -value)]
@@ -533,10 +546,20 @@
              {:value       (:title/local @state)
               :id          (str "editable-uid-" uid)
               :class       (when (= editing-uid uid) "is-editing")
-              :on-blur     (fn [_] (handle-blur node state linked-refs))
+              :on-blur     (fn [_]
+                             ;; add title Untitled-n for empty titles
+                             (when (empty? (:title/local @state))
+                               (swap! state assoc :title/local (auto-inc-untitled)))
+                             (handle-blur node state linked-refs))
               :on-key-down (fn [e] (handle-key-down e uid state children))
               :on-change   (fn [e] (handle-change e state))}])
-          [parse-renderer/parse-and-render (:title/local @state) uid]]
+          [parse-renderer/parse-and-render
+           (or (and (not (empty? (:title/local @state)))
+                    (:title/local @state))
+               ;; empty char to keep span on full height
+               ;; else it will collapse to 0 height (weird ui)
+               "&#8203;")
+           uid]]
 
          ;; Dropdown
          [menu-dropdown node state daily-note?]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -213,7 +213,6 @@
      (auto-inc-untitled (+ n 1)))))
 
 
-
 (defn handle-change
   [e state]
   (let [value (.. e -target -value)]
@@ -553,13 +552,12 @@
                              (handle-blur node state linked-refs))
               :on-key-down (fn [e] (handle-key-down e uid state children))
               :on-change   (fn [e] (handle-change e state))}])
-          [parse-renderer/parse-and-render
-           (or (and (not (empty? (:title/local @state)))
-                    (:title/local @state))
-               ;; empty char to keep span on full height
-               ;; else it will collapse to 0 height (weird ui)
-               "&#8203;")
-           uid]]
+          ;; empty word break to keep span on full height else it will collapse to 0 height (weird ui)
+          (if (str/blank? (:title/local @state))
+            [:wbr]
+            [parse-renderer/parse-and-render
+             (:title/local @state)
+             uid])]
 
          ;; Dropdown
          [menu-dropdown node state daily-note?]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -555,9 +555,7 @@
           ;; empty word break to keep span on full height else it will collapse to 0 height (weird ui)
           (if (str/blank? (:title/local @state))
             [:wbr]
-            [parse-renderer/parse-and-render
-             (:title/local @state)
-             uid])]
+            [parse-renderer/parse-and-render (:title/local @state) uid])]
 
          ;; Dropdown
          [menu-dropdown node state daily-note?]


### PR DESCRIPTION
close #713 

- Use `<wbr/>` instead of `&#8203;`, which works on Linux.
- Apply to block-page header as well