### PR TITLE
fix(electron): issue updating Mac (Intel, not Silicon)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
         {
           "target": "dmg",
           "arch": [
-            "arm64",
-            "x64"
+            "x64",
+            "arm64"
           ]
         },
         {
           "target": "zip",
           "arch": [
-            "arm64",
-            "x64"
+            "x64",
+            "arm64"
           ]
         }
       ],


### PR DESCRIPTION
Fixes #749, fixes #793 due to default ordering resulting in electron-update choosing ARM64 binary on Intel Macs

See comment on #749 describing validation testing performed