### PR TITLE
perf(icons): optimize size of material-ui/icons

### DIFF
--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -1,6 +1,6 @@
 (ns athens.components
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/Edit" :as Edit]
     [athens.db :as db]
     [athens.parse-renderer :refer [component]]
     [athens.style :refer [color]]
@@ -102,7 +102,7 @@
                        {:linked-ref false}
                        {:block-embed? true}]
                       (when-not @(subscribe [:editing/is-editing uid])
-                        [:> mui-icons/Edit
+                        [:> Edit
                          {:on-click (fn [e]
                                       (.. e stopPropagation)
                                       (dispatch [:editing/uid uid]))}])])])

--- a/src/cljs/athens/devcards/buttons.cljs
+++ b/src/cljs/athens/devcards/buttons.cljs
@@ -1,6 +1,7 @@
 (ns athens.devcards.buttons
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/ChevronRight" :as ChevronRight]
+    ["@material-ui/icons/Face" :as Face]
     [athens.views.buttons :refer [button]]
     [devcards.core :refer-macros [defcard-rg]]
     [stylefy.core :as stylefy :refer [use-style]]))
@@ -9,38 +10,38 @@
 (defcard-rg Default-button
   [:div (use-style {:display "grid" :grid-auto-flow "column" :justify-content "flex-start" :grid-gap "0.5rem"})
    [button "Button"]
-   [button [:> mui-icons/Face]]
+   [button [:> Face]]
    [button [:<>
-            [:> mui-icons/Face]
+            [:> Face]
             [:span "Button"]]]
    [button [:<>
             [:span "Button"]
-            [:> mui-icons/ChevronRight]]]
+            [:> ChevronRight]]]
    [button {:disabled true} "Button"]
-   [button {:disabled true} [:> mui-icons/Face]]
+   [button {:disabled true} [:> Face]]
    [button {:disabled true} [:<>
-                             [:> mui-icons/Face]
+                             [:> Face]
                              [:span "Button"]]]
    [button {:disabled true} [:<>
                              [:span "Button"]
-                             [:> mui-icons/ChevronRight]]]])
+                             [:> ChevronRight]]]])
 
 
 (defcard-rg Primary-Button
   [:div (use-style {:display "grid" :grid-auto-flow "column" :justify-content "flex-start" :grid-gap "0.5rem"})
    [button {:primary true} "Button"]
-   [button {:primary true} [:> mui-icons/Face]]
+   [button {:primary true} [:> Face]]
    [button {:primary true} [:<>
-                            [:> mui-icons/Face]
+                            [:> Face]
                             [:span "Button"]]]
    [button {:primary true} [:<>
                             [:span "Button"]
-                            [:> mui-icons/ChevronRight]]]
+                            [:> ChevronRight]]]
    [button {:primary true :disabled true} "Button"]
-   [button {:primary true :disabled true} [:> mui-icons/Face]]
+   [button {:primary true :disabled true} [:> Face]]
    [button {:primary true :disabled true} [:<>
-                                           [:> mui-icons/Face]
+                                           [:> Face]
                                            [:span "Button"]]]
    [button {:primary true :disabled true} [:<>
                                            [:span "Button"]
-                                           [:> mui-icons/ChevronRight]]]])
+                                           [:> ChevronRight]]]])

