### PR TITLE
fix: unlinked reference overflowing content

### DIFF
--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -452,8 +452,8 @@
            [:> mui-icons/ChevronRight])]
         [(r/adapt-react-class mui-icons/Link)]
         [:div {:style {:display         "flex"
-                       :flex            "1 1 100%"
-                       :justify-content "space-between"}}
+                       :justify-content "space-between"
+                       :width "100%"}}
          [:span unlinked?]
          (when (and unlinked? (not-empty @unlinked-refs))
            [button {:style    {:font-size "14px"}
@@ -473,10 +473,11 @@
                  (for [block group]
                    ^{:key (str "ref-" (:block/uid block))}
                    [:div {:style {:display         "flex"
-                                  :flex            "1 1 100%"
                                   :justify-content "space-between"
                                   :align-items     "flex-start"}}
-                    [:div (use-style references-group-block-style)
+                    [:div (merge
+                            (use-style references-group-block-style)
+                            {:style {:max-width "90%"}})
                      [ref-comp block]]
                     (when unlinked?
                       [button {:style    {:margin-top "1.5em"}


### PR DESCRIPTION
This should be a fix for #696 but it looks like it's fixed.
![image](https://user-images.githubusercontent.com/8164667/110261013-6e536a00-7fe9-11eb-8cba-4b37c04738dd.png)

So I just fixed a related bug:
The problem is that the `Link` button overflows from its container.
![image](https://user-images.githubusercontent.com/8164667/110261009-698eb600-7fe9-11eb-9d80-30a073a216c9.png)

Fixed:
![image](https://user-images.githubusercontent.com/8164667/110261117-d86c0f00-7fe9-11eb-98b3-1e9e55c68f98.png)


In Roam Research:
![image](https://user-images.githubusercontent.com/8164667/110261046-8925de80-7fe9-11eb-9cb2-af495bb3857d.png)

It looks like there might be a minor design update if Athens follows the one from Roam. Just let me know. 
