### PR TITLE
fix(block-ref): better reference number

### DIFF
--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -757,11 +757,10 @@
 
 (defn block-refs-count-el
   [count uid]
-  (when (pos? count)
-    [:div (use-style {:position "absolute"
-                      :right "0px"
-                      :z-index (:zindex-tooltip ZINDICES)})
-     [button {:on-click #(dispatch [:right-sidebar/open-item uid])} count]]))
+  [:div (use-style {:margin-left "1em"
+                    :z-index (:zindex-dropdown ZINDICES)
+                    :visibility (when-not (pos? count) "hidden")})
+    [button {:primary true :on-click #(dispatch [:right-sidebar/open-item uid])} count]])
 
 
 (defn block-drag-over


### PR DESCRIPTION
fix #742

![image](https://user-images.githubusercontent.com/8164667/110453333-0728d900-8101-11eb-8322-a259b08f7346.png)
![image](https://user-images.githubusercontent.com/8164667/110453339-085a0600-8101-11eb-9ff8-d094e133d54b.png)

Athens has two button styles. I used the primary button for this.
https://www.figma.com/file/XITWUHZHNJsIbcCsBkOHpZ/Athens-Design-System?node-id=9%3A1 