### PR TITLE
perf(search): faster search for (()), [[]] and ctrl-k

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -417,11 +417,11 @@
            case-insensitive-query (re-case-insensitive query)]
        (sequence
          (comp
-           (map #(d/entity @dsdb (:e %)))
            (filter (every-pred
-                     #(not= exact-match (:node/title %))
-                     #(re-find case-insensitive-query (:node/title %))))
-           (take n))
+                     #(not= exact-match (:v %))
+                     #(re-find case-insensitive-query (:v %))))
+           (take n)
+           (map #(d/entity @dsdb (:e %))))
          (d/datoms @dsdb :aevt :node/title))))))
 
 

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -1,12 +1,12 @@
 (ns athens.db
   (:require
-    [athens.patterns :as patterns]
-    [athens.util :refer [escape-str]]
-    [clojure.edn :as edn]
-    [clojure.string :as string]
-    [datascript.core :as d]
-    [posh.reagent :refer [posh! pull q]]
-    [re-frame.core :refer [dispatch]]))
+   [athens.patterns :as patterns]
+   [athens.util :refer [escape-str]]
+   [clojure.edn :as edn]
+   [clojure.string :as string]
+   [datascript.core :as d]
+   [posh.reagent :refer [posh! pull q]]
+   [re-frame.core :refer [dispatch]]))
 
 
 ;; -- Example Roam DBs ---------------------------------------------------
