### PR TITLE
fix(undo): undo after pair character input

### DIFF
--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -566,14 +566,12 @@
         close-pair (get PAIR-CHARS key)
         lookbehind-char (nth value start nil)]
     (.. e preventDefault)
-
+    
     (cond
       ;; when close char, increment caret index without writing more
-      (or (= ")" key lookbehind-char)
-          (= "}" key lookbehind-char)
-          (= "\"" key lookbehind-char)
-          (= "]" key lookbehind-char)) (do (setStart target (inc start))
-                                           (swap! state assoc :search/type nil))
+      (some #(= % key lookbehind-char)
+             [")" "}" "\"" "]"]) (do (setStart target (inc start))
+                                 (swap! state assoc :search/type nil))
 
       (= selection "") (let [new-str (str head key close-pair tail)
                              new-idx (inc start)]

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -578,6 +578,9 @@
       (= selection "") (let [new-str (str head key close-pair tail)
                              new-idx (inc start)]
                          (swap! state assoc :string/local new-str)
+                         ;; execCommand is obsolete:
+                         ;; be wary before updating electron - as chromium might drop support for execCommand
+                         ;; electron 11 - uses chromium < 90(latest) which supports execCommand
                          (.. js/document (execCommand
                                           "insertText"
                                           false
@@ -595,6 +598,9 @@
       (not= selection "") (let [surround-selection (surround selection key)
                                 new-str            (str head surround-selection tail)]
                             (swap! state assoc :string/local new-str)
+                            ;; execCommand is obsolete:
+                            ;; be wary before updating electron - as chromium might drop support for execCommand
+                            ;; electron 11 - uses chromium < 90(latest) which supports execCommand
                             (.. js/document (execCommand
                                              "insertText"
                                              false

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -578,7 +578,10 @@
       (= selection "") (let [new-str (str head key close-pair tail)
                              new-idx (inc start)]
                          (swap! state assoc :string/local new-str)
-                         (set! (.-value target) new-str)
+                         (.. js/document (execCommand
+                                          "insertText"
+                                          false
+                                          (str key close-pair)))
                          (set-cursor-position target new-idx)
                          (when (>= (count (:string/local @state)) 4)
                            (let [four-char        (subs (:string/local @state) (dec start) (+ start 3))
@@ -592,7 +595,10 @@
       (not= selection "") (let [surround-selection (surround selection key)
                                 new-str            (str head surround-selection tail)]
                             (swap! state assoc :string/local new-str)
-                            (set! (.-value target) new-str)
+                            (.. js/document (execCommand
+                                             "insertText"
+                                             false
+                                             surround-selection))
                             (set! (.-selectionStart target) (inc start))
                             (set! (.-selectionEnd target) (inc end))
                             (let [four-char        (str (subs (:string/local @state) (dec start) (inc start))


### PR DESCRIPTION
This fixes #559.

The problem seems to be that the textarea value is set via `(set! (.-value target) new-value)`. This corresponds to `target.value = new-value` in JavaScript and seems to break the undo mechanism.

In the above fix I replaced these commands by calls to `execCommand`, as it is already the case in [surround-and-set](https://sourcegraph.com/github.com/athensresearch/athens@a11ea7b/-/blob/src/cljs/athens/views/blocks/textarea_keydown.cljs?subtree=true#L444:7), which is called when the user presses cmd+y etc. to surround text with `~~`.