### PR TITLE
test(db): add Karma test for node search by title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,15 @@ jobs:
          if: steps.cache-deps.outputs.cache-hit != 'true'
          run: lein deps
 
-       - name: Run tests
+       - name: Run JVM tests
          run: script/test/jvm
+
+       # TODO(agentydragon): cache JS deps
+       - name: Fetch JS deps
+         run: yarn
+
+       - name: Run Karma tests
+         run: script/test/karma
 
    lint:
      runs-on: ubuntu-18.04

--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
             "gh-pages"     ["shell" "yarn" "gh-pages" "-d" "resources/public"]
             "karma"        ["do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "compile" "karma-test"]
-                            ["shell" "karma" "start" "--single-run" "--reporters" "junit,dots"]]}
+                            ["shell" "yarn" "run" "karma" "start" "--single-run" "--reporters" "junit,dots"]]}
 
   :profiles
   {:dev

--- a/script/test/karma
+++ b/script/test/karma
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+lein karma

--- a/test/athens/db_test.cljs
+++ b/test/athens/db_test.cljs
@@ -1,0 +1,41 @@
+(ns athens.db-test
+  (:require
+    [athens.db :as db]
+    [clojure.pprint :refer [pprint]]
+    [clojure.test :refer [deftest is are]]
+    [datascript.core :as d]))
+
+
+(enable-console-print!)
+
+
+(defn make-nodes-with-titles
+  "Returns empty nodes (pages) with the given titles."
+  [titles]
+  (map-indexed
+    (fn [i title]
+      {:node/title title
+       :block/uid (str "uid" (inc i))})
+    titles))
+
+
+(deftest search-in-node-title-test
+  ; Given that database contains nodes with titles node-titles and we search
+  ; for query, check that expected-titles were returned by the search.
+  (are [node-titles query expected-titles]
+       (with-redefs
+         [db/dsdb (d/create-conn db/schema)]
+         (d/transact! db/dsdb (make-nodes-with-titles node-titles))
+         (let
+           [search-results (db/search-in-node-title query)
+            actual-titles (map :node/title search-results)]
+           (is (= actual-titles expected-titles))))
+
+    ; Exact string match
+    ["Foo", "Bar"] "Foo" ["Foo"]
+
+    ; Case-insensitive substring match
+    ["Page foo 1", "Page bar 2"] "FOO" ["Page foo 1"]
+
+    ; TODO(agentydragon): "kiwi recipe" should match "[[Banana]] - [[Kiwi]] smoothie recipe"
+    ))


### PR DESCRIPTION
I'd like to add a few Karma tests, so that I can later conveniently
change stuff closer to frontend without breaking it. The function
to search for node by title is a convenient first target (to just get
Karma tests set up and running) - it's simple, and I want to enhance
it a little bit soon.

(In particular, I want to make it a bit more fuzzy - e.g.,
if I search for "kiwi recipes", the page "Summer [[Kiwi]] and [[Melon]]
Recipes" should come up. Currently it does not, probably because it
does not ignore the `[[` / `]]`.)