### PR TITLE
fix : revert(analytics) let non paying users opt out

### DIFF
--- a/src/cljs/athens/views/settings_page.cljs
+++ b/src/cljs/athens/views/settings_page.cljs
@@ -124,7 +124,6 @@
            [:h5 "Opted Into Analytics"])
          [:div {:style {:margin "10px 0"}}
           [button {:primary  (false? @opted-out?)
-                   :disabled (not @authed?)
                    :on-click #(handle-click opted-out?)}
            (if @opted-out?
              [:div {:style {:display "flex"}}


### PR DESCRIPTION
With regards to Issue #740 

Removes the requirement of being a paid user to opt out of analytics. 