--- a/src/cljs/athens/devcards/icons.cljs
+++ b/src/cljs/athens/devcards/icons.cljs
@@ -1,7 +1,13 @@
 (ns athens.devcards.icons
   (:require
-    ["@material-ui/icons" :as mui-icons]
-    [athens.db]
+    ["@material-ui/icons/Directions" :as Directions]
+    ["@material-ui/icons/DirectionsOutlined" :as DirectionsOutlined]
+    ["@material-ui/icons/DirectionsRounded" :as DirectionsRounded]
+    ["@material-ui/icons/DirectionsSharp" :as DirectionsSharp]
+    ["@material-ui/icons/DirectionsTwoTone" :as DirectionsTwoTone]
+    ["@material-ui/icons/Face" :as Face]
+    ["@material-ui/icons/Search" :as Search]
+    ["@material-ui/icons/Settings" :as Settings]
     [athens.style :refer [color OPACITIES]]
     [cljsjs.react]
     [cljsjs.react.dom]
@@ -11,32 +17,32 @@
 
 (defcard-rg Standard-Icons
   [:div
-   [:> mui-icons/Face]
-   [:> mui-icons/Settings]
-   [:> mui-icons/Search]])
+   [:> Face]
+   [:> Settings]
+   [:> Search]])
 
 
 (defcard-rg Icon-Types
   "Use the different built-in icon types by appending one of `Outlined`, `Rounded`, `TwoTone`, or `Sharp` to the icon name.
   List of icons: [https://material-ui.com/components/material-icons/](https://material-ui.com/components/material-icons/)"
   [:div
-   [:> mui-icons/Directions]
-   [:> mui-icons/DirectionsOutlined]
-   [:> mui-icons/DirectionsRounded]
-   [:> mui-icons/DirectionsTwoTone]
-   [:> mui-icons/DirectionsSharp]])
+   [:> Directions]
+   [:> DirectionsOutlined]
+   [:> DirectionsRounded]
+   [:> DirectionsTwoTone]
+   [:> DirectionsSharp]])
 
 
 (defcard-rg Styling-icons
   "To use icons in lazy seqs (like `for` loops or `map`), or to apply other properties like styles, use `r/adapt-react-class`. See [https://github.com/reagent-project/reagent/issues/369](https://github.com/reagent-project/reagent/issues/369)."
   [:div
-   [(r/adapt-react-class mui-icons/Face) {:style {:color (color :link-color)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:color (color :highlight-color)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:color (color :warning-color)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:color (color :confirmation-color)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:color (color :body-text-color)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:opacity (:opacity-lower OPACITIES)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:opacity (:opacity-low OPACITIES)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:opacity (:opacity-med OPACITIES)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:opacity (:opacity-high OPACITIES)}}]
-   [(r/adapt-react-class mui-icons/Face) {:style {:color (color :header-text-color)}}]])
+   [(r/adapt-react-class Face) {:style {:color (color :link-color)}}]
+   [(r/adapt-react-class Face) {:style {:color (color :highlight-color)}}]
+   [(r/adapt-react-class Face) {:style {:color (color :warning-color)}}]
+   [(r/adapt-react-class Face) {:style {:color (color :confirmation-color)}}]
+   [(r/adapt-react-class Face) {:style {:color (color :body-text-color)}}]
+   [(r/adapt-react-class Face) {:style {:opacity (:opacity-lower OPACITIES)}}]
+   [(r/adapt-react-class Face) {:style {:opacity (:opacity-low OPACITIES)}}]
+   [(r/adapt-react-class Face) {:style {:opacity (:opacity-med OPACITIES)}}]
+   [(r/adapt-react-class Face) {:style {:opacity (:opacity-high OPACITIES)}}]
+   [(r/adapt-react-class Face) {:style {:color (color :header-text-color)}}]])

--- a/src/cljs/athens/devcards/textinput.cljs
+++ b/src/cljs/athens/devcards/textinput.cljs
@@ -1,6 +1,6 @@
 (ns athens.devcards.textinput
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/Face" :as Face]
     [athens.views.textinput :refer [textinput]]
     [devcards.core :refer-macros [defcard-rg]]))
 
@@ -10,4 +10,4 @@
 
 
 (defcard-rg Input-with-icon
-  [textinput {:placeholder "pink" :icon [:> mui-icons/Face]}])
+  [textinput {:placeholder "pink" :icon [:> Face]}])

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -1,6 +1,11 @@
 (ns athens.keybindings
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/DesktopWindows" :as DesktopWindows]
+    ["@material-ui/icons/Done" :as Done]
+    ["@material-ui/icons/Timer" :as Timer]
+    ["@material-ui/icons/Today" :as Today]
+    ["@material-ui/icons/ViewDayRounded" :as ViewDayRounded]
+    ["@material-ui/icons/YouTube" :as YouTube]
     [athens.db :as db]
     [athens.router :as router]
     [athens.util :refer [scroll-if-needed get-day get-caret-position shortcut-key? escape-str]]
@@ -82,19 +87,19 @@
 
 ;; TODO: some expansions require caret placement after
 (def slash-options
-  [["Add Todo"      mui-icons/Done "{{[[TODO]]}} " "cmd-enter" nil]
-   ["Current Time"  mui-icons/Timer (fn [] (.. (js/Date.) (toLocaleTimeString [] (clj->js {"timeStyle" "short"})))) nil nil]
-   ["Today"         mui-icons/Today (fn [] (str "[[" (:title (get-day 0)) "]] ")) nil nil]
-   ["Tomorrow"      mui-icons/Today (fn [] (str "[[" (:title (get-day -1)) "]]")) nil nil]
-   ["Yesterday"     mui-icons/Today (fn [] (str "[[" (:title (get-day 1)) "]]")) nil nil]
-   ["YouTube Embed" mui-icons/YouTube "{{[[youtube]]: }}" nil 2]
-   ["iframe Embed"  mui-icons/DesktopWindows "{{iframe: }}" nil 2]
-   ["Block Embed"   mui-icons/ViewDayRounded "{{[[embed]]: (())}}" nil 4]])
+  [["Add Todo"      Done "{{[[TODO]]}} " "cmd-enter" nil]
+   ["Current Time"  Timer (fn [] (.. (js/Date.) (toLocaleTimeString [] (clj->js {"timeStyle" "short"})))) nil nil]
+   ["Today"         Today (fn [] (str "[[" (:title (get-day 0)) "]] ")) nil nil]
+   ["Tomorrow"      Today (fn [] (str "[[" (:title (get-day -1)) "]]")) nil nil]
+   ["Yesterday"     Today (fn [] (str "[[" (:title (get-day 1)) "]]")) nil nil]
+   ["YouTube Embed" YouTube "{{[[youtube]]: }}" nil 2]
+   ["iframe Embed"  DesktopWindows "{{iframe: }}" nil 2]
+   ["Block Embed"   ViewDayRounded "{{[[embed]]: (())}}" nil 4]])
 
