### PR TITLE
fix(keybindings): destructive undo/redo on mac/windows

### DIFF
--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -444,7 +444,7 @@
 ;; TODO: put text caret in correct position
 (defn handle-shortcuts
   [e uid state]
-  (let [{:keys [key-code head tail selection start end target value]} (destruct-key-down e)
+  (let [{:keys [key-code head tail selection start end target value shift]} (destruct-key-down e)
         selection?       (not= start end)
 
         surround-and-set (fn [surround-text]
@@ -479,7 +479,9 @@
       ;; When undo no longer makes changes for local textarea, do datascript undo.
       (= key-code KeyCodes.Z) (let [{:string/keys [local previous]} @state]
                                 (when (= local previous)
-                                  (dispatch [:undo])))
+                                  (if shift
+                                    (dispatch [:redo])
+                                    (dispatch [:undo]))))
 
       (= key-code KeyCodes.B) (surround-and-set "**")
 


### PR DESCRIPTION
close #1004 
close #1127

Thank you for looking into this @kamalmarhubi and @ssjoleary. 

Undo/redo isn't exactly intuitive from a code perspective. Let me walk through what is happening for future reference.

To recap:
- Undo is `ctrl-z` on Linux and Windows, `cmd-z` on Mac.
- Redo is `cmd-shift-z` on Linux and Windows, `cmd-shift-z` on Mac.

There are two cases:
1. User hits undo/redo when not focused on a block 
1. User hits undo/redo in a block

Focus is mapped towards or re-frame key `:editing/uid`. `:editing/uid` does a lot inside Athens, and should probably be documented thoroughly eventually. Right now the important part is how keybindings are handled with respect to it.

### Case 1: Block is not focused

This is defined in `listeners.cljs` because global DOM key events must be listened to. If there is no block in focus (`:editing/uid` is `nil`), then user should undo (no shift) or redo (shift). 

https://github.com/athensresearch/athens/blob/a64025a3abd9b1ceaa6b1ebd246f06f9f9a79038/src/cljs/athens/listeners.cljs#L91-L98

### Case 2: A block is focused

Defined in `keybindings.cljs` because only relevant when a textarea is focused.

If a block is focused and the previous string is equal to the current string, that means the history of changes managed by HTML textarea is empty. That means we should try to undo datascript at this point, since textarea undo doesn't do anything. However, the shift case is not being handled, therefore undo always tries to happen.

https://github.com/athensresearch/athens/blob/640420f8fa81ccf88b0a3dc73b55f89949e91a87/src/cljs/athens/views/blocks/textarea_keydown.cljs#L479-L482

### Addendum

- Manually checking for `shift` is a pain. The other place where we have a keybinding that is both normal and `shift` bindings is `ctrl-o`/`ctrl-shift-o`. But because this is a routing level thing, I let `navigate-uid` handle the shift. This is inconsistent and probably bad. Another issue: for all the other keybindings, you could hold `shift` and they would still work. I believe using a Keybinding library would solve this issue of manually checking for shift. #625

https://github.com/athensresearch/athens/blob/a64025a3abd9b1ceaa6b1ebd246f06f9f9a79038/src/cljs/athens/router.cljs#L118-L133

- Even with a keybindings library, I think there is still some mental gymnastics required to have keybindings play well at the local and global level. I think [re-pressed](https://github.com/gadfly361/re-pressed) tries to handle this - might be a helpful resource whether we use it or not.