### PR TITLE
fix: Checking a TODO item in block embed results to error

### DIFF
--- a/src/cljs/athens/views/blocks.cljs
+++ b/src/cljs/athens/views/blocks.cljs
@@ -640,7 +640,7 @@
                            :on-click       (fn [e] (textarea-click e uid state))
                            :on-mouse-enter (fn [e] (textarea-mouse-enter e uid state))
                            :on-mouse-down  (fn [e] (textarea-mouse-down e uid state))}]
-       [parse-and-render local uid]
+       [parse-and-render local (or original-uid uid)]
        [:div (use-style (merge drop-area-indicator
                                (when (= :child (:drag-target @state)) {;;:color "green"
                                                                        :opacity 1})))]])))

--- a/src/cljs/athens/views/node_page.cljs
+++ b/src/cljs/athens/views/node_page.cljs
@@ -403,7 +403,7 @@
                            :on-click #(do (let [new-B (db/get-block-document [:block/uid uid])
                                                 new-P (drop-last parents)]
                                             (swap! state assoc :block new-B :parents new-P)))}
-               [parse-and-render (or title string) (:block/uid block)]]))]
+               [parse-and-render (or title string) uid]]))]
          [:div.block-embed
           [block-el
            (recursively-modify-block-for-embed block embed-id)


### PR DESCRIPTION
fix #819

**Problem:** The `uid` that is passed to `todo-on-click` is the updated one from `recursively-modify-block-for-embed`. Which means it won't be found when `db/get-block` is called.
**Solution:** Use the `original-uid`, if available, or `uid` if not.

![athens-819](https://user-images.githubusercontent.com/8164667/114292389-d271be00-9ac0-11eb-91dd-6876973f7003.gif)


I have a question though. Will the `uid` from `recursively-modify-block-for-embed` be used in `parse-and-render`?


---
~~This other issue is not included here. I'll investigate further. https://github.com/athensresearch/athens/issues/819#issuecomment-811677701~~

Also fixes this comment https://github.com/athensresearch/athens/issues/819#issuecomment-811677701

**Problem:** The `uid` of the nested blocked is passed to `parse-and-render` instead of the `uid` of the parent block
**Solution:** Update the `uid` using the `uid` of the parent block
![athens-819-2](https://user-images.githubusercontent.com/8164667/114294992-e32c2f00-9ad4-11eb-8f5c-54b31b3cd7b0.gif)
