### PR TITLE
Replace posh with ratom

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -68,6 +68,7 @@
    {:dependencies [[binaryage/devtools "1.0.0"]
                    [day8.re-frame/re-frame-10x "0.6.0"]
                    [day8.re-frame/tracing "0.5.3"]
+                   [com.taoensso/tufte "2.2.0"]
                    [cider/cider-nrepl "0.25.1"]]
 
     :source-paths ["dev"]}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -29,7 +29,8 @@
                                         :closure-defines {re-frame.trace.trace-enabled? true}
                                         :output-feature-set :es-next}
                      :devtools {:preloads [devtools.preload
-                                           day8.re-frame-10x.preload]}}
+                                           day8.re-frame-10x.preload
+                                           #_athens.tracing]}}
 
           ;; backend for electron (node.js)
           :main {:target :node-script

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -1,11 +1,11 @@
 (ns athens.db
   (:require
     [athens.patterns :as patterns]
+    [athens.posh :as posh :refer [pull q]]
     [athens.util :refer [escape-str]]
     [clojure.edn :as edn]
     [clojure.string :as string]
     [datascript.core :as d]
-    [posh.reagent :refer [posh! pull q]]
     [re-frame.core :refer [dispatch]]))
 
 
@@ -132,11 +132,7 @@
                     :db/valueType :db.type/ref}})
 
 
