### PR TITLE
fix: use index.transit file if already exists

### DIFF
--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -215,15 +215,15 @@
     :local-storage/get-db-filepath
     [(inject-cofx :local-storage "db/filepath")
      (inject-cofx :local-storage-map {:ls-key "db/remote-graph-conf"
-                                      :key :remote-graph-conf})]
+                                      :key    :remote-graph-conf})]
     (fn [{:keys [local-storage remote-graph-conf]} _]
-     (let [default-db-path (.resolve path documents-athens-dir DB-INDEX)]
-       (cond
-         (some-> remote-graph-conf read-string :default?) {:dispatch [:start-socket]}
-         ;; No filepath in local storage, but an existing db suggests a dev chromium is running with a different local storage
-         ;; Short-circuit the first load and just use the existing DB
-         (and (nil? local-storage) (.existsSync fs default-db-path)) {:dispatch [:db/update-filepath default-db-path]}
-         :else {:dispatch [:db/update-filepath local-storage]}))))
+      (let [default-db-path (.resolve path documents-athens-dir DB-INDEX)]
+        (cond
+          (some-> remote-graph-conf read-string :default?) {:dispatch [:start-socket]}
+          ;; No filepath in local storage, but an existing db suggests a dev chromium is running with a different local storage
+          ;; Short-circuit the first load and just use the existing DB
+          (and (nil? local-storage) (.existsSync fs default-db-path)) {:dispatch [:db/update-filepath default-db-path]}
+          :else {:dispatch [:db/update-filepath local-storage]}))))
 
 
   (reg-event-fx

--- a/src/cljs/athens/electron.cljs
+++ b/src/cljs/athens/electron.cljs
@@ -31,6 +31,10 @@
   (def DB-INDEX "index.transit")
   (def IMAGES-DIR-NAME "images")
 
+  (def documents-athens-dir
+    (let [DOC-PATH (.getPath app "documents")]
+      (.resolve path DOC-PATH "athens")))
+
   ;;; Filesystem Dialogs
 
 
@@ -213,10 +217,13 @@
      (inject-cofx :local-storage-map {:ls-key "db/remote-graph-conf"
                                       :key :remote-graph-conf})]
     (fn [{:keys [local-storage remote-graph-conf]} _]
-      (if (some-> remote-graph-conf read-string
-                  :default?)
-        {:dispatch [:start-socket]}
-        {:dispatch [:db/update-filepath local-storage]})))
+     (let [default-db-path (.resolve path documents-athens-dir DB-INDEX)]
+       (cond
+         (some-> remote-graph-conf read-string :default?) {:dispatch [:start-socket]}
+         ;; No filepath in local storage, but an existing db suggests a dev chromium is running with a different local storage
+         ;; Short-circuit the first load and just use the existing DB
+         (and (nil? local-storage) (.existsSync fs default-db-path)) {:dispatch [:db/update-filepath default-db-path]}
+         :else {:dispatch [:db/update-filepath local-storage]}))))
 
 
   (reg-event-fx
@@ -224,11 +231,6 @@
     [(inject-cofx :local-storage "current-route/uid")]
     (fn [{:keys [local-storage]} _]
       {:dispatch [:navigate {:page {:id local-storage}}]}))
-
-
-  (def documents-athens-dir
-    (let [DOC-PATH (.getPath app "documents")]
-      (.resolve path DOC-PATH "athens")))
 
 
   (defn create-dir-if-needed!


### PR DESCRIPTION
**Current behavior:** When dev athens is launched for the first time, an `index.transit` file is created, overwriting the existing `index.transit` created by the production athens app.
**Expected behavior:** If dev athens is launched and does not have a filepath in local storage, it should check for the `index.transit` file at the default location

**Problem:** Dev athens and production athens use different instances of chromium, so they have different localstorages. App startup assumes that if there is no filepath in localstorage, it is absolutely the first time athens has been run, so it creates a new database at the default location, overwriting the existing database.
**Solution:** At startup, check for an `index.transit` file at the default location before creating a new database.