### PR TITLE
fix(breadcrumbs): limit breadcrumb size

### DIFF
--- a/src/cljs/athens/views/breadcrumbs.cljs
+++ b/src/cljs/athens/views/breadcrumbs.cljs
@@ -37,7 +37,13 @@
    :transition "all 0.3s ease"
    ::stylefy/manual [[:a {:text-decoration "none"
                           :cursor "pointer"
+                          :position "relative"
                           :color "inherit"}]
+                     [:* {:display "inline"
+                          :pointer-events "none"
+                          :margin 0
+                          :padding 0
+                          :font-size "inherit"}]
                      [:&:last-child {:color (color :body-text-color)}]
                      [:&:hover {:flex-shrink "0"
                                 :color (color :link-color)}]

--- a/src/cljs/athens/views/breadcrumbs.cljs
+++ b/src/cljs/athens/views/breadcrumbs.cljs
@@ -40,7 +40,6 @@
                           :position "relative"
                           :color "inherit"}]
                      [:* {:display "inline"
-                          :pointer-events "none"
                           :margin 0
                           :padding 0
                           :font-size "inherit"}]

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -119,7 +119,8 @@
                ^{:key breadcrumb-uid}
                [breadcrumb {:key (str "breadcrumb-" breadcrumb-uid)
                             :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)}
-                [parse-renderer/parse-and-render (or title string)]]))]]
+                [:span {:style {:pointer-events "none"}}
+                 [parse-renderer/parse-and-render (or title string)]]]))]]
 
          ;; Header
          [:h1 (merge

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -118,10 +118,8 @@
              (for [{:keys [node/title block/string] breadcrumb-uid :block/uid} parents]
                ^{:key breadcrumb-uid}
                [breadcrumb {:key (str "breadcrumb-" breadcrumb-uid)
-                            :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)
-                            :style {:position "relative"}}
-                [:span {:style {:pointer-events "none"}}
-                 [parse-renderer/parse-and-render (or title string)]]]))]]
+                            :on-click #(breadcrumb-handle-click % uid breadcrumb-uid)}
+                [parse-renderer/parse-and-render (or title string)]]))]]
 
          ;; Header
          [:h1 (merge


### PR DESCRIPTION
- Make all breadcrumbs inherit their text size, and have no margin or padding #1014 
- Minor refactor of breadcrumb styling to remove excess DOM elements