-(defonce dsdb (d/create-conn schema))
-
-
-;; todo: turn into an effect
-(posh! dsdb)
+(defonce dsdb (posh/create-conn schema))
 
 
 (defn e-by-av

--- a/src/cljs/athens/dbrx.cljs
+++ b/src/cljs/athens/dbrx.cljs
@@ -1,30 +1,35 @@
 (ns athens.dbrx
   (:require
-   [datascript.core :as d]
-   [reagent.core :as reagent]
-   [reagent.ratom :as ratom]))
+    [datascript.core :as d]
+    [reagent.core :as reagent]
+    [reagent.ratom :as ratom]))
 
 
-(defn create-conn [schema]
+(defn create-conn
+  [schema]
   (reagent/atom
-   (d/empty-db schema)
-   :meta {:listeners (atom {})}))
+    (d/empty-db schema)
+    :meta {:listeners (atom {})}))
 
 
-(defn pull [conn selector eid]
+(defn pull
+  [conn selector eid]
   (ratom/make-reaction
     #(d/pull @conn selector eid)))
 
 
-(defn pull-many [conn selector eids]
+(defn pull-many
+  [conn selector eids]
   (ratom/make-reaction
     #(d/pull-many @conn selector eids)))
 
 
-(defn q [query conn & args]
+(defn q
+  [query conn & args]
   (ratom/make-reaction
     #(apply d/q query @conn args)))
 
 
-(defn transact! [conn tx-data]
+(defn transact!
+  [conn tx-data]
   (d/transact! conn tx-data))

--- a/src/cljs/athens/dbrx.cljs
+++ b/src/cljs/athens/dbrx.cljs
@@ -1,0 +1,30 @@
+(ns athens.dbrx
+  (:require
+   [datascript.core :as d]
+   [reagent.core :as reagent]
+   [reagent.ratom :as ratom]))
+
+
+(defn create-conn [schema]
+  (reagent/atom
+   (d/empty-db schema)
+   :meta {:listeners (atom {})}))
+
+
+(defn pull [conn selector eid]
+  (ratom/make-reaction
+    #(d/pull @conn selector eid)))
+
+
+(defn pull-many [conn selector eids]
+  (ratom/make-reaction
+    #(d/pull-many @conn selector eids)))
+
+
+(defn q [query conn & args]
+  (ratom/make-reaction
+    #(apply d/q query @conn args)))
+
+
+(defn transact! [conn tx-data]
+  (d/transact! conn tx-data))

--- a/src/cljs/athens/devcards.cljs
+++ b/src/cljs/athens/devcards.cljs
@@ -27,10 +27,10 @@
     [athens.effects]
     [athens.events]
     [athens.listeners :as listeners]
+    [athens.posh :refer [transact!]]
     [cljsjs.react]
     [cljsjs.react.dom]
     [devcards.core]
-    [posh.reagent :refer [transact!]]
     [re-frame.core :refer [dispatch-sync]]
     [stylefy.core :as stylefy]))
 

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -22,10 +22,10 @@
   [button {:on-click (fn []
                        (let [n (:max-eid @db/dsdb)]
                          (transact! db/dsdb [{:node/title     (str "Test Title " n)
-                                                :block/uid      (str "uid" n)
-                                                :block/children [{:block/string "a block string" :block/uid (str "uid-" n "-" (rand))}]
-                                                :create/time    (.getTime (js/Date.))
-                                                :edit/time      (.getTime (js/Date.))}])))}
+                                              :block/uid      (str "uid" n)
+                                              :block/children [{:block/string "a block string" :block/uid (str "uid-" n "-" (rand))}]
+                                              :create/time    (.getTime (js/Date.))
+                                              :edit/time      (.getTime (js/Date.))}])))}
    "Create Page"])
 
 

--- a/src/cljs/athens/devcards/all_pages.cljs
+++ b/src/cljs/athens/devcards/all_pages.cljs
@@ -2,9 +2,9 @@
   (:require
     [athens.db :as db]
     [athens.devcards.db :refer [load-real-db-button]]
+    [athens.posh :refer [transact!]]
     [athens.views.all-pages :refer [table]]
     [athens.views.buttons :refer [button]]
-    [datascript.core :as d]
     [devcards.core :refer [defcard defcard-rg]]
     [garden.core :refer [css]]
     [tick.locale-en-us]))
@@ -21,7 +21,7 @@
   "Page title increments by more than one each time because we create multiple entities (the child blocks)."
   [button {:on-click (fn []
                        (let [n (:max-eid @db/dsdb)]
-                         (d/transact! db/dsdb [{:node/title     (str "Test Title " n)
+                         (transact! db/dsdb [{:node/title     (str "Test Title " n)
                                                 :block/uid      (str "uid" n)
                                                 :block/children [{:block/string "a block string" :block/uid (str "uid-" n "-" (rand))}]
                                                 :create/time    (.getTime (js/Date.))

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -2,10 +2,10 @@
   (:require
     [athens.db :as db]
     [athens.devcards.db :refer [load-real-db-button]]
+    [athens.posh :refer [transact!]]
     [athens.subs]
     [athens.views.athena :refer [athena-prompt-el athena-component]]
     [athens.views.buttons :refer [button]]
-    [datascript.core :as d]
     [devcards.core :refer-macros [defcard-rg]]))
 
 
@@ -14,7 +14,7 @@
   [button {:on-click (fn []
                        (let [n       (inc (:max-eid @db/dsdb))
                              n-child (inc n)]
-                         (d/transact! db/dsdb [{:node/title     (str "Test Page " n)
+                         (transact! db/dsdb [{:node/title     (str "Test Page " n)
                                                 :block/uid      (str "uid-" n)
                                                 :block/children [{:block/string (str "Test Block" n-child) :block/uid (str "uid-" n-child)}]}])))} "Create Test Pages and Blocks"])
 

--- a/src/cljs/athens/devcards/athena.cljs
+++ b/src/cljs/athens/devcards/athena.cljs
@@ -15,8 +15,8 @@
                        (let [n       (inc (:max-eid @db/dsdb))
                              n-child (inc n)]
                          (transact! db/dsdb [{:node/title     (str "Test Page " n)
-                                                :block/uid      (str "uid-" n)
-                                                :block/children [{:block/string (str "Test Block" n-child) :block/uid (str "uid-" n-child)}]}])))} "Create Test Pages and Blocks"])
+                                              :block/uid      (str "uid-" n)
+                                              :block/children [{:block/string (str "Test Block" n-child) :block/uid (str "uid-" n-child)}]}])))} "Create Test Pages and Blocks"])
 
 
 (defcard-rg Load-Real-DB

--- a/src/cljs/athens/devcards/db.cljs
+++ b/src/cljs/athens/devcards/db.cljs
@@ -1,6 +1,7 @@
 (ns athens.devcards.db
   (:require
     [athens.db :as db]
+    [athens.posh :refer [transact!]]
     [athens.views.buttons :refer [button]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [go <!]]
@@ -8,7 +9,6 @@
     [cljsjs.react.dom]
     [datascript.core :as d]
     [devcards.core :refer [defcard defcard-rg]]
-    [posh.reagent :refer [transact!]]
     [reagent.core :as r]))
 
 

--- a/src/cljs/athens/devcards/left_sidebar.cljs
+++ b/src/cljs/athens/devcards/left_sidebar.cljs
@@ -1,10 +1,10 @@
 (ns athens.devcards.left-sidebar
   (:require
     [athens.db :as db]
+    [athens.posh :refer [transact!]]
     [athens.views.buttons :refer [button]]
     [athens.views.left-sidebar :refer [left-sidebar]]
-    [devcards.core :refer [defcard-rg]]
-    [posh.reagent :refer [transact!]]))
+    [devcards.core :refer [defcard-rg]]))
 
 
 (defcard-rg Create-Shortcut

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -1,6 +1,7 @@
 (ns athens.effects
   (:require
     [athens.db :as db]
+    [athens.posh :refer [transact!]]
     [athens.util :as util]
     [athens.walk :as walk]
     [cljs-http.client :as http]
@@ -11,7 +12,6 @@
     [datascript.transit :as dt]
     [day8.re-frame.async-flow-fx]
     [goog.dom.selection :refer [setCursorPosition]]
-    [posh.reagent :as p :refer [transact!]]
     [re-frame.core :refer [dispatch reg-fx]]
     [stylefy.core :as stylefy]))
 

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -13,7 +13,8 @@
     [day8.re-frame.async-flow-fx]
     [goog.dom.selection :refer [setCursorPosition]]
     [re-frame.core :refer [dispatch reg-fx]]
-    [stylefy.core :as stylefy]))
+    [stylefy.core :as stylefy]
+    [taoensso.tufte :as tufte]))
 
 
 ;;; Effects
@@ -237,7 +238,7 @@
 (reg-fx
   :transact!
   (fn [tx-data]
-    (walk-transact tx-data)))
+    (tufte/profile {} (walk-transact tx-data))))
 
 
 (reg-fx

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -5,11 +5,11 @@
     ["katex/dist/contrib/mhchem"]
     [athens.db :as db]
     [athens.parser :as parser]
+    [athens.posh :refer [pull]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color OPACITIES]]
     [clojure.string :as str]
     [instaparse.core :as insta]
