### PR TITLE
fix(electron): issue updating Mac App

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,22 @@
     "generateUpdatesFilesForAllChannels": true,
     "afterSign": "electron-builder-notarize",
     "mac": {
-      "target": {
-        "target": "dmg",
-        "arch": [
-          "arm64",
-          "x64"
-        ]
-      },
+      "target": [
+        {
+           "target": "dmg",
+           "arch": [
+              "arm64",
+              "x64"
+           ]
+        },
+        {
+          "target": "zip",
+           "arch": [
+              "arm64",
+              "x64"
+           ]
+        }
+     ],
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist"


### PR DESCRIPTION
This PR fixes just the package.json config to re-enable ZIP target on Mac builds, which should re-enable auto-update on Mac.

Fixes https://github.com/athensresearch/athens/issues/749

Note: Issue #749 references an error popup, but was originally about auto update on Mac being broken, which this fixes.

#722 appears to reference that same error popup in #749, and is still not fixed.