### PR TITLE
enhance(all-pages): allow sort by titles / links / times

### DIFF
--- a/src/cljs/athens/devcards/blocks.cljs
+++ b/src/cljs/athens/devcards/blocks.cljs
@@ -1,6 +1,6 @@
 (ns athens.devcards.blocks
   (:require
-    [athens.views.core :refer [block-component]]
+    [athens.views.blocks.core :refer [block-component]]
     [devcards.core :refer-macros [defcard-rg]]))
 
 

--- a/src/cljs/athens/devcards/parser.cljs
+++ b/src/cljs/athens/devcards/parser.cljs
@@ -2,7 +2,7 @@
   (:require
     #_[athens.parse-renderer :refer [parse-and-render]]
     #_[athens.parser :refer [parse-to-ast combine-adjacent-strings]]
-    [athens.views.core :refer [block-el]]
+    [athens.views.blocks.core :refer [block-el]]
     #_[cljs.test :refer [is testing are async]]
     [cljsjs.react]
     [cljsjs.react.dom]

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -136,4 +136,4 @@
                 [:td {:class "links"} (count _refs)]
                 [:td {:class "body-preview"} (preview-body children)]
                 [:td {:class "date"} (date-string modified)]
-                [
+                [:td {:class "date"} (date-string created)]]))]]]))))

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -10,7 +10,7 @@
     [garden.selectors :as selectors]
     [posh.reagent :as p]
     [reagent.core :as r]
-    [stylefy.core :as stylefy :refer [use-style use-sub-style]]))
+    [stylefy.core :as stylefy :refer [use-style]]))
 
 
 ;;; Styles
@@ -91,8 +91,8 @@
           [:th [:h5 "Title"]]
           [:th [:h5 "Links"]]
           [:th [:h5 "Body"]]
