### PR TITLE
fix(unlinked refs): update unlinked refs when page changes

### DIFF
--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -530,8 +530,13 @@
   Similar to atom-string in blocks. Hacky, but state consistency is hard!"
   [_ _ _ _]
   (let [state         (r/atom init-state)
-        unlinked-refs (r/atom [])]
+        unlinked-refs (r/atom [])
+        block-uid     (r/atom nil)]
     (fn [node editing-uid linked-refs]
+      (when (not= @block-uid (:block/uid node))
+        (reset! state init-state)
+        (reset! unlinked-refs [])
+        (reset! block-uid (:block/uid node)))
       (let [{:block/keys [children uid] title :node/title} node
             {:alert/keys [message confirm-fn cancel-fn] alert-show :alert/show} @state
             daily-note?  (is-daily-note uid)


### PR DESCRIPTION
This fixes #1177 (sticky unlinked references).

It basically adds another atom to the local state of the component to keep track of changes of the block UID, and when they occur, it resets the local state.

However, it might be worth considering to move the block or page state from an atom into `app-db`, although I'm not sure how this might work exactly, since more than one instance of the block/page component can be present (which makes global state hard to use).