### PR TITLE
fix: expand the breadcrumb when [[link]], don't navigate

### DIFF
--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -4,7 +4,7 @@
     [athens.db :as db]
     [athens.parse-renderer :as parse-renderer]
     [athens.router :refer [navigate-uid]]
-    [athens.style :refer [color ZINDICES]]
+    [athens.style :refer [color]]
     [athens.util :refer [now-ts]]
     [athens.views.blocks :refer [block-el]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
@@ -118,12 +118,9 @@
              (for [{:keys [node/title block/string] breadcrumb-uid :block/uid} parents]
                ^{:key breadcrumb-uid}
                [breadcrumb {:key (str "breadcrumb-" breadcrumb-uid)
-                            :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)}
-                [:span {:style {:position "relative"}}
-                 [:span {:style {:opacity 0
-                                 :width "100%"
-                                 :position "absolute"
-                                 :z-index (:zindex-dropdown ZINDICES)}} (or title string)]
+                            :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)
+                            :style {:position "relative"}}
+                [:span {:style {:pointer-events "none"}}
                  [parse-renderer/parse-and-render (or title string)]]]))]]
 
          ;; Header

--- a/src/cljs/athens/views/block_page.cljs
+++ b/src/cljs/athens/views/block_page.cljs
@@ -4,7 +4,7 @@
     [athens.db :as db]
     [athens.parse-renderer :as parse-renderer]
     [athens.router :refer [navigate-uid]]
-    [athens.style :refer [color]]
+    [athens.style :refer [color ZINDICES]]
     [athens.util :refer [now-ts]]
     [athens.views.blocks :refer [block-el]]
     [athens.views.breadcrumbs :refer [breadcrumbs-list breadcrumb]]
@@ -119,7 +119,12 @@
                ^{:key breadcrumb-uid}
                [breadcrumb {:key (str "breadcrumb-" breadcrumb-uid)
                             :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)}
-                [parse-renderer/parse-and-render (or title string)]]))]]
+                [:span {:style {:position "relative"}}
+                 [:span {:style {:opacity 0
+                                 :width "100%"
+                                 :position "absolute"
+                                 :z-index (:zindex-dropdown ZINDICES)}} (or title string)]
+                 [parse-renderer/parse-and-render (or title string)]]]))]]
 
          ;; Header
          [:h1 (merge


### PR DESCRIPTION
**Current behavior:** See https://github.com/athensresearch/athens/pull/972#issuecomment-820496888
**Expected behavior:** When clicking the parsed block reference or page reference on the breadcrumb, Athens should navigate to the block page only
**Solution**: Add an invisible element above the parsed content to prevent it from getting clicked.

![athens-972-comment](https://user-images.githubusercontent.com/8164667/115030305-87f5a480-9ef9-11eb-8b39-6898b14ebe71.gif)

