### PR TITLE
fix: when block-embed is deleted, replace with content instead of "invalid"

### DIFF
--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -107,6 +107,6 @@
                                       (.. e stopPropagation)
                                       (dispatch [:editing/uid uid]))}])])])
       ;; roam actually hides the brackets around [[embed]]
-      [:span "{{" (str/replace content block-uid "invalid") "}}"])))
+      [:span "{{" content "}}"])))
 
 


### PR DESCRIPTION
Expected Outcome: Given a block embed, when the user deleted the referred block, then the block embed should display the `uid`.
Current Outcome: ...the block embed uid becomes `invalid`

Problem: The block embed is set to show `invalid`
Solution: Show the `content` instead of invalid
Not solved yet: Users need to refresh or re-edit the block-embed to re-render it.
![athens-1093](https://user-images.githubusercontent.com/8164667/116690762-71b51180-a9ec-11eb-9570-d395050f0b61.gif)


