### PR TITLE
fix: Removal of a daily journal page creates a 404

### DIFF
--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -395,11 +395,11 @@
                       [:> BubbleChart]
                       [:span "Show Local Graph"]]]]
                    [:hr (use-style menu-separator-style)]
-                   [button {:on-click #(if daily-note?
-                                         (dispatch [:daily-note/delete uid title])
-                                         (do
-                                           (navigate :pages)
-                                           (dispatch [:page/delete uid title])))}
+                   [button {:on-click #(do
+                                         (if daily-note?
+                                           (dispatch [:daily-note/delete uid title])
+                                           (dispatch [:page/delete uid title]))
+                                         (navigate :pages))}
                     [:<> [:> Delete] [:span "Delete Page"]]]]]])))
 
 
@@ -554,7 +554,7 @@
          [:header (use-style page-header-style)
 
           ;; Dropdown
-          [menu-dropdown node state daily-note?]
+          [menu-dropdown node daily-note?]
 
           [:h1 (use-style title-style
                           {:data-uid uid


### PR DESCRIPTION
fix #1022 (reported in v1.0.0-beta.74, reproduced in v1.0.0-beta.78 as well)

expected outcome: Given a page, when the user deletes it, then Athens should re-direct to the list of pages
current outcome: ...Athens re-directs to 404

1. For daily notes page
Problems: No re-direct to the list of pages
Solution: Ensure that Athens will navigate to the list of pages of deleting a page

![athens-1022-daily-del](https://user-images.githubusercontent.com/8164667/116703784-3e2eb300-a9fd-11eb-8ee4-675334e4750d.gif)

2. For non-daily notes page
Problem: `state` is passed to `menu-dropdown` instead of `daily-note?` as a 2nd argument which makes the check for `daily-note?` always true.
Solution: Remove the `state` argument

![athens-1022-page-del](https://user-images.githubusercontent.com/8164667/116703807-4555c100-a9fd-11eb-8532-27e8f56a3f89.gif)
