### PR TITLE
ci: cache cljstyle and add alias to lein

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,17 @@ jobs:
            fetch-depth: 1
            submodules: 'true'
 
+       - name: Cache deps
+         uses: actions/cache@v1
+         id: cache-deps-style
+         with:
+           path: ~/.m2/repository
+           key: ${{ runner.os }}-maven-style-${{ hashFiles('project.clj') }}
+
+       - name: Fetch deps
+         if: steps.cache-deps-style.outputs.cache-hit != 'true'
+         run: lein with-profile cljstyle deps
+
        - name: Style
          run: script/style
 

--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,8 @@
             "gh-pages"     ["shell" "yarn" "gh-pages" "-d" "resources/public"]
             "karma"        ["do"
                             ["run" "-m" "shadow.cljs.devtools.cli" "compile" "karma-test"]
-                            ["shell" "yarn" "run" "karma" "start" "--single-run" "--reporters" "junit,dots"]]}
+                            ["shell" "yarn" "run" "karma" "start" "--single-run" "--reporters" "junit,dots"]]
+            "cljstyle"     ["with-profile" "+cljstyle" "run" "-m" "cljstyle.main"]}
 
   :profiles
   {:dev
@@ -74,6 +75,8 @@
 
     :source-paths ["dev"]}
    :prod
-   {:dependencies [[day8.re-frame/tracing-stubs "0.5.3"]]}}
+   {:dependencies [[day8.re-frame/tracing-stubs "0.5.3"]]}
+   :cljstyle {:dependencies
+              [[mvxcvi/cljstyle "0.14.0" :exclusions [org.clojure/clojure]]]}}
 
   :prep-tasks [])

--- a/script/style
+++ b/script/style
@@ -2,11 +2,4 @@
 
 set -eo pipefail
 
-# This script depends on cljstyle. Installation instructions for cljstyle are linked to in CONTRIBUTING.md.
-
-# REVIEW consider rewriting to babashka to make platform independent?
-
-curl -L -O https://github.com/greglook/cljstyle/releases/download/0.14.0/cljstyle_0.14.0_linux.tar.gz
-tar -zxvf cljstyle_0.14.0_linux.tar.gz
-
-./cljstyle check
+lein cljstyle check --report


### PR DESCRIPTION
Downloading cljstyle binary and running it takes just **11s** in GH actions.
Running the style job with `lein cljstyle` takes **30s** when the deps are already cached:
https://github.com/Em-AK/athens/actions/runs/825896007

I let you judge if this is a blocker.