### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The problem today is that we are getting drowned in information. If we don't tak
 
 Athens lets you take notes without praying to the search gods, without double-clicking endlessly on folders, and without manual tagging.
 
-Athens does this with **[[bidirectional links]]** and **((block references))** that let you to take notes on anything from any page. Just [[link]] or ((reference)) another page or block - and voilà! - you can now go to this page and see all the places that linked back to it. The next time you press `[[` or `((`, you will be indexing through your previous notes, helping you connect the dots. You've starting creating a graph of your knowledge!
+Athens does this with **[[bidirectional links]]** and **((block references))** that let you to take notes on anything from any page. Just [[link]] or ((reference)) another page or block - and voilà! - you can now go to this page and see all the places that linked back to it. The next time you press `[[` or `((`, you will be indexing through your previous notes, helping you connect the dots. You've started creating a graph of your knowledge!
 
 # [Contributing](https://athensresearch.gitbook.io/handbook/contributing)
 


### PR DESCRIPTION
This fixes a small typo I found as I was reading the Problem section of the README.

"You've _starting_ creating a graph of your knowledge!"

to

"You've _**started**_ creating a graph of your knowledge!"