### PR TITLE
perf(athena): debounce athena search

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -5,7 +5,6 @@
     [clojure.edn :as edn]
     [clojure.string :as string]
     [datascript.core :as d]
-    [goog.functions :refer [debounce]]
     [posh.reagent :refer [posh! pull q]]
     [re-frame.core :refer [dispatch]]))
 
@@ -437,6 +436,7 @@
       (:block/_children b)  (recur (first (:block/_children b)))
       ;; protect against orphaned nodes
       :else                 nil)))
+
 
 (defn search-in-block-content
   ([query] (search-in-block-content query 20))

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -5,6 +5,7 @@
     [clojure.edn :as edn]
     [clojure.string :as string]
     [datascript.core :as d]
+    [goog.functions :refer [debounce]]
     [posh.reagent :refer [posh! pull q]]
     [re-frame.core :refer [dispatch]]))
 
@@ -436,7 +437,6 @@
       (:block/_children b)  (recur (first (:block/_children b)))
       ;; protect against orphaned nodes
       :else                 nil)))
-
 
 (defn search-in-block-content
   ([query] (search-in-block-content query 20))

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -15,7 +15,7 @@
     [goog.dom :refer [getElement]]
     [goog.dom.selection :refer [setStart setEnd getText setCursorPosition getEndPoints]]
     [goog.events.KeyCodes :refer [isCharacterKey]]
-    [goog.functions :refer [throttle]]
+    [goog.functions :refer [throttle debounce]]
     [re-frame.core :refer [dispatch dispatch-sync subscribe]])
   (:import
     (goog.events
@@ -118,7 +118,7 @@
   Head goes up to the text caret position."
   [state head key type]
   (let [query-fn        (case type
-                          :block db/search-in-block-content
+                          :block (debounce db/search-in-block-content 1000)
                           :page db/search-in-node-title
                           :hashtag db/search-in-node-title
                           :slash filter-slash-options)

--- a/src/cljs/athens/keybindings.cljs
+++ b/src/cljs/athens/keybindings.cljs
@@ -15,7 +15,7 @@
     [goog.dom :refer [getElement]]
     [goog.dom.selection :refer [setStart setEnd getText setCursorPosition getEndPoints]]
     [goog.events.KeyCodes :refer [isCharacterKey]]
-    [goog.functions :refer [throttle debounce]]
+    [goog.functions :refer [throttle #_debounce]]
     [re-frame.core :refer [dispatch dispatch-sync subscribe]])
   (:import
     (goog.events
@@ -118,7 +118,7 @@
   Head goes up to the text caret position."
   [state head key type]
   (let [query-fn        (case type
-                          :block (debounce db/search-in-block-content 1000)
+                          :block db/search-in-block-content
                           :page db/search-in-node-title
                           :hashtag db/search-in-node-title
                           :slash filter-slash-options)

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -16,7 +16,7 @@
     [garden.selectors :as selectors]
     [goog.dom :refer [getElement]]
     [goog.events :as events]
-    ;;[goog.functions :refer [debounce]]
+    [goog.functions :refer [debounce]]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]])
@@ -165,17 +165,18 @@
 
 (defn create-search-handler
   [state]
-  (fn [query]
-    (if (str/blank? query)
-      (reset! state {:index   0
-                     :query   nil
-                     :results []})
-      (reset! state {:index   0
-                     :query   query
-                     :results (->> (concat [(search-exact-node-title query)]
-                                           (search-in-node-title query 20 true)
-                                           (search-in-block-content query))
-                                   vec)}))))
+  (debounce (fn [query]
+              (if (str/blank? query)
+                (reset! state {:index   0
+                               :query   nil
+                               :results []})
+                (reset! state {:index   0
+                               :query   query
+                               :results (->> (concat [(search-exact-node-title query)]
+                                                     (search-in-node-title query 20 true)
+                                                     (search-in-block-content query))
+                                             vec)})))
+            1000))
 
 
 (defn key-down-handler


### PR DESCRIPTION
Addresses #969 without addressing root problem, using debounce. Wanted to debounce inline ((block-ref)) search as well but query-fn on line 133 of athens.keybindings always returned `nil`. 