### PR TITLE
fix(10x): ctrl/cmd-t always works to toggle 10x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ If all goes well, now you can see documentation of symbols (binding: K), go to d
 
 # Using re-frame-10x
 
-The right sidebar has [`re-frame-10x`](https://github.com/day8/re-frame-10x/tree/master/src/day8) developer tools. You can toggle it open and close with `ctrl-h`, but you must not be focused on a block (ctrl-h has a specific action in some operating systems).
+The right sidebar has [`re-frame-10x`](https://github.com/day8/re-frame-10x/tree/master/src/day8) developer tools. You can toggle it open and close with `Ctrl+T`, but you must not be focused on a block.
 
 Once you have 10x open, you can hover over blocks' bullets to see some of their datascript data.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ If all goes well, now you can see documentation of symbols (binding: K), go to d
 
 # Using re-frame-10x
 
-The right sidebar has [`re-frame-10x`](https://github.com/day8/re-frame-10x/tree/master/src/day8) developer tools. You can toggle it open and close with `Ctrl+T`, but you must not be focused on a block.
+The right sidebar has [`re-frame-10x`](https://github.com/day8/re-frame-10x/tree/master/src/day8) developer tools. You can toggle it open and close with `Cmd-T` or `Ctrl-T`.
 
 Once you have 10x open, you can hover over blocks' bullets to see some of their datascript data.
 

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -22,9 +22,9 @@
         var userAgent = navigator.userAgent.toLowerCase();
         return userAgent.indexOf("electron/") > -1
       }
-      function hide10x() {
-        localStorage.setItem("day8.re-frame-10x.show-panel","\"false\"")
-        localStorage.setItem("day8.re-frame-10x.using-trace?","\"false\"")
+      function show10x() {
+        localStorage.setItem("day8.re-frame-10x.show-panel","\"true\"")
+        localStorage.setItem("day8.re-frame-10x.using-trace?","\"true\"")
       }
     </script>
     <script>
@@ -32,7 +32,7 @@
       var src = ""
       if (electron) {
          src = "js/compiled/renderer.js"
-         hide10x() // hide10x by default. To stop, remove relevant localStorage key-vals and comment this out
+         show10x() // 10x exists on DOM by default, but athens.style hides via CSS
       } else {
          src = "js/compiled/app.js"
       }


### PR DESCRIPTION
close #900

By default, `index.html` creates DOM elements for 10x. But then `athens.style` hides `10x` via CSS. User can then toggle with `ctrl` or `cmd-t`.

Normal 10x behavior is not great. It shows shows, even when it should be closed, when a user resizes the window quickly. Therefore we use inline CSS to toggle.

Also, normal 10x behavior is to use `ctrl-h`, but this can get caught when a user is focused on a textarea. Using `ctrl-t` works more consistently.