### PR TITLE
feat(athena): Shift+Click opens in right sidebar, not just Shift+Enter

### DIFF
--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -250,22 +250,22 @@
 
 (defn results-el
   [state]
-  (let [query? (str/blank? (:query @state))
+  (let [no-query? (str/blank? (:query @state))
         recent-items @(subscribe [:athena/get-recent])]
     [:<> [:div (use-style results-heading-style)
-          [:h5 (if query? "Recent" "Results")]
+          [:h5 (if no-query? "Recent" "Results")]
           [:span (use-style hint-style)
            "Press "
            [:kbd "shift + enter"]
            " to open in right sidebar."]]
-     (when query?
+     (when no-query?
        [:div (use-style results-list-style)
         (doall
           (for [[i x] (map-indexed list recent-items)]
             (when x
               (let [{:keys [query :node/title :block/uid :block/string]} x]
                 [:div (use-style result-style {:key      i
-                                               :on-click #(navigate-uid uid)})
+                                               :on-click #(navigate-uid uid %)})
                  [:h4.title (use-sub-style result-style :title) (highlight-match query title)]
                  (when string
                    [:span.preview (use-sub-style result-style :preview) (highlight-match query string)])
@@ -320,6 +320,8 @@
                                                                                              (let [uid (gen-block-uid)]
                                                                                                (dispatch [:athena/toggle])
                                                                                                (dispatch [:page/create query uid])
+                                                                                               ;; TODO(agentydragon): Open the new page in sidebar if Shift is pressed.
+                                                                                               ;; (navigate-uid uid e) does not work, because the page does not exist yet.
                                                                                                (navigate-uid uid)))
                                                                                  :class    (when (= i index) "selected")})
 
@@ -330,14 +332,14 @@
                                                    [:span.link-leader (use-sub-style result-style :link-leader) [(r/adapt-react-class Create)]]]
 
                                                   [:div (use-style result-style {:key      i
-                                                                                 :on-click (fn []
+                                                                                 :on-click (fn [e]
                                                                                              (let [selected-page {:node/title   title
                                                                                                                   :block/uid    uid
                                                                                                                   :block/string string
                                                                                                                   :query        query}]
                                                                                                (dispatch [:athena/toggle])
                                                                                                (dispatch [:athena/update-recent-items selected-page])
-                                                                                               (navigate-uid uid)))
+                                                                                               (navigate-uid uid e)))
                                                                                  :class    (when (= i index) "selected")})
                                                    [:div (use-style result-body-style)
 


### PR DESCRIPTION
Currently Athena only respects Shift modifier as "open in sidebar" with Enter key, not with left click.

Tested:

* Shift-Enter
* Shift-LeftClick

Not implementing this for new pages yet, because dispatching the open effect for them needs to be delayed until db is updated, and that'd make the code a bit messier.