-    [posh.reagent :refer [pull #_q]]
     [stylefy.core :as stylefy :refer [use-style]]))
 
 

--- a/src/cljs/athens/posh.cljs
+++ b/src/cljs/athens/posh.cljs
@@ -1,48 +1,54 @@
 (ns athens.posh
   (:require
-   [athens.dbrx :as dbrx]
-   [datascript.core :as d]
-   [posh.reagent :as posh]
-   [taoensso.tufte :as tufte]))
+    [athens.dbrx :as dbrx]
+    [datascript.core :as d]
+    [posh.reagent :as posh]
+    [taoensso.tufte :as tufte]))
 
 
 (def version
   ;; :dbrx or :posh
+  #_:posh
   :dbrx)
 
 
-(defn create-conn [schema]
+(defn create-conn
+  [schema]
   (tufte/p ::create-conn
-     (case version
-       :posh (let [conn (d/create-conn schema)]
-               (posh/posh! conn)
-               conn)
-       :dbrx (dbrx/create-conn schema))))
+           (case version
+             :posh (let [conn (d/create-conn schema)]
+                     (posh/posh! conn)
+                     conn)
+             :dbrx (dbrx/create-conn schema))))
 
 
-(defn pull [conn selector eid]
+(defn pull
+  [conn selector eid]
   (tufte/p ::pull
-     (case version
-       :posh (posh/pull conn selector eid)
-       :dbrx (dbrx/pull conn selector eid))))
+           (case version
+             :posh (posh/pull conn selector eid)
+             :dbrx (dbrx/pull conn selector eid))))
 
 
-(defn pull-many [conn selector eids]
+(defn pull-many
+  [conn selector eids]
   (tufte/p ::pull-many
-     (case version
-       :posh (posh/pull-many conn selector eids)
-       :dbrx (dbrx/pull-many conn selector eids))))
+           (case version
+             :posh (posh/pull-many conn selector eids)
+             :dbrx (dbrx/pull-many conn selector eids))))
 
 
-(defn q [query conn & args]
+(defn q
+  [query conn & args]
   (tufte/p ::q
-     (case version
-       :posh (apply posh/q query conn args)
-       :dbrx (apply dbrx/q query conn args))))
+           (case version
+             :posh (apply posh/q query conn args)
+             :dbrx (apply dbrx/q query conn args))))
 
 
-(defn transact! [conn tx-data]
+(defn transact!
+  [conn tx-data]
   (tufte/p ::transact!
-     (case version
-       :posh (posh/transact! conn tx-data)
-       :dbrx (dbrx/transact! conn tx-data))))
+           (case version
+             :posh (posh/transact! conn tx-data)
+             :dbrx (dbrx/transact! conn tx-data))))

