### PR TITLE
feat(blocks): improved visibility of hover/focus of block bullets

### DIFF
--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,9 +1,9 @@
 (ns athens.style
   (:require
-    [athens.config :as config]
-    [athens.util :as util]
-    [garden.color :refer [opacify hex->hsl]]
-    [stylefy.core :as stylefy]))
+   [athens.config :as config]
+   [athens.util :as util]
+   [garden.color :refer [opacify hex->hsl]]
+   [stylefy.core :as stylefy]))
 
 
 (def THEME-DARK
@@ -19,8 +19,6 @@
    :background-color    "#1A1A1A"
    :background-plus-1   "#222"
    :background-plus-2   "#333"
-
-   :shadow-color  "rgba(0,0,0,0.16)"
 
    :graph-control-bg    "#272727"
    :graph-control-color "white"
@@ -39,14 +37,11 @@
    :header-text-color   "#322F38"
    :body-text-color     "#433F38"
    :border-color        "hsla(32, 81%, 10%, 0.08)"
-   :background-plus-2   "#FFFFFF"
-   :background-plus-1   "#FFFFFF"
-   :background-color    "#FFFFFF"
+   :background-plus-2   "#fff"
+:background-plus-1   "#fbfbfb"
+:background-color    "#F6F6F6"
    :background-minus-1  "#FAF8F6"
    :background-minus-2  "#EFEDEB"
-
-   :shadow-color  "rgba(0,0,0,0.16)"
-
    :graph-control-bg    "#f9f9f9"
    :graph-control-color "black"
    :graph-node-normal   "#909090"
@@ -57,10 +52,10 @@
 
 
 (def DEPTH-SHADOWS
-  {:4  "0px 1.6px 3.6px rgba(0, 0, 0, 0.13), 0px 0.3px 0.9px rgba(0, 0, 0, 0.1)"
-   :8  "0px 3.2px 7.2px rgba(0, 0, 0, 0.13), 0px 0.6px 1.8px rgba(0, 0, 0, 0.1)"
-   :16 "0px 6.4px 14.4px rgba(0, 0, 0, 0.13), 0px 1.2px 3.6px rgba(0, 0, 0, 0.1)"
-   :64 "0px 24px 60px rgba(0, 0, 0, 0.15), 0px 5px 12px rgba(0, 0, 0, 0.1)"})
+  {:4  "0 2px 4px rgba(0, 0, 0, 0.2)"
+   :8  "0 4px 8px rgba(0, 0, 0, 0.2)"
+   :16 "0 4px 16px rgba(0, 0, 0, 0.2)"
+   :64 "0 24px 60px rgba(0, 0, 0, 0.2)"})
 
 
 (def OPACITIES

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -1,9 +1,9 @@
 (ns athens.style
   (:require
-   [athens.config :as config]
-   [athens.util :as util]
-   [garden.color :refer [opacify hex->hsl]]
-   [stylefy.core :as stylefy]))
+    [athens.config :as config]
+    [athens.util :as util]
+    [garden.color :refer [opacify hex->hsl]]
+    [stylefy.core :as stylefy]))
 
 
 (def THEME-DARK
@@ -38,8 +38,8 @@
    :body-text-color     "#433F38"
    :border-color        "hsla(32, 81%, 10%, 0.08)"
    :background-plus-2   "#fff"
-:background-plus-1   "#fbfbfb"
-:background-color    "#F6F6F6"
+   :background-plus-1   "#fbfbfb"
+   :background-color    "#F6F6F6"
    :background-minus-1  "#FAF8F6"
    :background-minus-2  "#EFEDEB"
    :graph-control-bg    "#f9f9f9"

--- a/src/cljs/athens/views/blocks/bullet.cljs
+++ b/src/cljs/athens/views/blocks/bullet.cljs
@@ -4,7 +4,6 @@
     [athens.router :as router]
     [athens.style :as style]
     [athens.views.blocks.context-menu :as context-menu]
-    [garden.selectors :as selectors]
     [goog.dom.classlist :as classList]
     [stylefy.core :as stylefy]))
 
@@ -17,25 +16,38 @@
    :position "relative"
    :z-index 2
    :cursor "pointer"
-   :width "0.75em"
    :margin-right "0.25em"
+   :appearance "none"
+   :border 0
+   :background "transparent"
    :transition "all 0.05s ease"
    :height "2em"
+   :width "1em"
    :color (style/color :body-text-color :opacity-low)
