### PR TITLE
enhance(left-sidebar): clicking on the logo opens to issue creation rather than main repo

### DIFF
--- a/src/cljs/athens/views/left_sidebar.cljs
+++ b/src/cljs/athens/views/left_sidebar.cljs
@@ -169,7 +169,7 @@
 
        ;; LOGO + BOTTOM BUTTONS
       [:footer (use-sub-style left-sidebar-style :footer)
-       [:a (use-style notional-logotype-style {:href "https://github.com/athensresearch/athens" :target "_blank"}) "Athens"]
+       [:a (use-style notional-logotype-style {:href "https://github.com/athensresearch/athens/issues/new/choose" :target "_blank"}) "Athens"]
        [:h5 (use-style {:align-self "center"})
         [:a (use-style version-style {:href "https://github.com/athensresearch/athens/blob/master/CHANGELOG.md"
                                       :target "_blank"})


### PR DESCRIPTION
Clicking on the logo in the left sidebar will go to https://github.com/athensresearch/athens/issues/new/choose rather than https://github.com/athensresearch/athens/ allowing for the user to more easily be able to create a bug report. 

Idea from https://discord.com/channels/708122962422792194/708122962905006203/840610093438730252. Thanks to @seekanddefine 