@@ -416,14 +416,14 @@
      (let [exact-match            (when exclude-exact-match? query)
            case-insensitive-query (re-case-insensitive query)]
        (sequence
-         (comp
-           (filter (every-pred
-                     #(not= exact-match (:v %))
-                     #(re-find case-insensitive-query (:v %))))
-           (take n)
-           (map #(d/entity @dsdb (:e %))))
-         (d/datoms @dsdb :aevt :node/title))))))
-
+        (comp
+         (filter (every-pred
+                  #(re-find case-insensitive-query (:v %))
+                  #(not= exact-match (:v %))))
+         (take n)
+         (map #(d/entity @dsdb (:e %))))
+        (d/datoms @dsdb :aevt :node/title))))))
+        
 
 (defn get-root-parent-node
   [block]
@@ -442,17 +442,17 @@
      (vector)
      (let [case-insensitive-query (re-case-insensitive query)]
        (->>
-         (d/datoms @dsdb :aevt :block/string)
-         (sequence
-           (comp
-             (filter #(re-find case-insensitive-query (:v %)))
-             (take n)
-             (map #(:e %))))
-         (d/pull-many @dsdb '[:db/id :block/uid :block/string :node/title {:block/_children ...}])
-         (sequence
-           (comp
-             (keep get-root-parent-node)
-             (map #(dissoc % :block/_children)))))))))
+        (d/datoms @dsdb :aevt :block/string)
+        (sequence
+         (comp
+          (filter #(re-find case-insensitive-query (:v %)))
+          (take n)
+          (map #(:e %))))
+        (d/pull-many @dsdb '[:db/id :block/uid :block/string :node/title {:block/_children ...}])
+        (sequence
+         (comp
+          (keep get-root-parent-node)
+          (map #(dissoc % :block/_children)))))))))
 
 
 (defn nth-sibling
@@ -578,9 +578,9 @@
                            ref-ids)
         blocks (map (fn [id] (get-block-document id)) ref-ids)]
     (mapv
-      (fn [block]
-        (merge block {:block/parents (get parents (:db/id block))}))
-      blocks)))
+     (fn [block]
+       (merge block {:block/parents (get parents (:db/id block))}))
+     blocks)))
 
 
 (defn group-by-parent

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -410,18 +410,18 @@
 (defn search-in-node-title
   ([query] (search-in-node-title query 20 false))
   ([query n] (search-in-node-title query n false))
-  ([query n ignore-dup]
+  ([query n ignore-exact-match?]
    (if (string/blank? query)
      (vector)
-     (let [ignore-dup             (when ignore-dup query)
+     (let [exact-match            (when ignore-exact-match? query)
            case-insensitive-query (re-case-insensitive query)]
        (sequence
          (comp
-           (filter #(re-find case-insensitive-query (:v %)))
-           (filter #(not= (:v %) ignore-dup))
-           (take n)
-           (map #(:e %))
-           (map #(d/entity @dsdb %)))
+           (map #(d/entity @dsdb (:e %)))
+           (filter (every-pred
+                     #(not= exact-match (:node/title %))
+                     #(re-find case-insensitive-query (:node/title %))))
+           (take n))
          (d/datoms @dsdb :aevt :node/title))))))
 
 

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -1,12 +1,12 @@
 (ns athens.db
   (:require
-   [athens.patterns :as patterns]
-   [athens.util :refer [escape-str]]
-   [clojure.edn :as edn]
-   [clojure.string :as string]
-   [datascript.core :as d]
-   [posh.reagent :refer [posh! pull q]]
-   [re-frame.core :refer [dispatch]]))
+    [athens.patterns :as patterns]
+    [athens.util :refer [escape-str]]
+    [clojure.edn :as edn]
+    [clojure.string :as string]
+    [datascript.core :as d]
+    [posh.reagent :refer [posh! pull q]]
+    [re-frame.core :refer [dispatch]]))
 
 
 ;; -- Example Roam DBs ---------------------------------------------------
@@ -416,14 +416,14 @@
      (let [exact-match            (when exclude-exact-match? query)
            case-insensitive-query (re-case-insensitive query)]
        (sequence
-        (comp
-         (filter (every-pred
-                  #(re-find case-insensitive-query (:v %))
-                  #(not= exact-match (:v %))))
-         (take n)
-         (map #(d/entity @dsdb (:e %))))
-        (d/datoms @dsdb :aevt :node/title))))))
-        
+         (comp
+           (filter (every-pred
+                     #(re-find case-insensitive-query (:v %))
+                     #(not= exact-match (:v %))))
+           (take n)
+           (map #(d/entity @dsdb (:e %))))
+         (d/datoms @dsdb :aevt :node/title))))))
+
 
 (defn get-root-parent-node
   [block]
@@ -442,17 +442,17 @@
      (vector)
      (let [case-insensitive-query (re-case-insensitive query)]
        (->>
-        (d/datoms @dsdb :aevt :block/string)
-        (sequence
-         (comp
-          (filter #(re-find case-insensitive-query (:v %)))
-          (take n)
-          (map #(:e %))))
-        (d/pull-many @dsdb '[:db/id :block/uid :block/string :node/title {:block/_children ...}])
-        (sequence
-         (comp
-          (keep get-root-parent-node)
-          (map #(dissoc % :block/_children)))))))))
+         (d/datoms @dsdb :aevt :block/string)
+         (sequence
+           (comp
+             (filter #(re-find case-insensitive-query (:v %)))
+             (take n)
+             (map #(:e %))))
+         (d/pull-many @dsdb '[:db/id :block/uid :block/string :node/title {:block/_children ...}])
+         (sequence
+           (comp
+             (keep get-root-parent-node)
+             (map #(dissoc % :block/_children)))))))))
 
 
 (defn nth-sibling
@@ -578,9 +578,9 @@
                            ref-ids)
         blocks (map (fn [id] (get-block-document id)) ref-ids)]
     (mapv
-     (fn [block]
-       (merge block {:block/parents (get parents (:db/id block))}))
-     blocks)))
+      (fn [block]
+        (merge block {:block/parents (get parents (:db/id block))}))
+      blocks)))
 
 
 (defn group-by-parent

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -410,10 +410,10 @@
 (defn search-in-node-title
   ([query] (search-in-node-title query 20 false))
   ([query n] (search-in-node-title query n false))
-  ([query n ignore-exact-match?]
+  ([query n exclude-exact-match?]
    (if (string/blank? query)
      (vector)
-     (let [exact-match            (when ignore-exact-match? query)
+     (let [exact-match            (when exclude-exact-match? query)
            case-insensitive-query (re-case-insensitive query)]
        (sequence
          (comp

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -171,8 +171,8 @@
                      :results []})
       (reset! state {:index   0
                      :query   query
-                     :results (->> (into (search-in-node-title query 20 true)
-                                         (search-in-block-content query))
+                     :results (->> (into (search-in-block-content query)
+                                         (search-in-node-title query 20 true))
                                    (into [(search-exact-node-title query)]))}))))
 
 

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -171,9 +171,11 @@
                      :results []})
       (reset! state {:index   0
                      :query   query
-                     :results (->> (into (search-in-block-content query)
-                                         (search-in-node-title query 20 true))
-                                   (into [(search-exact-node-title query)]))}))))
+                     :results (vec
+                                (concat
+                                  [(search-exact-node-title query)]
+                                  (search-in-node-title query 20 true)
+                                  (search-in-block-content query)))}))))
 
 
 (defn key-down-handler

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -16,7 +16,6 @@
     [garden.selectors :as selectors]
     [goog.dom :refer [getElement]]
     [goog.events :as events]
-    [goog.functions :refer [debounce]]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
     [stylefy.core :as stylefy :refer [use-style use-sub-style]])
@@ -165,18 +164,17 @@
 
 (defn create-search-handler
   [state]
-  (debounce (fn [query]
-              (if (str/blank? query)
-                (reset! state {:index   0
-                               :query   nil
-                               :results []})
-                (reset! state {:index   0
-                               :query   query
-                               :results (->> (concat [(search-exact-node-title query)]
-                                                     (search-in-node-title query 20 true)
-                                                     (search-in-block-content query))
-                                             vec)})))
-            1000))
+  (fn [query]
+    (if (str/blank? query)
+      (reset! state {:index   0
+                     :query   nil
+                     :results []})
+      (reset! state {:index   0
+                     :query   query
+                     :results (doall
+                                (concat [(search-exact-node-title query)]
+                                        (search-in-node-title query 20 true)
+                                        (search-in-block-content query)))}))))
 
 
 (defn key-down-handler

--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -171,10 +171,9 @@
                      :results []})
       (reset! state {:index   0
                      :query   query
-                     :results (doall
-                                (concat [(search-exact-node-title query)]
-                                        (search-in-node-title query 20 true)
-                                        (search-in-block-content query)))}))))
+                     :results (->> (into (search-in-node-title query 20 true)
+                                         (search-in-block-content query))
+                                   (into [(search-exact-node-title query)]))}))))
 
 
 (defn key-down-handler


### PR DESCRIPTION
Making search instantaneous. From ~300ms to ~50ms (or less) on my PC . Tested in relatively large db https://roamresearch.com/#/app/KJV/page/lFeHFy8qE

fix #756