### PR TITLE
fix: non-formatted breadcrumb on page block

### DIFF
--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -119,7 +119,7 @@
                ^{:key breadcrumb-uid}
                [breadcrumb {:key (str "breadcrumb-" breadcrumb-uid)
                             :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)}
-                (or title string)]))]]
+                [parse-renderer/parse-and-render (or title string)]]))]]
 
          ;; Header
          [:h1 (merge


### PR DESCRIPTION
closes #970

![image](https://user-images.githubusercontent.com/8164667/114866241-e7828000-9e25-11eb-84d6-cd3d062eeea3.png)
