### PR TITLE
enhance(linked-refs): sort references by newest first

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -598,7 +598,7 @@
        (mapv :db/id)
        merge-parents-and-block
        group-by-parent
-       (sort-by :block/id)
+       (sort-by :db/id)
        vec
        rseq))
 

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -598,7 +598,9 @@
        (mapv :db/id)
        merge-parents-and-block
        group-by-parent
-       vec))
+       (sort-by :block/id)
+       vec
+       rseq))
 
 
 (defn get-linked-block-references


### PR DESCRIPTION
Fixes #728, sorts references by newest note ID instead of oldest ID.