--- a/src/cljs/athens/posh.cljs
+++ b/src/cljs/athens/posh.cljs
@@ -1,0 +1,42 @@
+(ns athens.posh
+  (:require
+   [athens.dbrx :as dbrx]
+   [datascript.core :as d]
+   [posh.reagent :as posh]))
+
+
+(def version
+  ;; :dbrx or :posh
+  :dbrx)
+
+
+(defn create-conn [schema]
+  (case version
+    :posh (let [conn (d/create-conn schema)]
+            (posh/posh! conn)
+            conn)
+    :dbrx (dbrx/create-conn schema)))
+
+
+(defn pull [conn selector eid]
+  (case version
+    :posh (posh/pull conn selector eid)
+    :dbrx (dbrx/pull conn selector eid)))
+
+
+(defn pull-many [conn selector eids]
+  (case version
+    :posh (posh/pull-many conn selector eids)
+    :dbrx (dbrx/pull-many conn selector eids)))
+
+
+(defn q [query conn & args]
+  (case version
+    :posh (apply posh/q query conn args)
+    :dbrx (apply dbrx/q query conn args)))
+
+
+(defn transact! [conn tx-data]
+  (case version
+    :posh (posh/transact! conn tx-data)
+    :dbrx (dbrx/transact! conn tx-data)))

--- a/src/cljs/athens/posh.cljs
+++ b/src/cljs/athens/posh.cljs
@@ -2,7 +2,8 @@
   (:require
    [athens.dbrx :as dbrx]
    [datascript.core :as d]
-   [posh.reagent :as posh]))
+   [posh.reagent :as posh]
+   [taoensso.tufte :as tufte]))
 
 
 (def version
@@ -11,32 +12,37 @@
 
 
 (defn create-conn [schema]
-  (case version
-    :posh (let [conn (d/create-conn schema)]
-            (posh/posh! conn)
-            conn)
-    :dbrx (dbrx/create-conn schema)))
+  (tufte/p ::create-conn
+     (case version
+       :posh (let [conn (d/create-conn schema)]
+               (posh/posh! conn)
+               conn)
+       :dbrx (dbrx/create-conn schema))))
 
 
 (defn pull [conn selector eid]
-  (case version
-    :posh (posh/pull conn selector eid)
-    :dbrx (dbrx/pull conn selector eid)))
+  (tufte/p ::pull
+     (case version
+       :posh (posh/pull conn selector eid)
+       :dbrx (dbrx/pull conn selector eid))))
 
 
 (defn pull-many [conn selector eids]
-  (case version
-    :posh (posh/pull-many conn selector eids)
-    :dbrx (dbrx/pull-many conn selector eids)))
+  (tufte/p ::pull-many
+     (case version
+       :posh (posh/pull-many conn selector eids)
+       :dbrx (dbrx/pull-many conn selector eids))))
 
 
 (defn q [query conn & args]
-  (case version
-    :posh (apply posh/q query conn args)
-    :dbrx (apply dbrx/q query conn args)))
+  (tufte/p ::q
+     (case version
+       :posh (apply posh/q query conn args)
+       :dbrx (apply dbrx/q query conn args))))
 
 
 (defn transact! [conn tx-data]
-  (case version
-    :posh (posh/transact! conn tx-data)
-    :dbrx (dbrx/transact! conn tx-data)))
+  (tufte/p ::transact!
+     (case version
+       :posh (posh/transact! conn tx-data)
+       :dbrx (dbrx/transact! conn tx-data))))

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -38,7 +38,8 @@
      :local-storage/set! ["current-route/uid" (-> route second :id)]}))
 
 