-   ::stylefy/mode [[:after {:content "''"
-                            :background "currentColor"
-                            :transition "all 0.05s ease"
-                            :border-radius "100px"
-                            :box-shadow "0 0 0 0.125rem transparent"
-                            :display "inline-flex"
-                            :margin "50% 0 0 50%"
-                            :transform "translate(-50%, -50%)"
-                            :height "0.3125em"
-                            :width "0.3125em"}]
-                   [:hover {:color (style/color :link-color)}]]
-   ::stylefy/manual [[:&.closed-with-children [(selectors/& (selectors/after)) {:box-shadow (str "0 0 0 0.125rem " (style/color :body-text-color))
-                                                                                :opacity (:opacity-med style/OPACITIES)}]]
-                     [:&.closed-with-children [(selectors/& (selectors/before)) {:content "none"}]]
+   ::stylefy/manual [[:&:after {:content "''"
+                                :background "currentColor"
+                                :transition "all 0.05s ease"
+                                :border-radius "100px"
+                                :box-shadow "0 0 0 0.125rem transparent"
+                                :display "inline-flex"
+                                :margin "50% 0 0 50%"
+                                :transform "translate(-50%, -50%)"
+                                :height "0.3125em"
+                                :width "0.3125em"}]
+                     [:&:before {:content "''"
+                                 :inset "0.25rem -0.125rem"
+                                 :z-index -1
+                                 :transition "opacity 0.1s ease"
+                                 :position "absolute"
+                                 :border-radius "0.25rem"
+                                 :box-shadow (:4 style/DEPTH-SHADOWS)
+                                 :opacity 0
+                                 :background (style/color :background-plus-2)}]
+                     [:&:hover {:color (style/color :link-color)}]
+                     [:&:hover:before
+                      :&:focus-visible:before {:opacity 1}]
+                     [:&.closed-with-children [:&:after {:box-shadow (str "0 0 0 0.125rem " (style/color :body-text-color))
+                                                         :opacity (:opacity-med style/OPACITIES)}]]
                      [:&:hover:after {:transform "translate(-50%, -50%) scale(1.3)"}]
                      [:&.dragging {:z-index 1
                                    :cursor "grabbing"
@@ -84,14 +96,15 @@
   [_ _ _]
   (fn [block state linked-ref]
     (let [{:block/keys [uid children open]} block]
-      [:span {:class           ["bullet" (when (and (seq children)
-                                                    (or (and (true? linked-ref) (not (:linked-ref/open @state)))
-                                                        (and (false? linked-ref) (not open))))
-                                           "closed-with-children")]
-              :draggable       true
-              :on-click        (fn [e] (router/navigate-uid uid e))
-              :on-context-menu (fn [e] (context-menu/bullet-context-menu e uid state))
-              :on-mouse-over   (fn [e] (bullet-mouse-over e uid state)) ;; useful during development to check block meta-data
-              :on-mouse-out    (fn [e] (bullet-mouse-out e uid state))
-              :on-drag-start   (fn [e] (bullet-drag-start e uid state))
-              :on-drag-end     (fn [e] (bullet-drag-end e uid state))}])))
+      [:button {:class           ["bullet" (when (and (seq children)
+                                                      (or (and (true? linked-ref) (not (:linked-ref/open @state)))
+                                                          (and (false? linked-ref) (not open))))
+                                             "closed-with-children")]
+                :tab-index 0
+                :draggable       true
+                :on-click        (fn [e] (router/navigate-uid uid e))
+                :on-context-menu (fn [e] (context-menu/bullet-context-menu e uid state))
+                :on-mouse-over   (fn [e] (bullet-mouse-over e uid state)) ;; useful during development to check block meta-data
+                :on-mouse-out    (fn [e] (bullet-mouse-out e uid state))
+                :on-drag-start   (fn [e] (bullet-drag-start e uid state))
+                :on-drag-end     (fn [e] (bullet-drag-end e uid state))}])))

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -39,7 +39,7 @@
    ::stylefy/manual [[:&.show-tree-indicator:before {:content "''"
                                                      :position "absolute"
                                                      :width "1px"
-                                                     :left "calc(1.25em + 1px)"
+                                                     :left "calc(1.375em + 1px)"
                                                      :top "2em"
                                                      :bottom "0"
                                                      :transform "translateX(50%)"

--- a/src/cljs/athens/views/blocks/toggle.cljs
+++ b/src/cljs/athens/views/blocks/toggle.cljs
@@ -18,12 +18,23 @@
    :transition "all 0.05s ease"
    :align-items "center"
    :justify-content "center"
+   :cursor "pointer"
    :padding "0"
    :-webkit-appearance "none"
    :color (style/color :body-text-color :opacity-med)
-   ::stylefy/mode [[:hover {:color (style/color :link-color)}]
-                   [":is(button)" {:cursor "pointer"}]]
-   ::stylefy/manual [[:&.closed [:svg {:transform "rotate(-90deg)"}]]
+   ::stylefy/manual [[:&:hover {:color (style/color :link-color)}]
+                     [:&:before {:content "''"
+                                 :inset "0.25rem -0.125rem"
+                                 :z-index -1
+                                 :position "absolute"
+                                 :transition "opacity 0.1s ease"
+                                 :border-radius "0.25rem"
+                                 :box-shadow (:4 style/DEPTH-SHADOWS)
+                                 :opacity 0
+                                 :background (style/color :background-plus-2)}]
+                     [:&:hover:before
+                      :&:focus-visible:before {:opacity 1}]
+                     [:&.closed [:svg {:transform "rotate(-90deg)"}]]
                      [:&:empty {:pointer-events "none"}]]})
 
 
@@ -40,6 +51,7 @@
                                                    (and (false? linked-ref) open))
                                              "open"
                                              "closed")
+                                 :tab-index 0
                                  :on-click (fn [_]
                                              (if (true? linked-ref)
                                                (swap! state update :linked-ref/open not)


### PR DESCRIPTION
- This PR includes changes to the base light theme
    - Slightly darker base background color(!)
    - Improved color scaling from base background to lighter backgrounds
- Addresses Improved visual indication of hover of bullets and toggles #1016
- Slightly more clickable area given to block bullets
  - Note: highlight is slightly larger than actual mouseable area

<img width="1216" alt="Screen Shot 2021-04-26 at 9 40 26 PM" src="https://user-images.githubusercontent.com/98312/116172060-057a9b00-a6d8-11eb-9519-a757cb17ba68.png">