### PR TITLE
fix: Persistent Pop-up when scrolling

### DIFF
--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -37,7 +37,7 @@
    :right 0
    :left 0
    :grid-template-columns "auto 1fr auto"
-   :z-index "1000"
+   :z-index "1070"
    :grid-auto-flow "column"
    :padding "0.25rem 0.75rem"
    ::stylefy/manual [[:svg {:font-size "20px"}]

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -328,8 +328,6 @@
 
 (def init-state
   {:menu/show            false
-   :menu/x               nil
-   :menu/y               nil
    :title/initial        nil
    :title/local          nil
    :alert/show           nil
@@ -353,14 +351,14 @@
        :component-will-unmount (fn [_this] (unlisten js/document "mousedown" handle-click-outside))
        :reagent-render         (fn [node state daily-note?]
                                  (let [{:block/keys [uid] sidebar :page/sidebar title :node/title} node
-                                       {:menu/keys [show x y]} @state]
+                                       {:menu/keys [show]} @state]
                                    (when show
                                      [:div (merge (use-style dropdown-style
                                                              {:ref #(reset! ref %)})
                                                   {:style {:font-size "14px"
-                                                           :position  "fixed"
-                                                           :left      (str x "px")
-                                                           :top       (str y "px")}})
+                                                           :position  "absolute"
+                                                           :left      "-3em"
+                                                           :top       "3.5em"}})
                                       [:div (use-style menu-style)
                                        [:<>
                                         (if sidebar
@@ -547,10 +545,7 @@
                                (.. e stopPropagation)
                                (if show
                                  (swap! state assoc :menu/show false)
-                                 (let [rect (.. e -target getBoundingClientRect)]
-                                   (swap! state merge {:menu/show true
-                                                       :menu/x    (.. rect -left)
-                                                       :menu/y    (.. rect -bottom)}))))
+                                 (swap! state merge {:menu/show true})))
                    :style    page-menu-toggle-style}
            [:> MoreHoriz]]
           (when-not daily-note?
@@ -568,10 +563,10 @@
           ;; empty word break to keep span on full height else it will collapse to 0 height (weird ui)
           (if (str/blank? (:title/local @state))
             [:wbr]
-            [parse-renderer/parse-and-render (:title/local @state) uid])]
+            [parse-renderer/parse-and-render (:title/local @state) uid])
 
-         ;; Dropdown
-         [menu-dropdown node state daily-note?]
+          ;; Dropdown
+          [menu-dropdown node state daily-note?]]
 
          ;; Children
          (if (empty? children)


### PR DESCRIPTION
close https://github.com/athensresearch/athens/issues/592

![image](https://user-images.githubusercontent.com/8164667/110648070-5c451780-81f3-11eb-8762-0294230a5d27.png)

---
Also fixed the z-index of the toolbar.

Problem:
The toolbar is below the pop-ups. For example, the toolbar is below the block inline search.
![image](https://user-images.githubusercontent.com/8164667/110645866-4f272900-81f1-11eb-9410-5f94bc9714fd.png)

Fixed
The toolbar is now above.
![image](https://user-images.githubusercontent.com/8164667/110646391-d2487f00-81f1-11eb-8c78-855a89aa21ae.png)
![image](https://user-images.githubusercontent.com/8164667/110646489-e5f3e580-81f1-11eb-8a7a-e28767ae2427.png)