-          [:th (use-sub-style table-style :th-date) [:h5 "Modified"]]
-          [:th (use-sub-style table-style :th-date) [:h5 "Created"]]]]
+          [:th [:h5 "Modified"]]
+          [:th [:h5 "Created"]]]]
         [:tbody
          (doall
            (for [page @pages]

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -6,6 +6,7 @@
     [athens.util :refer [date-string]]
     [cljsjs.react]
     [cljsjs.react.dom]
+    [clojure.string :refer [lower-case]]
     [datascript.core :as d]
     [garden.selectors :as selectors]
     [posh.reagent :as p]
@@ -72,34 +73,49 @@
 
 ;;; Components
 
+(def sort-fn
+  {:title       (fn [x] (-> x :node/title lower-case))
+   :links-count (fn [x] (count (:block/_refs x)))
+   :modified    :edit/time
+   :created     :create/time})
 
 (defn page
   []
-  (let [pages (r/atom (->> (d/q '[:find [?e ...]
-                                  :where
-                                  [?e :node/title ?t]]
-                                @db/dsdb)
-                           (p/pull-many db/dsdb '["*" :block/_refs {:block/children [:block/string] :limit 5}])
-                           deref
-                           (sort-by (fn [x] (count (:block/_refs x))))
-                           reverse))]
+  (let [sorted-by   (r/atom :links-count)
+        growing?    (r/atom false)
+        flip-order! #(swap! growing? not)
+        sort!       (fn [column]
+                      (if (= @sorted-by column)
+                        (flip-order!)
+                        (do (reset! sorted-by column)
+                            (reset! growing? false))))
+        pages       (->> (d/q '[:find [?e ...]
+                                :where
+                                [?e :node/title ?t]]
+                              @db/dsdb)
+                         (p/pull-many db/dsdb '["*" :block/_refs {:block/children [:block/string] :limit 5}])
+                         deref)]
     (fn []
-      [:div (use-style page-style)
-       [:table (use-style table-style)
-        [:thead
-         [:tr
-          [:th [:h5 "Title"]]
-          [:th [:h5 "Links"]]
-          [:th [:h5 "Body"]]
-          [:th [:h5 "Modified"]]
-          [:th [:h5 "Created"]]]]
-        [:tbody
-         (doall
-           (for [page @pages]
-             (let [{:keys [block/uid node/title block/children block/_refs] modified :edit/time created :create/time} page]
-               [:tr {:key uid}
-                [:td {:class "title" :on-click #(navigate-uid uid %)} title]
-                [:td {:class "links"} (count _refs)]
-                [:td {:class "body-preview"} (map (fn [child] [:span (:block/string child)]) children)]
-                [:td {:class "date"} (date-string modified)]
-                [:td {:class "date"} (date-string created)]])))]]])))
+      (let [sorted-pages (sort-by (get sort-fn @sorted-by)
+                                  (if @growing? compare (comp - compare))
+                                  pages)]
+        [:div (use-style page-style)
+         [:table (use-style table-style)
+          [:thead
+           [:tr
+            [:th {:on-click #(sort! :title)} [:h5 "Title"]]
+            [:th {:on-click #(sort! :links-count)} [:h5 "Links"]]
+            [:th [:h5 "Body"]]
+            [:th {:on-click #(sort! :modified)} [:h5 "Modified"]]
+            [:th {:on-click #(sort! :created)} [:h5 "Created"]]]]
+          [:tbody
+           (doall
+            (for [{:keys [block/uid node/title block/children block/_refs]
+                   modified :edit/time
+                   created :create/time} sorted-pages]
+              [:tr {:key uid}
+               [:td {:class "title" :on-click #(navigate-uid uid %)} title]
+               [:td {:class "links"} (count _refs)]
+               [:td {:class "body-preview"} (map (fn [child] [:span (:block/string child)]) children)]
+               [:td {:class "date"} (date-string modified)]
+               [:td {:class "date"} (date-string created)]]))]]]))))

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -78,17 +78,20 @@
 
 ;;; Components
 
-(defn- preview-body [block-children]
+(defn- preview-body
+  [block-children]
   (map (fn [{:keys [db/id block/string]}]
          ^{:key id}
          [:span string])
        block-children))
+
 
 (def sort-fn
   {:title       (fn [x] (-> x :node/title lower-case))
    :links-count (fn [x] (count (:block/_refs x)))
    :modified    :edit/time
    :created     :create/time})
+
 
 (defn page
   []
@@ -125,12 +128,12 @@
                   :on-click #(sort! :created)} [:h5 "Created"]]]]
           [:tbody
            (doall
-            (for [{:keys [block/uid node/title block/children block/_refs]
-                   modified :edit/time
-                   created :create/time} sorted-pages]
-              [:tr {:key uid}
-               [:td {:class "title" :on-click #(navigate-uid uid %)} title]
-               [:td {:class "links"} (count _refs)]
-               [:td {:class "body-preview"} (preview-body children)]
-               [:td {:class "date"} (date-string modified)]
-               [:td {:class "date"} (date-string created)]]))]]]))))
+             (for [{:keys [block/uid node/title block/children block/_refs]
+                    modified :edit/time
+                    created :create/time} sorted-pages]
+               [:tr {:key uid}
+                [:td {:class "title" :on-click #(navigate-uid uid %)} title]
+                [:td {:class "links"} (count _refs)]
+                [:td {:class "body-preview"} (preview-body children)]
+                [:td {:class "date"} (date-string modified)]
+                [

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -68,7 +68,12 @@
                         [:td [:&:first-child {:box-shadow [["-1rem 0 " (color :background-minus-1 :opacity-med)]]}]]
                         [:td [:&:last-child {:box-shadow [["1rem 0 " (color :background-minus-1 :opacity-med)]]}]]]]]
                      [:td :th {:padding "0.5rem"}]
-                     [:th [:h5 {:opacity (:opacity-med OPACITIES)}]]]})
+                     [:th [:h5 {:opacity (:opacity-med OPACITIES)
+                                :user-select "none"}]
+                      [:&.sortable
+                       [:h5 {:cursor "pointer"}
+                        [:&:hover {:opacity 1}]]]
+                      [:&.date {:text-align "end"}]]]})
 
 
 ;;; Components
@@ -109,11 +114,15 @@
          [:table (use-style table-style)
           [:thead
            [:tr
-            [:th {:on-click #(sort! :title)} [:h5 "Title"]]
-            [:th {:on-click #(sort! :links-count)} [:h5 "Links"]]
+            [:th {:class "sortable"
+                  :on-click #(sort! :title)} [:h5 "Title"]]
+            [:th {:class "sortable"
+                  :on-click #(sort! :links-count)} [:h5 "Links"]]
             [:th [:h5 "Body"]]
-            [:th {:on-click #(sort! :modified)} [:h5 "Modified"]]
-            [:th {:on-click #(sort! :created)} [:h5 "Created"]]]]
+            [:th {:class "sortable date"
+                  :on-click #(sort! :modified)} [:h5 "Modified"]]
+            [:th {:class "sortable date"
+                  :on-click #(sort! :created)} [:h5 "Created"]]]]
           [:tbody
            (doall
             (for [{:keys [block/uid node/title block/children block/_refs]

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -73,6 +73,12 @@
 
 ;;; Components
 
+(defn- preview-body [block-children]
+  (map (fn [{:keys [db/id block/string]}]
+         ^{:key id}
+         [:span string])
+       block-children))
+
 (def sort-fn
   {:title       (fn [x] (-> x :node/title lower-case))
    :links-count (fn [x] (count (:block/_refs x)))
@@ -116,6 +122,6 @@
               [:tr {:key uid}
                [:td {:class "title" :on-click #(navigate-uid uid %)} title]
                [:td {:class "links"} (count _refs)]
-               [:td {:class "body-preview"} (map (fn [child] [:span (:block/string child)]) children)]
+               [:td {:class "body-preview"} (preview-body children)]
                [:td {:class "date"} (date-string modified)]
                [:td {:class "date"} (date-string created)]]))]]]))))


### PR DESCRIPTION
close #669 

This is a minimal implementation of the feature.

### Needs improvement

1.  Show a triangle icon just before or after the column header that is actively sorted by. The icon should represent the current sorting direction: :small_red_triangle: :small_red_triangle_down: 
No triangle is visible in other columns.

2. Store `sorted-by` and `growing?` state into re-frame layer instead of local ratoms. So that the sorting preferences are maintained when the user is leaving "All pages" then coming back to it.