### PR TITLE
feat: fuzzy search

### DIFF
--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -4,7 +4,7 @@
     ["@material-ui/icons/Close" :default Close]
     ["@material-ui/icons/Create" :default Create]
     ["@material-ui/icons/Search" :default Search]
-    [athens.db :as db :refer [search-exact-node-title re-case-insensitive fuzzy-search]]
+    [athens.db :as db :refer [re-case-insensitive fuzzy-search]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
     [athens.subs]

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -171,8 +171,10 @@
                                :results []})
                 (reset! state {:index   0
                                :query   query
-                               :results (into [(search-exact-node-title query)]
-                                              (fuzzy-search query))})))
+                               :results (let [search-result (fuzzy-search query)] ; remove this. check the first item in fuzzy instead. if not exact, append nil 
+                                          (if (= query (first search-result))
+                                            search-result
+                                            (into [nil] search-result)))})))
             300))
 
 

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -4,7 +4,7 @@
     ["@material-ui/icons/Close" :default Close]
     ["@material-ui/icons/Create" :default Create]
     ["@material-ui/icons/Search" :default Search]
-    [athens.db :as db :refer [search-in-block-content search-exact-node-title search-in-node-title re-case-insensitive]]
+    [athens.db :as db :refer [search-exact-node-title re-case-insensitive fuzzy-search]]
     [athens.router :refer [navigate-uid]]
     [athens.style :refer [color DEPTH-SHADOWS OPACITIES ZINDICES]]
     [athens.subs]
@@ -151,7 +151,6 @@
 
 ;;; Utilities
 
-
 (defn highlight-match
   [query txt]
   (let [query-pattern (re-case-insensitive (str "((?<=" query ")|(?=" query "))"))]
@@ -172,11 +171,9 @@
                                :results []})
                 (reset! state {:index   0
                                :query   query
-                               :results (->> (concat [(search-exact-node-title query)]
-                                                     (search-in-node-title query 20 true)
-                                                     (search-in-block-content query))
-                                             vec)})))
-            1000))
+                               :results (into [(search-exact-node-title query)]
+                                              (fuzzy-search query))})))
+            300))
 
 
 (defn key-down-handler


### PR DESCRIPTION
Posting this for feedback especially for performance improvement and/or better approach to fuzzy search.

Trying to solve https://github.com/athensresearch/athens/issues/756 + better search result

Currently tested in Athena only.

In terms of speed, search result returns in <200ms on my PC and db that's why the `debounce` is reduced.

More importantly, this will help the user find the notes that they're looking for even if they provided an inexact phrase.
![image](https://user-images.githubusercontent.com/8164667/116770576-96a29680-aa77-11eb-9a6a-e97d6cff5125.png)
![image](https://user-images.githubusercontent.com/8164667/116770581-a4f0b280-aa77-11eb-9a88-c232091e1d64.png)

The code is adapted from https://gist.github.com/vaughnd/5099299

TODO
- [ ] add to `(())`
- [ ] include exact search for blocks
