### PR TITLE
fix: toolbar overlaps on scrollbar

### DIFF
--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -44,11 +44,11 @@
    :padding-top "2.5rem"
    :display "flex"
    :overflow-y "auto"
-   ::stylefy/mode [["::webkit-scrollbar" {:background "transparent"
-                                          :width "0.25rem"
-                                          :height "0.25rem"}]
-                   ["::webkit-scrollbar-thumb" {:background (color :header-text-color)
-                                                :border-radius "0.25rem"}]]})
+   ::stylefy/mode [["::webkit-scrollbar" {:background (color :background-minus-1)
+                                          :width "0.5rem"
+                                          :height "0.5rem"}]
+                   ["::webkit-scrollbar-thumb" {:background (color :background-minus-2)
+                                                :border-radius "0.5rem"}]]})
 
 
 ;;; Components

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -2,6 +2,7 @@
   (:require
     [athens.config]
     [athens.db :as db]
+    [athens.style :refer [color]]
     [athens.subs]
     [athens.views.all-pages :refer [table]]
     [athens.views.app-toolbar :refer [app-toolbar]]
@@ -42,7 +43,12 @@
    :justify-content "stretch"
    :padding-top "2.5rem"
    :display "flex"
-   :overflow-y "auto"})
+   :overflow-y "auto"
+   ::stylefy/mode [["::webkit-scrollbar" {:background "transparent"
+                                          :width "0.25rem"
+                                          :height "0.25rem"}]
+                   ["::webkit-scrollbar-thumb" {:background (color :header-text-color)
+                                                :border-radius "0.25rem"}]]})
 
 
 ;;; Components

--- a/src/cljs/athens/views/right_sidebar.cljs
+++ b/src/cljs/athens/views/right_sidebar.cljs
@@ -38,7 +38,12 @@
    ::stylefy/manual [[:svg {:color (color :body-text-color :opacity-high)}]
                      [:&.is-closed {:width "0"}]
                      [:&.is-open {:width "32vw"
-                                  :background-color (color :background-minus-1)}]]})
+                                  :background-color (color :background-minus-1)}]
+                     ["::webkit-scrollbar" {:background (color :background-minus-1)
+                                            :width "0.5rem"
+                                            :height "0.5rem"}]
+                     ["::webkit-scrollbar-thumb" {:background (color :background-minus-2)
+                                                  :border-radius "0.5rem"}]]})
 
 
 (def sidebar-content-style


### PR DESCRIPTION
close #805 (somehow?)

I reduce the size of the scrollbar, change its color, and add border-radius.

Not sure if @shanberg will approve this. 😅 Also, not tested in Mac or Linux.

![image](https://user-images.githubusercontent.com/8164667/111014295-084a5680-83de-11eb-9dc0-f3bd76a62b0f.png)
![image](https://user-images.githubusercontent.com/8164667/111014297-0a141a00-83de-11eb-95e4-72803ca072a9.png)