-(defn page-title [nav-match]
+(defn page-title
+  [nav-match]
   (let [prefix #(str % " | Athens")]
     (if-some [block-id (get-in nav-match [:path-params :id])]
       (let [node (pull db/dsdb '[*] [:block/uid block-id])

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -1,10 +1,10 @@
 (ns athens.router
   (:require
     [athens.db :as db]
+    [athens.posh :refer [pull]]
     [athens.util :as util]
     #_[athens.views :as views]
     [day8.re-frame.tracing :refer-macros [fn-traced]]
-    [posh.reagent :refer [pull]]
     [re-frame.core :as rf :refer [subscribe dispatch reg-sub reg-event-fx reg-fx]]
     [reitit.coercion.spec :as rss]
     [reitit.frontend :as rfe]

--- a/src/cljs/athens/tracing.cljs
+++ b/src/cljs/athens/tracing.cljs
@@ -1,9 +1,9 @@
 (ns athens.tracing
   (:require
-   [reagent.impl.batching :as batching]
-   ;; This exists only in newer versions of re-frame-10x
-   ;; [day8.reagent.impl.batching :as day8.batching]
-   [taoensso.tufte :as tufte]))
+    [reagent.impl.batching :as batching]
+    ;; This exists only in newer versions of re-frame-10x
+    ;; [day8.reagent.impl.batching :as day8.batching]
+    [taoensso.tufte :as tufte]))
 
 
 (defonce reagent-next-tick batching/next-tick)
@@ -20,11 +20,12 @@
   (atom nil))
 
 
-(defn format-stats [stats]
+(defn format-stats
+  [stats]
   (-> stats
       (tufte/format-pstats
-       {:columns [:n-calls :p50 :p95 :p99 :max :clock :total]
-        :format-id-fn str})
+        {:columns [:n-calls :p50 :p95 :p99 :max :clock :total]
+         :format-id-fn str})
       (println)))
 
 
@@ -37,19 +38,19 @@
   (reagent-next-tick
    ;; TODO: ideally, should also be wrapping re-frame-10x:
    ;; reframe10x-next-tick day8.batching/next-tick
-   (fn []
-     (tufte/profile {} (f))
-     (when (false? (.-scheduled? batching/render-queue))
-       (when-some [m (not-empty @stats-accumulator)]
-         (when (some-> m vals first deref :stats)
-           (let [stats (-> m vals first)]
-             (println "Epoch Stats:")
-             (format-stats stats)
-             (if @stats-total
-               (swap! stats-total tufte/merge-pstats stats)
-               (reset! stats-total stats))
-             (println "Total Stats:")
-             (format-stats @stats-total))))))))
+    (fn []
+      (tufte/profile {} (f))
+      (when (false? (.-scheduled? batching/render-queue))
+        (when-some [m (not-empty @stats-accumulator)]
+          (when (some-> m vals first deref :stats)
+            (let [stats (-> m vals first)]
+              (println "Epoch Stats:")
+              (format-stats stats)
+              (if @stats-total
+                (swap! stats-total tufte/merge-pstats stats)
+                (reset! stats-total stats))
+              (println "Total Stats:")
+              (format-stats @stats-total))))))))
 
 
 (defn patch-next-tick

--- a/src/cljs/athens/tracing.cljs
+++ b/src/cljs/athens/tracing.cljs
@@ -1,0 +1,62 @@
+(ns athens.tracing
+  (:require
+   [reagent.impl.batching :as batching]
+   ;; This exists only in newer versions of re-frame-10x
+   ;; [day8.reagent.impl.batching :as day8.batching]
+   [taoensso.tufte :as tufte]))
+
+
+(defonce reagent-next-tick batching/next-tick)
+
+;; This exists only in newer version of re-frame-10x:
+;; (defonce reframe10x-next-tick day8.batching/next-tick)
+
+
+(defonce stats-accumulator
+  (tufte/add-accumulating-handler! {:ns-pattern "*"}))
+
+
+(defonce stats-total
+  (atom nil))
+
+
+(defn format-stats [stats]
+  (-> stats
+      (tufte/format-pstats
+       {:columns [:n-calls :p50 :p95 :p99 :max :clock :total]
+        :format-id-fn str})
+      (println)))
+
+
+(defn next-tick
+  [f]
+  ;; Schedule a trace to be emitted after a render if
+  ;; there is nothing else scheduled after that render.
+  ;; This signals the end of the epoch.
+
+  (reagent-next-tick
+   ;; TODO: ideally, should also be wrapping re-frame-10x:
+   ;; reframe10x-next-tick day8.batching/next-tick
+   (fn []
+     (tufte/profile {} (f))
+     (when (false? (.-scheduled? batching/render-queue))
+       (when-some [m (not-empty @stats-accumulator)]
+         (when (some-> m vals first deref :stats)
+           (let [stats (-> m vals first)]
+             (println "Epoch Stats:")
+             (format-stats stats)
+             (if @stats-total
+               (swap! stats-total tufte/merge-pstats stats)
+               (reset! stats-total stats))
+             (println "Total Stats:")
+             (format-stats @stats-total))))))))
+
+
+(defn patch-next-tick
+  []
+  (println "Patching with tufte profiling")
+  (set! batching/next-tick next-tick))
+
+
+;; TODO: assuming this namespace will only be loaded via shadow preloads
+(patch-next-tick)

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -5,7 +5,6 @@
     [clojure.string :as string]
     [com.rpl.specter :as s]
     [goog.dom :refer [getElement setProperties]]
-    [posh.reagent :refer [#_pull]]
     [tick.alpha.api :as t]
     [tick.locale-en-us])
   (:require-macros

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -29,14 +29,15 @@
     (specter-recursive-path #(contains? % :block/uid))
     (fn [{:block/keys [uid] :as block}]
       (assoc block :block/uid (str uid "-embed-" embed-id)
-                   :block/original-uid uid))
+             :block/original-uid uid))
     block))
 
 
 ;; -- DOM ----------------------------------------------------------------
 
 ;; TODO: move all these DOM utilities to a .cljs file instead of cljc
-(defn scroll-top! [element pos]
+(defn scroll-top!
+  [element pos]
   (when pos
     (set! (.. element -scrollTop) pos)))
 
@@ -85,7 +86,8 @@
       (< (.. el-box -top) (.. cont-box -top)))))
 
 
-(defn scroll-into-view [element container align-top?]
+(defn scroll-into-view
+  [element container align-top?]
   (when (is-beyond-rect? element container)
     (.. element (scrollIntoView align-top? {:behavior "auto"}))))
 
@@ -225,9 +227,9 @@
    satisfies the function"
   [afn]
   (recursive-path [] p
-    (s/cond-path
-      map? (s/multi-path [s/MAP-VALS p] afn)
-      sequential? [s/ALL p])))
+                  (s/cond-path
+                    map? (s/multi-path [s/MAP-VALS p] afn)
+                    sequential? [s/ALL p])))
 
 ;; OS
 

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -2,6 +2,7 @@
   (:require
     [athens.config]
     [athens.db :as db]
+    [athens.posh :refer [pull]]
     [athens.subs]
     [athens.views.all-pages :refer [table]]
     [athens.views.app-toolbar :refer [app-toolbar]]
@@ -16,7 +17,6 @@
     [athens.views.right-sidebar :refer [right-sidebar-component]]
     [athens.views.settings-page :as settings-page]
     [athens.views.spinner :refer [initial-spinner-component]]
-    [posh.reagent :refer [pull]]
     [re-frame.core :refer [subscribe dispatch]]
     [stylefy.core :as stylefy :refer [use-style]]))
 