-;;[mui-icons/ "Block Embed" #(str "[[" (:title (get-day 1)) "]]")]
-;;[mui-icons/DateRange "Date Picker"]
-;;[mui-icons/Attachment "Upload Image or File"]
-;;[mui-icons/ExposurePlus1 "Word Count"]
+;;[ "Block Embed" #(str "[[" (:title (get-day 1)) "]]")]
+;;[DateRange "Date Picker"]
+;;[Attachment "Upload Image or File"]
+;;[ExposurePlus1 "Word Count"]
 
 
 (defn filter-slash-options

--- a/src/cljs/athens/views/alerts.cljs
+++ b/src/cljs/athens/views/alerts.cljs
@@ -1,6 +1,8 @@
 (ns athens.views.alerts
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/Announcement" :as Announcement]
+    ["@material-ui/icons/Check" :as Check]
+    ["@material-ui/icons/Close" :as Close]
     [athens.style :refer [color]]
     [athens.views.buttons :refer [button]]
     [cljsjs.react]
@@ -32,9 +34,9 @@
   [message confirm-fn close-fn]
   [:div (use-style alert-container-style)
    [button {:style {:color (color :highlight-color)}}
-    [(r/adapt-react-class mui-icons/Announcement)]]
+    [(r/adapt-react-class Announcement)]]
    [:span message]
    [button {:on-click confirm-fn :style {:color (color :header-text-color)}}
-    [(r/adapt-react-class mui-icons/Check)]]
+    [(r/adapt-react-class Check)]]
    [button {:on-click close-fn :style {:color (color :header-text-color)}}
-    [(r/adapt-react-class mui-icons/Close)]]])
+    [(r/adapt-react-class Close)]]])

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -1,6 +1,18 @@
 (ns athens.views.app-toolbar
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/BubbleChart" :as BubbleChart]
+    ["@material-ui/icons/ChevronLeft" :as ChevronLeft]
+    ["@material-ui/icons/ChevronRight" :as ChevronRight]
+    ["@material-ui/icons/FiberManualRecord" :as FiberManualRecord]
+    ["@material-ui/icons/FileCopy" :as FileCopy]
+    ["@material-ui/icons/FolderOpen" :as FolderOpen]
+    ["@material-ui/icons/Menu" :as Menu]
+    ["@material-ui/icons/Search" :as Search]
+    ["@material-ui/icons/Settings" :as Settings]
+    ["@material-ui/icons/Today" :as Today]
+    ["@material-ui/icons/ToggleOff" :as ToggleOff]
+    ["@material-ui/icons/ToggleOn" :as ToggleOn]
+    ["@material-ui/icons/VerticalSplit" :as VerticalSplit]
     [athens.router :as router]
     [athens.style :refer [color]]
     [athens.subs]
@@ -87,49 +99,49 @@
         [:div (use-style app-header-control-section-style)
          [button {:active   @left-open?
                   :on-click #(dispatch [:left-sidebar/toggle])}
-          [:> mui-icons/Menu]]
+          [:> Menu]]
          [separator]
          ;; TODO: refactor to effects
          (when electron?
            [:<>
-            [button {:on-click #(.back js/window.history)} [:> mui-icons/ChevronLeft]]
-            [button {:on-click #(.forward js/window.history)} [:> mui-icons/ChevronRight]]
+            [button {:on-click #(.back js/window.history)} [:> ChevronLeft]]
+            [button {:on-click #(.forward js/window.history)} [:> ChevronRight]]
             [separator]])
          [button {:on-click router/nav-daily-notes
-                  :active   (= @route-name :home)} [:> mui-icons/Today]]
+                  :active   (= @route-name :home)} [:> Today]]
          [button {:on-click #(router/navigate :pages)
-                  :active   (= @route-name :pages)} [:> mui-icons/FileCopy]]
+                  :active   (= @route-name :pages)} [:> FileCopy]]
          [button {:on-click #(router/navigate :graph)
-                  :active   (= @route-name :graph)} [:> mui-icons/BubbleChart]]
+                  :active   (= @route-name :graph)} [:> BubbleChart]]
          ;; below is used for testing error tracking
          #_[button {:on-click #(throw (js/Error "error"))
-                    :style {:border "1px solid red"}} [:> mui-icons/Warning]]
+                    :style {:border "1px solid red"}} [:> Warning]]
          [button {:on-click #(dispatch [:athena/toggle])
                   :style    {:width "14rem" :margin-left "1rem" :background (color :background-minus-1)}
                   :active   @(subscribe [:athena/open])}
-          [:<> [:> mui-icons/Search] [:span "Find or Create a Page"]]]]
+          [:<> [:> Search] [:span "Find or Create a Page"]]]]
 
         [:div (use-style app-header-secondary-controls-style)
          (if electron?
            [:<>
-            [(reagent.core/adapt-react-class mui-icons/FiberManualRecord)
+            [(reagent.core/adapt-react-class FiberManualRecord)
              {:style {:color      (color (if @(subscribe [:db/synced])
                                            :confirmation-color
                                            :highlight-color))
                       :align-self "center"}}]
             [button {:on-click #(router/navigate :settings)
                      :active   (= @route-name :settings)}
-             [:> mui-icons/Settings]]
+             [:> Settings]]
             [button {:on-click #(dispatch [:modal/toggle])}
-             [:> mui-icons/FolderOpen]]
+             [:> FolderOpen]]
             [separator]]
            [button {:on-click #(dispatch [:get-db/init]) :primary true} "Load Test DB"])
          [button {:on-click #(dispatch [:theme/toggle])}
           (if @theme-dark
-            [:> mui-icons/ToggleOff]
-            [:> mui-icons/ToggleOn])]
+            [:> ToggleOff]
+            [:> ToggleOn])]
          [separator]
          [button {:active   @right-open?
                   :on-click #(dispatch [:right-sidebar/toggle])}
-          [:> mui-icons/VerticalSplit {:style {:transform "scaleX(-1)"}}]]]]])))
+          [:> VerticalSplit {:style {:transform "scaleX(-1)"}}]]]]])))
 

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -1,6 +1,9 @@
 (ns athens.views.athena
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/ArrowForward" :as ArrowForward]
+    ["@material-ui/icons/Close" :as Close]
+    ["@material-ui/icons/Create" :as Create]
+    ["@material-ui/icons/Search" :as Search]
     [athens.db :as db :refer [search-in-block-content search-exact-node-title search-in-node-title re-case-insensitive]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
@@ -238,7 +241,7 @@
            :primary true
            :style {:font-size "11px"}}
    [:<>
-    [:> mui-icons/Search]
+    [:> Search]
     [:span "Find or Create a Page"]]])
 
 
