### PR TITLE
fix: redo incorrectly does undo

### DIFF
--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -476,10 +476,6 @@
                                                                                       (sort-by :block/order)
                                                                                       (mapv :block/uid))]
                                                           (dispatch [:selected/add-items children]))
-      ;; When undo no longer makes changes for local textarea, do datascript undo.
-      (= key-code KeyCodes.Z) (let [{:string/keys [local previous]} @state]
-                                (when (= local previous)
-                                  (dispatch [:undo])))
 
       (= key-code KeyCodes.B) (surround-and-set "**")
 


### PR DESCRIPTION
There's still a small bit of undesirable behaviour* but undo/redo will mostly work as expected and won't cause any data to be lost permanently.

From what I can see, the history of the text that's typed into a block is stored in electrons undo/reo history while we track the history of the blocks on the page in an `atom`. The swap from electrons history to the block history `atom` when an undo action no longer makes changes is where the bug is.

To properly fix this I think we'll need to move away from electrons undo/redo history to have better control over the undo/redo actions to make the experience smoother and more predictable. This feels like scope creep for this issue though! #1004 

I think I've seen some discussion around implementing a new text area, maybe they come with undo/redo functionality builtin or via plugins?

*constantly hitting undo on an empty block queues up each 'undo' action so you need to redo each 'undo' before you start seeing changes
*once the cursor leaves a block then its history is lost and undo/redo doesn't do anything when the cursor returns to the same block