### PR TITLE
Mhchem extension

### DIFF
--- a/src/cljc/athens/parser.cljc
+++ b/src/cljc/athens/parser.cljc
@@ -63,7 +63,7 @@
    bold = <'**'> non-bold-chars <'**'>
    
    (* LaTeX *)
-   <not-dollars> = #'[^\\$]*'
+   <not-dollars> = #'.*?(?=\\$\\$)'
    latex = <'$$'> not-dollars <'$$'>
 
    (* -- It’s useful to extract this rule because its transform joins the individual characters everywhere it’s used. *)

--- a/src/cljs/athens/athens_datoms.cljs
+++ b/src/cljs/athens/athens_datoms.cljs
@@ -133,7 +133,15 @@
                                                                               #:block{:uid "dd1e080fb"
                                                                                       :string "Highlights invalid $$\\LaTeX$$ in red, like this $$\\Latex$$"
                                                                                       :open true
-                                                                                      :order 6}]}]}
+                                                                                      :order 6}
+                                                                              #:block{:uid "dd1e080fc"
+                                                                                      :string "Also `mhchem` extension is available:"
+                                                                                      :open true
+                                                                                      :order 7
+                                                                                      :children [#:block{:uid "dd1e080fd"
+                                                                                                         :string "$$\\ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\\underset{\\text{amphoteres Hydroxid}}{\\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\\underset{\\text{Hydroxozikat}}{\\ce{[Zn(OH)4]^2-}}$}$$"
+                                                                                                         :open true
+                                                                                                         :order 0}]}]}]}
                                         #:block{:uid "94272f778",
                                                 :string "All Keybindings",
                                                 :open false,

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -2,6 +2,7 @@
 (ns athens.parse-renderer
   (:require
     ["katex" :as katex]
+    ["katex/dist/contrib/mhchem"]
     [athens.db :as db]
     [athens.parser :as parser]
     [athens.router :refer [navigate-uid]]

--- a/test/athens/parser_test.clj
+++ b/test/athens/parser_test.clj
@@ -164,4 +164,8 @@
   (testing "that LaTeX is not embedded in "
     (are [x y] (= x (parse-to-ast y))
       [:block [:url-link {:url "https://example.com/"} "an $$\textLaTeX$$ example"]]
-      "[an $$\textLaTeX$$ example](https://example.com/)")))
+      "[an $$\textLaTeX$$ example](https://example.com/)"))
+
+  (testing "that LaTeX expressions can have $ in them"
+    (is (= [:block [:latex "a b $ c"]]
+           (parse-to-ast "$$a b $ c$$")))))


### PR DESCRIPTION
<img width="700" alt="Screenshot 2021-03-04 at 22 25 06" src="https://user-images.githubusercontent.com/19492/110032899-fd862680-7d38-11eb-90b9-ac289288050d.png">

`mhchem` KaTeX extension activate.