@@ -263,7 +266,7 @@
                  [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
                  (when string
                    [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])
-                 [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]]))))])]))
+                 [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class ArrowForward)]]]))))])]))
 
 
 (defn athena-component
@@ -297,7 +300,7 @@
                                                            :on-key-down (fn [e] (key-down-handler e s))})]
                                        [:button (use-style search-cancel-button-style
                                                            {:on-click #(set! (.-value (getElement "athena-input")))})
-                                        [:> mui-icons/Close]]]
+                                        [:> Close]]]
                                       [results-el s]
                                       [(fn []
                                          (let [{:keys [results query index]} @s]
@@ -321,7 +324,7 @@
                                                     [:h4.title (use-sub-style result-style :title)
                                                      [:b "Create Page: "]
                                                      query]]
-                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/Create)]]]
+                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class Create)]]]
 
                                                   [:div (use-style result-style {:key      i
                                                                                  :on-click (fn []
@@ -338,4 +341,4 @@
                                                     [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
                                                     (when string
                                                       [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])]
-                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class mui-icons/ArrowForward)]]])))]))]])))})))
+                                                   [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class ArrowForward)]]])))]))]])))})))

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -1,6 +1,6 @@
 (ns athens.views.block-page
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/Link" :as Link]
     [athens.db :as db]
     [athens.parse-renderer :as parse-renderer]
     [athens.router :refer [navigate-uid]]
@@ -149,10 +149,10 @@
            [:div (use-style node-page/references-style {:key "Linked References"})
             [:section
              [:h4 (use-style node-page/references-heading-style)
-              [(r/adapt-react-class mui-icons/Link)]
+              [(r/adapt-react-class Link)]
               [:span "Linked References"]]
               ;; Hide button until feature is implemented
-              ;;[button {:disabled true} [(r/adapt-react-class mui-icons/FilterList)]]]
+              ;;[button {:disabled true} [(r/adapt-react-class FilterList)]]]
              [:div (use-style node-page/references-list-style)
               (doall
                 (for [[group-title group] refs]

--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -1,6 +1,6 @@
 (ns athens.views.blocks
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/KeyboardArrowDown" :as KeyboardArrowDown]
     [athens.db :as db]
     [athens.electron :as electron]
     [athens.events :refer [select-up select-down]]
@@ -367,7 +367,7 @@
                                      (if (true? linked-ref)
                                        (swap! state update :linked-ref/open not)
                                        (toggle [:block/uid uid] open)))})
-     [:> mui-icons/KeyboardArrowDown {:style {:font-size "16px"}}]]
+     [:> KeyboardArrowDown {:style {:font-size "16px"}}]]
     [:span (use-style block-disclosure-toggle-style)]))
 
 