--- a/src/cljs/athens/views/all_pages.cljs
+++ b/src/cljs/athens/views/all_pages.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.all-pages
   (:require
     [athens.db :as db]
+    [athens.posh :as p]
     [athens.router :refer [navigate-uid]]
     [athens.style :as style :refer [color OPACITIES]]
     [athens.util :refer [date-string]]
@@ -9,7 +10,6 @@
     [clojure.string :as str]
     [datascript.core :as d]
     [garden.selectors :as selectors]
-    [posh.reagent :as p]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
 

--- a/src/cljs/athens/views/daily_notes.cljs
+++ b/src/cljs/athens/views/daily_notes.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.daily-notes
   (:require
     [athens.db :as db]
+    [athens.posh :refer [pull]]
     [athens.style :refer [DEPTH-SHADOWS]]
     [athens.util :refer [get-day uid-to-date]]
     [athens.views.node-page :refer [node-page-component]]
@@ -8,7 +9,6 @@
     [cljsjs.react.dom]
     [goog.dom :refer [getElement]]
     [goog.functions :refer [debounce]]
-    [posh.reagent :refer [pull]]
     [re-frame.core :refer [dispatch subscribe]]
     [stylefy.core :refer [use-style]]))
 

--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -1,13 +1,13 @@
 (ns athens.views.left-sidebar
   (:require
     [athens.db :as db]
+    [athens.posh :refer [q]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color OPACITIES]]
     [athens.util :refer [mouse-offset vertical-center]]
     ;;[athens.views.buttons :refer [button]]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [posh.reagent :refer [q]]
     [re-frame.core :refer [dispatch subscribe]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]]))


