### PR TITLE
fix: athena should stay within viewport bounds

### DIFF
--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -30,6 +30,7 @@
 
 (def container-style
   {:width         "49rem"
+   :max-width "calc(100vw - 1rem)"
    :border-radius "0.25rem"
    :box-shadow    [[(:64 DEPTH-SHADOWS) ", 0 0 0 1px " (color :body-text-color :opacity-lower)]]
    :display       "flex"
@@ -97,6 +98,8 @@
    :background (color :background-plus-2)
    :display "flex"
    :position "sticky"
+   :flex-wrap "wrap"
+   :gap "0.5rem"
    :align-items "center"
    :top "0"
    :justify-content "space-between"


### PR DESCRIPTION
#797

- set Athena max-width to just under 100%
- reflow the results heading when there's not enough space for all contents