### PR TITLE
enhance(daily-notes): Shorter debounce time for loading of daily pages

### DIFF
--- a/src/cljs/athens/views/pages/daily_notes.cljs
+++ b/src/cljs/athens/views/pages/daily_notes.cljs
@@ -62,7 +62,7 @@
       (< bottom-delta 1) (dispatch [:daily-note/next (get-day (uid-to-date (last daily-notes)) 1)]))))
 
 
-(def db-scroll-daily-notes (debounce scroll-daily-notes 500))
+(def db-scroll-daily-notes (debounce scroll-daily-notes 100))
 
 
 (defn safe-pull-many


### PR DESCRIPTION
Simplified from https://github.com/athensresearch/athens/pull/1061.

https://github.com/athensresearch/athens/pull/1061 also made the loading start before the user scrolls to the very bottom, but @tangjeff0 asked to just reduce the debounce timer for now.