### PR DESCRIPTION
This is a continuation of the work done by @lambduhh on https://github.com/athensresearch/athens/pull/665. Kudos to @lambduhh for the idea!

The supporting code has changed significantly, though, so I thought it would be easier to open a separate PR.

## How to reproduce

The TL;DR to run this branch:

1. Uncomment `athens.tracing` in `shadow-cljs.edn`: `(-> :renderer :devtools :preloads)`
2. Choose your poison in `athens.posh/version` (`:posh` is original flavor, `:dbrx` is brand new fizzy flavor)
3. Rebuild (`lein dev`) and run Athens (`yarn run electron .`), open the DevTools Console, and click around.

Two reports will show up. `Epoch Stats` report percentiles for profiled functions between epochs (as understood by re-frame-10x). `Total Stats` is a running total for the entire session. Epochs can help you identify the performance characteristics of a specific action, while Totals can help approximate the general performance of the app during regular usage.

![report1](https://user-images.githubusercontent.com/21281/110523916-09942e80-8113-11eb-8460-4bbb6953107a.jpg)

## What are the results?

For my tests, I'm using a basic Welcome db + a large tagged markdown file.

### `:posh` - original flavor

Open/Close sections of the Welcome page:

![posh1](https://user-images.githubusercontent.com/21281/110524498-c4bcc780-8113-11eb-84cf-4c1fb05f3ae2.jpg)

Open/Close sections of the Markdown report:

![posh2](https://user-images.githubusercontent.com/21281/110524522-cd150280-8113-11eb-94d8-90f62a6e0e2f.jpg)

⚠️ 408 ms just to process the `transact!`. So, with additional parsing and rendering we have failed the Doherty Threshold!

### `:dbrx` - brand new fizzy flavor

Open/Closing sections of the Welcome page:

![dbrx1](https://user-images.githubusercontent.com/21281/110524937-50365880-8114-11eb-924d-f3eeba58c06e.jpg)

Open/Close sections of the Markdown report:

![dbrx2](https://user-images.githubusercontent.com/21281/110524964-56c4d000-8114-11eb-9367-b0cb90b60dd7.jpg)

💯 Max 40 ms response times.

## Next Steps

This should also benefit https://github.com/athensresearch/athens/issues/570

Athens is still noticeably slow when working with large files, but this is the first of several problems that needed to be fixed; the next biggest bottleneck may be in parsing and/or rendering.

In the meantime, we need to test and make sure this approach doesn't break on some edge cases. More 👀 and user reports would be most welcome!

## PR Code Review

The last two commits are intended for profiling and may be optionally merged, depending on preference. I split them out to make it easier to cherry-pick this branch.

1. https://github.com/athensresearch/athens/commit/75b1d57fbee60b0cb05e62e2b8c12e709712c092
2. https://github.com/athensresearch/athens/commit/d0f18d3e8f75096177c3eef61ef9f8c08e7bc370
