### PR TITLE
feat: import from Roam

### DIFF
--- a/.carve_ignore
+++ b/.carve_ignore
@@ -23,3 +23,6 @@ athens.main.core/main
 ;; used when updating athens-datoms (don't pull :db/id)
 athens.db/get-athens-datoms
 athens.util/common-ancestor
+athens.events/shared-blocks-excl-date-pages
+athens.events/pages
+athens.patterns/date

--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -24,3 +24,26 @@
                           (linked old-title)
                           (str "$1$3$4" new-title "$2$5")))
 
+
+
+;; Positive Lookbehind: between 1 and 2 digits
+;; One of an oridinal suffix, e.g. -st, -nd, -rd, -th, see https://en.wikipedia.org/wiki/Ordinal_indicator
+;; Comma
+;; Positive Lookahead: whitespace and 4 digits
+(def roam-date #"(?<=\d{1,2})(st|nd|rd|th),(?=\s\d{4})")
+
+
+(defn date
+  [str]
+  (re-find #"(?=\d{2}-\d{2}-\d{4}).*" str))
+
+
+(defn date-block-string
+  [str]
+  (re-find #"\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\s\d{1,2}(?:st|nd|rd|th),\s\d{4}\b" str))
+
+
+(defn replace-roam-date
+  [string]
+  (clojure.string/replace string athens.patterns/roam-date ","))
+

--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -25,9 +25,8 @@
                           (str "$1$3$4" new-title "$2$5")))
 
 
-
 ;; Positive Lookbehind: between 1 and 2 digits
-;; One of an oridinal suffix, e.g. -st, -nd, -rd, -th, see https://en.wikipedia.org/wiki/Ordinal_indicator
+;; One of an ordinal suffix, e.g. -st, -nd, -rd, -th, see https://en.wikipedia.org/wiki/Ordinal_indicator
 ;; Comma
 ;; Positive Lookahead: whitespace and 4 digits
 (def roam-date #"(?<=\d{1,2})(st|nd|rd|th),(?=\s\d{4})")

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -283,7 +283,6 @@
        sort-block-children))
 
 
-
 (defn get-athens-datoms
   "Copy REPL output to athens-datoms.cljs"
   [id]

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -258,6 +258,10 @@
       (conj :node/title :page/sidebar)))
 
 
+(def roam-node-document-pull-vector
+  '[:node/title :block/uid :block/string :block/open :block/order {:block/children ...}])
+
+
 (defn get-block-document
   [id]
   (->> @(pull dsdb block-document-pull-vector id)
@@ -265,9 +269,19 @@
 
 
 (defn get-node-document
-  [id]
-  (->> @(pull dsdb node-document-pull-vector id)
+  ([id]
+   (->> @(pull dsdb node-document-pull-vector id)
+        sort-block-children))
+  ([id db]
+   (->> (d/pull db node-document-pull-vector id)
+        sort-block-children)))
+
+
+(defn get-roam-node-document
+  [id db]
+  (->> (d/pull db roam-node-document-pull-vector id)
        sort-block-children))
+
 
 
 (defn get-athens-datoms

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -2,6 +2,7 @@
   (:require
     [athens.db :as db :refer [retract-uid-recursively inc-after dec-after plus-after minus-after]]
     [athens.keybindings :as keybindings]
+    [athens.patterns :as patterns]
     [athens.style :as style]
     [athens.util :refer [now-ts gen-block-uid]]
     [clojure.string :as string]
@@ -136,7 +137,7 @@
                                   [(?date ?t)]
                                   [?e :block/uid ?u]]
                                 db
-                                athens.patterns/date-block-string)
+                                patterns/date-block-string)
         date-block-strings (d/q '[:find ?s ?u
                                   :keys block/string block/uid
                                   :in $ ?date
@@ -145,23 +146,17 @@
                                   [(?date ?s)]
                                   [?e :block/uid ?u]]
                                 db
-                                athens.patterns/date-block-string)
+                                patterns/date-block-string)
         date-concat        (concat date-pages date-block-strings)
         tx-data            (map (fn [{:keys [block/string node/title block/uid]}]
                                   (cond-> {:db/id [:block/uid uid]}
-                                          string (assoc :block/string (athens.patterns/replace-roam-date string))
-                                          title (assoc :node/title (athens.patterns/replace-roam-date title))))
+                                    string (assoc :block/string (patterns/replace-roam-date string))
+                                    title (assoc :node/title (patterns/replace-roam-date title))))
                                 date-concat)]
     ;;tx-data))
     (d/db-with db tx-data)))
 
