### PR TITLE
fix: ensure choose file input is visible in merge from roam dialog

### DIFF
--- a/src/cljs/athens/views/filesystem.cljs
+++ b/src/cljs/athens/views/filesystem.cljs
@@ -136,7 +136,7 @@
                     [button {:on-click close-modal}
                      [:> Close]]]
 
-         :content  [:div (use-style modal-contents-style)
+         :content  [:div (use-style (merge modal-contents-style {:height "20em"}))
                     (if (nil? @transformed-roam-db)
                       [:<>
                        [:input {:type "file" :accept ".edn" :on-change #(file-cb % transformed-roam-db roam-db-filename)}]


### PR DESCRIPTION
I recently pushed up some changes to the filesystem dialog and those changes inadvertently caused the "choose file" button in the import-from-roam dialog to be hidden.

This should fix that.