--- a/src/cljs/athens/views/devtool.cljs
+++ b/src/cljs/athens/views/devtool.cljs
@@ -1,6 +1,10 @@
 (ns athens.views.devtool
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/Build" :as Build]
+    ["@material-ui/icons/ChevronLeft" :as ChevronLeft]
+    ["@material-ui/icons/Clear" :as Clear]
+    ["@material-ui/icons/History" :as History]
+    ["@material-ui/icons/ShortText" :as ShortText]
     [athens.db :as db :refer [dsdb]]
     [athens.style :refer [color]]
     [athens.views.buttons :refer [button]]
@@ -332,7 +336,7 @@
                                                     (-> s
                                                         (update :navs subvec 0 i)
                                                         (dissoc :viewer))))}
-                  [:<> [:> mui-icons/ChevronLeft] [:span (first nav)]]])))
+                  [:<> [:> ChevronLeft] [:span (first nav)]]])))
            [:h3 (use-style current-location-name-style) (pr-str (type navved-data))]
            [:div (use-style current-location-controls-style)
             [:span "View as "]
@@ -459,14 +463,14 @@
            :primary true
            :style {:font-size "11px"}}
    [:<>
-    [:> mui-icons/Build]
+    [:> Build]
     [:span "Toggle devtool"]]])
 
 
 (defn devtool-close-el
   []
   [button {:on-click #(dispatch [:devtool/toggle])}
-   [:> mui-icons/Clear]])
+   [:> Clear]])
 
 
 (defn devtool-el
@@ -479,10 +483,10 @@
         [:div (use-style tabs-section-style)
          [button {:on-click #(switch-panel :query)
                   :active (= active-panel :query)}
-          [:<> [:> mui-icons/ShortText] [:span "Query"]]]
+          [:<> [:> ShortText] [:span "Query"]]]
          [button {:on-click #(switch-panel :txes)
                   :active (= active-panel :txes)}]
-         [:<> [:> mui-icons/History] [:span "Transactions"]]]
+         [:<> [:> History] [:span "Transactions"]]]
         [devtool-close-el]]
        [:div (use-style panels-style)
         (case active-panel

--- a/src/cljs/athens/views/dropdown.cljs
+++ b/src/cljs/athens/views/dropdown.cljs
@@ -89,21 +89,21 @@
 ;;             [menu {:content
 ;;                    [:<>
 ;;                     ;;  [menu-heading "Modify Block 'Day of Datomic On-Prem 2016'"]
-;;                     ;;  [textinput {:icon [:> mui-icons/Face] :placeholder "Type to filter"}]
-;;                     [button [:<> [:> mui-icons/Link] [:span "Copy Page Reference"]]]
-;;                     [button [:<> [:> mui-icons/Star] [:span "Add to Shortcuts"]]]
-;;                     [button [:<> [:> mui-icons/Face] [:span "Add Reaction"] [submenu-indicator]]]
+;;                     ;;  [textinput {:icon [:> Face] :placeholder "Type to filter"}]
+;;                     [button [:<> [:> Link] [:span "Copy Page Reference"]]]
+;;                     [button [:<> [:> Star] [:span "Add to Shortcuts"]]]
+;;                     [button [:<> [:> Face] [:span "Add Reaction"] [submenu-indicator]]]
 ;;                     [menu-separator]
-;;                     [button [:<> [:> mui-icons/LastPage] [:span "Open in Sidebar"] [:kbd "shift-click"]]]
-;;                     [button [:<> [:> mui-icons/Launch] [:span "Open in New Window"] [:kbd "ctrl-o"]]]
-;;                     [button [:<> [:> mui-icons/UnfoldMore] [:span "Expand All"]]]
-;;                     [button [:<> [:> mui-icons/UnfoldLess] [:span "Collapse All"]]]
-;;                     [button [:<> [:> mui-icons/Slideshow] [:span "View As"] [submenu-indicator]]]
+;;                     [button [:<> [:> LastPage] [:span "Open in Sidebar"] [:kbd "shift-click"]]]
+;;                     [button [:<> [:> Launch] [:span "Open in New Window"] [:kbd "ctrl-o"]]]
+;;                     [button [:<> [:> UnfoldMore] [:span "Expand All"]]]
+;;                     [button [:<> [:> UnfoldLess] [:span "Collapse All"]]]
+;;                     [button [:<> [:> Slideshow] [:span "View As"] [submenu-indicator]]]
 ;;                     [menu-separator]
-;;                     [button [:<> [:> mui-icons/FileCopy] [:span "Duplicate and Break Links"]]]
-;;                     [button [:<> [:> mui-icons/LibraryAdd] [:span "Save as Template"]]]
-;;                     [button [:<> [:> mui-icons/History] [:span "Browse Versions"]]]
-;;                     [button [:<> [:> mui-icons/CloudDownload] [:span "Export As"]]]]}]}])
+;;                     [button [:<> [:> FileCopy] [:span "Duplicate and Break Links"]]]
+;;                     [button [:<> [:> LibraryAdd] [:span "Save as Template"]]]
+;;                     [button [:<> [:> History] [:span "Browse Versions"]]]
+;;                     [button [:<> [:> CloudDownload] [:span "Export As"]]]]}]}])
 ;;
 ;;
 ;;(def items

--- a/src/cljs/athens/views/filesystem.cljs
+++ b/src/cljs/athens/views/filesystem.cljs
@@ -1,6 +1,8 @@
 (ns athens.views.filesystem
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/ArrowBack" :as ArrowBack]
+    ["@material-ui/icons/Close" :as Close]
+    ["@material-ui/icons/FolderOpen" :as FolderOpen]
     [athens.electron :as electron]
     [athens.subs]
     #_[athens.util :as util]
@@ -38,17 +40,17 @@
       [:div (use-style modal-style)
        [modal/modal
         {:title    [:div.modal__title
-                    [:> mui-icons/FolderOpen]
+                    [:> FolderOpen]
                     [:h4 "Filesystem"]
                     (when-not @loading
-                      [button {:on-click close-modal} [:> mui-icons/Close]])]
+                      [button {:on-click close-modal} [:> Close]])]
          :content  [:div (use-style modal-contents-style)
                     (if (:create @state)
                       [:<>
                        [button {:style    {:align-self "start" :padding "0"}
                                 :on-click #(swap! state update :create not)}
                         [:<>
-                         [:> mui-icons/ArrowBack]
+                         [:> ArrowBack]
                          [:span "Back"]]]
                        [:div {:style {:display         "flex"
                                       :justify-content "space-between"

--- a/src/cljs/athens/views/filters.cljs
+++ b/src/cljs/athens/views/filters.cljs
@@ -1,6 +1,10 @@
 (ns athens.views.filters
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/ArrowDownward" :as ArrowDownward]
+    ["@material-ui/icons/Block" :as Block]
+    ["@material-ui/icons/Check" :as Check]
+    ["@material-ui/icons/FilterList" :as FilterList]
+    ["@material-ui/icons/Sort" :as Sort]
     [athens.style :refer [color OPACITIES]]
     [athens.views.buttons :refer [button]]
     [athens.views.textinput :refer [textinput]]
@@ -166,7 +170,7 @@
                                {:type        "search"
                                 :autoFocus  true
                                 :placeholder "Type to find filters"
-                                :icon [:> mui-icons/FilterList]
+                                :icon [:> FilterList]
                                 :value (:search @s)
                                 :on-change   (fn [e]
                                                (swap! s assoc-in [:search] (.. e -target -value)))})]
@@ -178,8 +182,8 @@
                                (swap! s assoc :sort (if (= sort_ :lex)
                                                       :count
                                                       :lex)))}
-           [:> mui-icons/Sort]]
-          [:span (use-style sort-indicator-style) [:<> [:> mui-icons/ArrowDownward] (if (= sort_ :lex) "Title" "Number")]]
+           [:> Sort]]
+          [:span (use-style sort-indicator-style) [:<> [:> ArrowDownward] (if (= sort_ :lex) "Title" "Number")]]
           [:span (str num-filters " Active")]
           [button {:style reset-control-style
                    :on-click (fn [_]
@@ -219,6 +223,6 @@
                 (when (or added? excluded?)
                   [:span (use-style state-style) state
                    (if added?
-                     [:> mui-icons/Check]
-                     [:> mui-icons/Block])])]))
+                     [:> Check]
+                     [:> Block])])]))
             [:p (use-style no-items-message-style) "No filters found"])]]))))

