### PR TITLE
fix: Delete a block and "undo" cannot bring it back

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -420,8 +420,9 @@
           retract-vecs      (mapcat #(retract-uid-recursively %) sanitize-selected)
           reindex-last-selected-parent (delete-selected sanitize-selected)
           tx-data           (concat retract-vecs reindex-last-selected-parent)]
-      {:dispatch [:transact tx-data]
-       :db       (assoc db :selected/items [])})))
+      {:fx [[:dispatch [:transact tx-data]]
+            [:dispatch [:editing/uid nil]]]
+       :db (assoc db :selected/items [])})))
 
 
 ;; Alerts


### PR DESCRIPTION
fix #987 

**Current Behavior:** Given a deleted block/s (deleted by selection ie. the selection is indicated with blue highlight), when the user tries to undo the action, nothing happens.
**Expected Behavior:** Given a deleted block/s (deleted by selection ie. the selection is indicated with blue highlight), when the user tries to undo the action, the deleted block/s should be brought back.

**Problem:** The value of `:editing/uid` is the `uid` of the deleted block (or one of the deleted blocks if multiple blocks are deleted) which makes Athens "freeze" (I'm not sure what's the right word here). Undo for deleted blocks actually works when you click anywhere on Athens before trying to undo.
**Solution:** Update the `:editing/uid` to `nil` after deleting the selected blocks so the system won't "freeze".

![athens-987](https://user-images.githubusercontent.com/8164667/115314404-b698a700-a1a7-11eb-9493-5b6e636201b5.gif)

**Note:** When the deleted block is used in block embed, the block embed is not brought back after the undo because the `uid` of the block embed becomes "invalid" instead of the `uid` of the deleted block. I'll try to fix it separately.

![athens-987-block-embed](https://user-images.githubusercontent.com/8164667/115314807-869dd380-a1a8-11eb-8876-1e4be0fc5aef.gif)
