### PR TITLE
fix(electron): Avoid race-condition with filesystem mtime

### DIFF
--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -414,8 +414,9 @@
                         ;; If copy fails, by default, node.js deletes the destination file (index.transit): https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_mode
                         (when copy?
                           (.. fs (copyFileSync bkp-filepath filepath))
-                          (dispatch [:db/sync])
-                          (dispatch [:db/update-mtime (js/Date.)]))))
+                          (let [mtime (.-mtime (.statSync fs filepath))]
+                            (dispatch-sync [:db/update-mtime mtime])
+                            (dispatch [:db/sync])))))
       (.pipe r w)))
 
 


### PR DESCRIPTION
There are two race-conditions, that should resolve https://github.com/athensresearch/athens/issues/698.

They are reproducible without an external sync service; but at first-glance are not obvious to spot, because machines are generally very fast and the debounces also helped to distort reality. :)

The first race-condition is using current `(js/Date.)` instead of the actual mtime of the filesystem. If we force a minimum 1 second delay, we can reproduce this conflict every time:

``` clojure
;; athens.electron/write-db
(when copy?
  (.. fs (copyFileSync bkp-filepath filepath))
  (dispatch [:db/sync])
  ;; (dispatch [:db/update-mtime (js/Date.)])
  (js/setTimeout #(dispatch [:db/update-mtime (js/Date.)]) 1100))
```

By using the actual mtime from the filesystem, we can avoid any race-conditions between when the file synced, the time it takes to check the actual system clock, and any weird clock drifts:

``` clojure
;; athens.electron/write-db
(when copy?
  (.. fs (copyFileSync bkp-filepath filepath))
  (dispatch [:db/sync])
  ;; (dispatch [:db/update-mtime (js/Date.)])
  (let [mtime (.-mtime (.statSync fs filepath))]
    (js/setTimeout #(dispatch [:db/update-mtime mtime]) 1100)))
```

The second race-condition is more subtle and has to do with the order and batching of re-frame events. To reproduce consistently, we need to disable the debouncing functionality:

``` clojure
;; athens.electron/debounce-sync-db-from-fs
(when (re-find (re-pattern (str "\\b" filename "$")) filepath)
  #_(debounce-sync-db-from-fs filepath filename)
  (sync-db-from-fs filepath filename))
```

What we would see (with the help of some println pixie-dust):

![mtime-before](https://user-images.githubusercontent.com/21281/109973437-aceed900-7cf8-11eb-9400-2bebc3d921a8.jpg)

Even though we are now sending the correct new filesystem mtime, the operations are out of order and `athens.electron/sync-db-from-fs` is comparing to a stale mtime in the database. We can fix this, by changing the order of operations and making sure to use `dispatch-sync` so that we force re-frame to update the value before it calls `sync-db-from-fs`:

``` clojure
(when copy?
    (.. fs (copyFileSync bkp-filepath filepath))
    (let [mtime (.-mtime (.statSync fs filepath))]
      (dispatch-sync [:db/update-mtime mtime])
      (dispatch [:db/sync])))
```

Now the order of operations looks like this:

![mtime-after](https://user-images.githubusercontent.com/21281/109973463-b415e700-7cf8-11eb-94ac-1d012556f1fd.jpg)