--- a/src/cljs/athens/views/graph_page.cljs
+++ b/src/cljs/athens/views/graph_page.cljs
@@ -21,7 +21,8 @@
     ["@material-ui/core/ExpansionPanelSummary" :as ExpansionPanelSummary]
     ["@material-ui/core/Slider" :as Slider]
     ["@material-ui/core/Switch" :as Switch]
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/KeyboardArrowRight" :as KeyboardArrowRight]
+    ["@material-ui/icons/KeyboardArrowUp" :as KeyboardArrowUp]
     ["react-force-graph-2d" :as ForceGraph2D]
     [athens.db :as db]
     [athens.router :as router]
@@ -226,7 +227,7 @@
                 [m-expansion-panel
                  [m-expansion-panel-summary
                   {:onClick #(swap! is-open? not)}
-                  [:<> [:span heading] (if @is-open? [:> mui-icons/KeyboardArrowUp] [:> mui-icons/KeyboardArrowRight])]]
+                  [:<> [:span heading] (if @is-open? [:> KeyboardArrowUp] [:> KeyboardArrowRight])]]
                  [m-expansion-panel-details
                   (doall
                     (for [{:keys [key comp label onChange no-simulation-reheat? props class]} controls]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -1,6 +1,13 @@
 (ns athens.views.node-page
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/Bookmark" :as Bookmark]
+    ["@material-ui/icons/BookmarkBorder" :as BookmarkBorder]
+    ["@material-ui/icons/BubbleChart" :as BubbleChart]
+    ["@material-ui/icons/ChevronRight" :as ChevronRight]
+    ["@material-ui/icons/Delete" :as Delete]
+    ["@material-ui/icons/KeyboardArrowDown" :as KeyboardArrowDown]
+    ["@material-ui/icons/Link" :as Link]
+    ["@material-ui/icons/MoreHoriz" :as MoreHoriz]
     [athens.db :as db :refer [get-linked-references get-unlinked-references]]
     [athens.keybindings :refer [destruct-key-down arrow-key-direction block-start? block-end?]]
     [athens.parse-renderer :as parse-renderer :refer [pull-node-from-string parse-and-render]]
@@ -359,15 +366,15 @@
                                         (if sidebar
                                           [button {:on-click #(dispatch [:page/remove-shortcut uid])}
                                            [:<>
-                                            [:> mui-icons/BookmarkBorder]
+                                            [:> BookmarkBorder]
                                             [:span "Remove Shortcut"]]]
                                           [button {:on-click #(dispatch [:page/add-shortcut uid])}
                                            [:<>
-                                            [:> mui-icons/Bookmark]
+                                            [:> Bookmark]
                                             [:span "Add Shortcut"]]])
                                         [button {:on-click #(dispatch [:right-sidebar/open-item uid true])}
                                          [:<>
-                                          [:> mui-icons/BubbleChart]
+                                          [:> BubbleChart]
                                           [:span "Show Local Graph"]]]]
                                        [:hr (use-style menu-separator-style)]
                                        [button {:on-click #(if daily-note?
@@ -375,7 +382,7 @@
                                                              (do
                                                                (navigate :pages)
                                                                (dispatch [:page/delete uid title])))}
-                                        [:<> [:> mui-icons/Delete] [:span "Delete Page"]]]]])))})))
+                                        [:<> [:> Delete] [:span "Delete Page"]]]]])))})))
 
 
 (defn ref-comp
@@ -415,9 +422,9 @@
        [:h4 (use-style references-heading-style)
         [button {:on-click (fn [] (swap! state update linked? not))}
          (if (get @state linked?)
-           [:> mui-icons/KeyboardArrowDown]
-           [:> mui-icons/ChevronRight])]
-        [(r/adapt-react-class mui-icons/Link)]
+           [:> KeyboardArrowDown]
+           [:> ChevronRight])]
+        [(r/adapt-react-class Link)]
         [:div {:style {:display "flex"
                        :flex "1 1 100%"
                        :justify-content "space-between"}}
@@ -453,9 +460,9 @@
                                  (swap! state assoc unlinked? true)
                                  (reset! unlinked-refs un-refs))))}
          (if (get @state unlinked?)
-           [:> mui-icons/KeyboardArrowDown]
-           [:> mui-icons/ChevronRight])]
-        [(r/adapt-react-class mui-icons/Link)]
+           [:> KeyboardArrowDown]
+           [:> ChevronRight])]
+        [(r/adapt-react-class Link)]
         [:div {:style {:display         "flex"
                        :justify-content "space-between"
                        :width "100%"}}
@@ -545,7 +552,7 @@
                                                        :menu/x    (.. rect -left)
                                                        :menu/y    (.. rect -bottom)}))))
                    :style    page-menu-toggle-style}