-;;(/ 3736 3842) 97% clean
-;;(-> (- 1056 2)
-;;    (+ (- 3088 406))))
-;;(defonce ROAM-DB (atom nil))
-;; 1056 pages, 2 shared
-;; 3088 pages, 406 shared
-;; 3736 math, 3842 actual count
+
 (reg-event-fx
   :upload/roam-edn
   (fn [_ [_ transformed-dates-roam-db roam-db-filename]]

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -7,6 +7,7 @@
     ["@material-ui/icons/FileCopy" :default FileCopy]
     ["@material-ui/icons/FolderOpen" :default FolderOpen]
     ["@material-ui/icons/Menu" :default Menu]
+    ["@material-ui/icons/MergeType" :default MergeType]
     ["@material-ui/icons/Search" :default Search]
     ["@material-ui/icons/Settings" :default Settings]
     ["@material-ui/icons/Today" :default Today]
@@ -18,6 +19,7 @@
     [athens.subs]
     [athens.util :as util]
     [athens.views.buttons :refer [button]]
+    [athens.views.filesystem :as filesystem]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style]]))
@@ -86,16 +88,11 @@
   [:hr (use-style separator-style)])
 
 
-
-
-
-
 (defn app-toolbar
   []
   (let [left-open?  (subscribe [:left-sidebar/open])
         right-open? (subscribe [:right-sidebar/open])
         route-name  (subscribe [:current-route/name])
-        theme-dark  (subscribe [:theme/dark])
         electron? (util/electron?)
         theme-dark  (subscribe [:theme/dark])
         merge-open? (reagent.core/atom false)]
@@ -135,13 +132,13 @@
         [:div (use-style app-header-secondary-controls-style)
          (if electron?
            [:<>
-            [button {:on-click #(swap! merge-open? not)}
-             [:> mui-icons/MergeType]]
             [(reagent.core/adapt-react-class FiberManualRecord)
              {:style {:color      (color (if @(subscribe [:db/synced])
                                            :confirmation-color
                                            :highlight-color))
                       :align-self "center"}}]
+            [button {:on-click #(swap! merge-open? not)}
+             [:> MergeType]]
             [button {:on-click #(router/navigate :settings)
                      :active   (= @route-name :settings)}
              [:> Settings]]

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -86,15 +86,26 @@
   [:hr (use-style separator-style)])
 
 
+
+
+
+
 (defn app-toolbar
   []
   (let [left-open?  (subscribe [:left-sidebar/open])
         right-open? (subscribe [:right-sidebar/open])
         route-name  (subscribe [:current-route/name])
         theme-dark  (subscribe [:theme/dark])
-        electron? (util/electron?)]
+        electron? (util/electron?)
+        theme-dark  (subscribe [:theme/dark])
+        merge-open? (reagent.core/atom false)]
     (fn []
       [:<>
+
+
+       (when @merge-open?
+         [filesystem/merge-modal merge-open?])
+
        [:header (use-style app-header-style)
         [:div (use-style app-header-control-section-style)
          [button {:active   @left-open?
@@ -124,6 +135,8 @@
         [:div (use-style app-header-secondary-controls-style)
          (if electron?
            [:<>
+            [button {:on-click #(swap! merge-open? not)}
+             [:> mui-icons/MergeType]]
             [(reagent.core/adapt-react-class FiberManualRecord)
              {:style {:color      (color (if @(subscribe [:db/synced])
                                            :confirmation-color

--- a/src/cljs/athens/views/filesystem.cljs
+++ b/src/cljs/athens/views/filesystem.cljs
@@ -3,6 +3,7 @@
     ["@material-ui/icons/ArrowBack" :default ArrowBack]
     ["@material-ui/icons/Close" :default Close]
     ["@material-ui/icons/FolderOpen" :default FolderOpen]
+    ["@material-ui/icons/MergeType" :default MergeType]
     [athens.electron :as electron]
     [athens.events :as events]
     [athens.subs]
@@ -38,7 +39,6 @@
                   filename                  (.-name file)
                   db                        (edn/read-string {:readers datascript.core/data-readers} edn-data)
                   transformed-dates-roam-db (athens.events/update-roam-db-dates db)]
-              ;;(reset! athens.events/ROAM-DB db)
               (reset! roam-db-filename filename)
               (reset! transformed-db transformed-dates-roam-db))))
     (.readAsText fr file)))
@@ -63,10 +63,10 @@
        [modal/modal
 
         {:title    [:div.modal__title
-                    [:> mui-icons/MergeType]
+                    [:> MergeType]
                     [:h4 "Merge Roam DB"]
                     [button {:on-click close-modal}
-                     [:> mui-icons/Close]]]
+                     [:> Close]]]
 
          :content  [:div (use-style modal-contents-style)
                     (if (nil? @transformed-roam-db)

--- a/src/cljs/athens/views/filesystem.cljs
+++ b/src/cljs/athens/views/filesystem.cljs
@@ -4,10 +4,13 @@
     ["@material-ui/icons/Close" :default Close]
     ["@material-ui/icons/FolderOpen" :default FolderOpen]
     [athens.electron :as electron]
+    [athens.events :as events]
     [athens.subs]
     #_[athens.util :as util]
     [athens.views.buttons :refer [button]]
     [athens.views.modal :refer [modal-style]]
+    [clojure.edn :as edn]
+    [datascript.core :as d]
     [komponentit.modal :as modal]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
@@ -23,6 +26,85 @@
    ::stylefy/manual [[:p {:max-width "24rem"
                           :text-align "center"}]
                      [:button {:font-size "18px"}]]})
+
+
+(defn file-cb
+  [e transformed-db roam-db-filename]
+  (let [fr   (js/FileReader.)
+        file (.. e -target -files (item 0))]
+    (set! (.-onload fr)
+          (fn [e]
+            (let [edn-data                  (.. e -target -result)
+                  filename                  (.-name file)
+                  db                        (edn/read-string {:readers datascript.core/data-readers} edn-data)
+                  transformed-dates-roam-db (athens.events/update-roam-db-dates db)]
+              ;;(reset! athens.events/ROAM-DB db)
+              (reset! roam-db-filename filename)
+              (reset! transformed-db transformed-dates-roam-db))))
+    (.readAsText fr file)))
+
+
+(defn roam-pages
+  [roam-db]
+  (d/q '[:find [?pages ...]
+         :in $
+         :where
+         [_ :node/title ?pages]]
+       roam-db))
+
+
+(defn merge-modal
+  [open?]
+  (let [close-modal         #(reset! open? false)
+        transformed-roam-db (r/atom nil)
+        roam-db-filename    (r/atom "")]
+    (fn []
+      [:div (use-style modal-style)
+       [modal/modal
+
+        {:title    [:div.modal__title
+                    [:> mui-icons/MergeType]
+                    [:h4 "Merge Roam DB"]
+                    [button {:on-click close-modal}
+                     [:> mui-icons/Close]]]
+
+         :content  [:div (use-style modal-contents-style)
+                    (if (nil? @transformed-roam-db)
+                      [:<>
+                       [:input {:type "file" :accept ".edn" :on-change #(file-cb % transformed-roam-db roam-db-filename)}]
+                       [:div {:style {:position       "relative"
+                                      :padding-bottom "56.25%"
+                                      :margin         "20px 0"
+                                      :width          "100%"}}
+                        [:iframe {:src                   "https://www.loom.com/embed/787ed48da52c4149b031efb8e17c0939"
+                                  :frameBorder           "0"
+                                  :webkitallowfullscreen "true"
+                                  :mozallowfullscreen    "true"
+                                  :allowFullScreen       true
+                                  :style                 {:position "absolute"
+                                                          :top      0
+                                                          :left     0
+                                                          :width    "100%"
+                                                          :height   "100%"}}]]]
+                      (let [roam-pages   (roam-pages @transformed-roam-db)
+                            shared-pages (events/get-shared-pages @transformed-roam-db)]
+                        [:div {:style {:display "flex" :flex-direction "column"}}
+                         [:h6 (str "Your Roam DB had " (count roam-pages)) " pages. " (count shared-pages) " of these pages were also found in your Athens DB. Press Merge to continue merging your DB."]
+                         [:p {:style {:margin "10px 0 0 0"}} "Shared Pages"]
+                         [:ol {:style {:max-height "400px"
+                                       :width      "100%"
+                                       :overflow-y "auto"}}
+                          (for [x shared-pages]
+                            ^{:key x}
+                            [:li (str "[[" x "]]")])]
+                         [button {:style    {:align-self "center"}
+                                  :primary  true
+                                  :on-click (fn []
+                                              (dispatch [:upload/roam-edn @transformed-roam-db @roam-db-filename])
+                                              (close-modal))}
+                          "Merge"]]))]
+
+         :on-close close-modal}]])))
 
 
 (defn window


### PR DESCRIPTION
close #561

```
(/ 3736 3842) 97% clean
(-> (- 1056 2)
    (+ (- 3088 406))))
 1056 pages, 2 shared
 3088 pages, 406 shared
 3736 math, 3842 actual count
```

When importing a Roam DB that has 3842 pages, 3736 are created in an Athens DB. This could be an error on either Athens's (lossy import) or Roam's side (orphan pages). It's not necessarily lossy.

Import is done by analyzing each `:block/string` for [[links]] and #tags, rather than using datascript values directly. This is because datascript references such as `:block/refs` point to entity ids, which may collide with Athens entity ids.

By looking at plain `:block/string`, it should be easy to reuse the code for markdown import.