### PR TITLE
fix(selection): Selection "freeze"

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -50,7 +50,7 @@
                :right-sidebar/width 32
                :mouse-down          false
                :daily-notes/items   []
-               :selected/items      []
+               :selected/items      #{}
                :theme/dark          false
                :graph-conf          default-graph-conf})
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -310,6 +310,12 @@
 
 
 (reg-event-db
+  :selected/remove-items
+  (fn [db [_ uids]]
+    (update db :selected/items #(apply disj %1 %2) uids)))
+
+
+(reg-event-db
   :selected/add-items
   (fn [db [_ uids]]
     (update db :selected/items #(apply conj %1 %2) uids)))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -300,26 +300,25 @@
 (reg-event-db
   :selected/add-item
   (fn [db [_ uid]]
-    (update db :selected/items conj uid)))
+    (update db :selected/items (fnil conj #{}) uid)))
 
 
 (reg-event-db
   :selected/remove-item
   (fn [db [_ uid]]
-    (let [items (:selected/items db)]
-      (assoc db :selected/items (filterv #(not= % uid) items)))))
+    (update db :selected/items disj uid)))
 
 
 (reg-event-db
   :selected/add-items
   (fn [db [_ uids]]
-    (update db :selected/items concat uids)))
+    (update db :selected/items #(apply conj %1 %2) uids)))
 
 
 (reg-event-db
   :selected/clear-items
   (fn [db _]
-    (assoc db :selected/items [])))
+    (assoc db :selected/items #{})))
 
 
 (defn select-up

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -102,6 +102,18 @@
     uid))
 
 
+(defn get-dataset-children-uids
+  [el]
+  (let [block         (when el (.. el (closest ".block-container")))
+        children-uids (when block
+                        (let [dom-children-uids ^String (.-childrenuids (.-dataset block))]
+                          (when-not (string/blank? dom-children-uids)
+                            (-> dom-children-uids
+                                (string/split #",")
+                                set))))]
+    children-uids))
+
+
 (defn get-caret-position
   [target]
   (let [selectionEnd (.. target -selectionEnd)]

--- a/src/cljs/athens/views/blocks/content.cljs
+++ b/src/cljs/athens/views/blocks/content.cljs
@@ -1,17 +1,18 @@
 (ns athens.views.blocks.content
   (:require
-    [athens.db :as db]
-    [athens.electron :as electron]
-    [athens.events :as events]
-    [athens.parse-renderer :refer [parse-and-render]]
-    [athens.style :as style]
-    [athens.util :as util]
+    [athens.config                        :as config]
+    [athens.db                            :as db]
+    [athens.electron                      :as electron]
+    [athens.parse-renderer                :refer [parse-and-render]]
+    [athens.style                         :as style]
+    [athens.util                          :as util]
     [athens.views.blocks.textarea-keydown :as textarea-keydown]
-    [garden.selectors :as selectors]
-    [goog.events :as goog-events]
-    [komponentit.autosize :as autosize]
-    [re-frame.core :as rf]
-    [stylefy.core :as stylefy])
+    [clojure.set                          :as set]
+    [garden.selectors                     :as selectors]
+    [goog.events                          :as goog-events]
+    [komponentit.autosize                 :as autosize]
+    [re-frame.core                        :as rf]
+    [stylefy.core                         :as stylefy])
   (:import
     (goog.events
       EventType)))
@@ -187,34 +188,54 @@
    • 3
   Because of this bug, add additional exit cases to prevent stack overflow."
   [e source-uid target-uid]
-  (let [target (.. e -target)
-        page (or (.. target (closest ".node-page")) (.. target (closest ".block-page")))
-        blocks (->> (.. page (querySelectorAll ".block-container"))
-                    array-seq
-                    vec)
-        uids (map util/get-dataset-uid blocks)
-        start-idx (first (keep-indexed (fn [i uid] (when (= uid source-uid) i)) uids))
-        end-idx   (first (keep-indexed (fn [i uid] (when (= uid target-uid) i)) uids))]
-    (when (and start-idx end-idx)
-      (let [up? (> start-idx end-idx)
-            delta (js/Math.abs (- start-idx end-idx))
-            select-fn  (if up? events/select-up events/select-down)
-            start-uid (nth uids start-idx)
-            end-uid   (nth uids end-idx)
-            ;; TODO: refactor/simplify this loop
-            new-items (loop [new-items [source-uid]
-                             prev-items []]
-                        (cond
-                          (= prev-items new-items) new-items
-                          (> (count new-items) delta) new-items
-                          (nil? new-items) []
-                          (or (and (= (first new-items) start-uid)
-                                   (= (last new-items) end-uid))
-                              (and (= (last new-items) start-uid)
-                                   (= (first new-items) end-uid))) new-items
-                          :else (recur (select-fn new-items)
-                                       new-items)))]
-        (rf/dispatch [:selected/add-items new-items])))))
+  (let [target              (.. e -target)
+        page                (or (.. target (closest ".node-page"))
+                                (.. target (closest ".block-page")))
+        blocks              (->> (.. page (querySelectorAll ".block-container"))
+                                 array-seq
+                                 vec)
+        uids                (map util/get-dataset-uid blocks)
+        uids->children-uids (->> (zipmap uids
+                                         (map util/get-dataset-children-uids blocks))
+                                 (remove #(-> % second empty?))
+                                 (into {}))
+        indexed-uids        (map-indexed vector uids)
+        start-index         (->> indexed-uids
+                                 (filter (fn [[_idx uid]]
+                                           (= source-uid uid)))
+                                 ffirst)
+        end-index           (->> indexed-uids
+                                 (filter (fn [[_idx uid]]
+                                           (= target-uid uid)))
+                                 ffirst)
+        selected-uids       @(rf/subscribe [:selected/items])
+        candidate-uids      (->> indexed-uids
+                                 (filter (fn [[idx _uid]]
+                                           (<= (min start-index end-index)
+                                               idx
+                                               (max start-index end-index))))
+                                 (map second)
+                                 (into (or selected-uids #{})))
+        descendants-uids    (loop [descendants #{}
+                                   ancestors-uids candidate-uids]
+                              (if (seq ancestors-uids)
+                                (let [ancestors-children (->> ancestors-uids
+                                                              (mapcat #(get uids->children-uids %))
+                                                              (into #{}))]
+                                  (recur (apply conj descendants ancestors-children)
+                                         ancestors-children))
+                                descendants))
+        to-remove-uids      (set/intersection selected-uids descendants-uids)
+        selection-new-uids  (set/difference candidate-uids descendants-uids)]
+    (when config/debug?
+      (js/console.debug (str "selection: " (pr-str selected-uids)
+                             ", candidates: " (pr-str candidate-uids)
+                             ", descendants: " (pr-str descendants-uids)
+                             ", rm: " (pr-str to-remove-uids)
+                             ", add: " (pr-str selection-new-uids))))
+    (when (and start-index end-index)
+      (rf/dispatch [:selected/remove-items to-remove-uids])
+      (rf/dispatch [:selected/add-items selection-new-uids]))))
 
 
 ;; Event Handlers
@@ -280,9 +301,14 @@
   "If shift key is held when user clicks across multiple blocks, select the blocks."
   [e target-uid _state]
   (let [[target-uid _] (db/uid-and-embed-id target-uid)
-        source-uid @(rf/subscribe [:editing/uid])]
-    (when (and source-uid target-uid (not= source-uid target-uid) (.. e -shiftKey))
-      (find-selected-items e source-uid target-uid))))
+        source-uid     @(rf/subscribe [:editing/uid])
+        shift?         (.-shiftKey e)]
+    (if (and shift?
+             source-uid
+             target-uid
+             (not= source-uid target-uid))
+      (find-selected-items e source-uid target-uid)
+      (rf/dispatch [:selected/clear-items]))))
 
 
 (defn global-mouseup

--- a/src/cljs/athens/views/blocks/content.cljs
+++ b/src/cljs/athens/views/blocks/content.cljs
@@ -201,6 +201,7 @@
             select-fn  (if up? events/select-up events/select-down)
             start-uid (nth uids start-idx)
             end-uid   (nth uids end-idx)
+            ;; TODO: refactor/simplify this loop
             new-items (loop [new-items [source-uid]
                              prev-items []]
                         (cond

--- a/src/cljs/athens/views/devtool.cljs
+++ b/src/cljs/athens/views/devtool.cljs
@@ -395,9 +395,9 @@
     (eval-box!)))
 
 
-; Only run the listener in dev mode, not in prod. The listener slows things
-; down a lot. For example it makes the enter key take ~300ms rather than ~100ms,
-; according to the Chrome devtools flamegraph.
+;; Only run the listener in dev mode, not in prod. The listener slows things
+;; down a lot. For example it makes the enter key take ~300ms rather than ~100ms,
+;; according to the Chrome devtools flamegraph.
 (when config/debug?
   (d/listen! dsdb :devtool/open listener))
 


### PR DESCRIPTION
Fixes for #1267 #1265

Manage selection behaviour with set theory.

![Science For The Win](https://media.giphy.com/media/VVgRNcBKp64NO/giphy.gif)

`athens.events/select-{up,down}` are working properly, so for now leaving them untouched.
They'll be on a workbench soon with common-events.