-           [:> mui-icons/MoreHoriz]]
+           [:> MoreHoriz]]
           (when-not daily-note?
             [autosize/textarea
              {:value       (:title/local @state)

--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -1,6 +1,11 @@
 (ns athens.views.right-sidebar
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/BubbleChart" :as BubbleChart]
+    ["@material-ui/icons/ChevronRight" :as ChevronRight]
+    ["@material-ui/icons/Close" :as Close]
+    ["@material-ui/icons/Description" :as Description]
+    ["@material-ui/icons/FiberManualRecord" :as FiberManualRecord]
+    ["@material-ui/icons/VerticalSplit" :as VerticalSplit]
     [athens.parse-renderer :as parse-renderer]
     [athens.style :refer [color OPACITIES ZINDICES]]
     [athens.views.block-page :refer [block-page-component]]
@@ -164,7 +169,7 @@
 (defn empty-message
   []
   [:div (use-style empty-message-style)
-   [:> mui-icons/VerticalSplit]
+   [:> VerticalSplit]
    [:p
     "Hold " [:kbd "shift"] " when clicking a page link to view the page in the sidebar."]])
 
@@ -212,7 +217,7 @@
                                   [:div (use-style sidebar-content-style {:class (if open? "is-open" "is-closed")})
                                    ;; [:header (use-style sidebar-section-heading-style)] ;; Waiting on additional sidebar contents
                                    ;;  [:h1 "Pages and Blocks"]]
-                                   ;;  [button [:> mui-icons/FilterList]]
+                                   ;;  [button [:> FilterList]]
                                    (if (empty? items)
                                      [empty-message]
                                      (doall
@@ -223,17 +228,17 @@
                                            [button {:style    sidebar-item-toggle-style
                                                     :on-click #(dispatch [:right-sidebar/toggle-item uid])
                                                     :class    (when open "is-open")}
-                                            [:> mui-icons/ChevronRight]]
+                                            [:> ChevronRight]]
                                            [:h2
                                             (cond
-                                              is-graph? [:<> [:> mui-icons/BubbleChart] [parse-renderer/parse-and-render title uid]]
-                                              title     [:<> [:> mui-icons/Description] [parse-renderer/parse-and-render title uid]]
-                                              :else     [:<> [:> mui-icons/FiberManualRecord] [parse-renderer/parse-and-render string uid]])]
+                                              is-graph? [:<> [:> BubbleChart] [parse-renderer/parse-and-render title uid]]
+                                              title     [:<> [:> Description] [parse-renderer/parse-and-render title uid]]
+                                              :else     [:<> [:> FiberManualRecord] [parse-renderer/parse-and-render string uid]])]
                                            [:div {:class "controls"}
-                                            ;;  [button [:> mui-icons/DragIndicator]]
+                                            ;;  [button [:> DragIndicator]]
                                             ;;  [:hr]
                                             [button {:on-click #(dispatch [:right-sidebar/close-item uid])}
-                                             [:> mui-icons/Close]]]]
+                                             [:> Close]]]]
                                           (when open
                                             [:div (use-style sidebar-item-container-style)
                                              (cond

--- a/src/cljs/athens/views/settings_page.cljs
+++ b/src/cljs/athens/views/settings_page.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.settings-page
   (:require
-    ["@material-ui/icons" :as mui-icons]
+    ["@material-ui/icons/ToggleOff" :as ToggleOff]
+    ["@material-ui/icons/ToggleOn" :as ToggleOn]
     [athens.electron :as electron]
     [athens.views.buttons :refer [button]]
     [cljs-http.client :as http]
@@ -127,10 +128,10 @@
                    :on-click #(handle-click opted-out?)}
            (if @opted-out?
              [:div {:style {:display "flex"}}
-              [:> mui-icons/ToggleOn]
+              [:> ToggleOn]
               [:span "\uD83D\uDE41 We understand."]]
              [:div {:style {:display "flex"}}
-              [:> mui-icons/ToggleOff]
+              [:> ToggleOff]
               [:span "\uD83D\uDE00 Thanks for helping make Athens better!"]])]]
 
          [:span "Analytics are delivered by "


### PR DESCRIPTION
Reduces the bundle size from a total of 6.72MB to 3.45MB (@material-ui/icons shrinks from 3.27MB to 14.35KB).

As proof please see the before/after output of `npx shadow-cljs run shadow.cljs.build-report app athens-app-report.html`:
- [Before 6.72MB](https://drive.google.com/file/d/1RIBAs1gA5KWvkqGUj1Wj4NuRRzbKgSjn/view?usp=sharing)
- [After 3.45MB](https://drive.google.com/file/d/1m5xp2mj1XX_J0hIVWYUWKFExzSYj33H3/view?usp=sharing)