### PR TITLE
fix(selection): prod build mangles dataset access

### DIFF
--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -98,7 +98,7 @@
 (defn get-dataset-uid
   [el]
   (let [block (when el (.. el (closest ".block-container")))
-        uid (when block (.. block -dataset -uid))]
+        uid   (when block (.getAttribute block "data-uid"))]
     uid))
 
 
@@ -106,7 +106,7 @@
   [el]
   (let [block         (when el (.. el (closest ".block-container")))
         children-uids (when block
-                        (let [dom-children-uids ^String (.-childrenuids (.-dataset block))]
+                        (let [dom-children-uids ^String (.getAttribute block "data-childrenuids")]
                           (when-not (string/blank? dom-children-uids)
                             (-> dom-children-uids
                                 (string/split #",")

--- a/src/cljs/athens/views/blocks/content.cljs
+++ b/src/cljs/athens/views/blocks/content.cljs
@@ -216,7 +216,7 @@
                                                (max start-index end-index))))
                                  (map second)
                                  (into (or selected-uids #{})))
-        descendants-uids    (loop [descendants #{}
+        descendants-uids    (loop [descendants    #{}
                                    ancestors-uids candidate-uids]
                               (if (seq ancestors-uids)
                                 (let [ancestors-children (->> ancestors-uids

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -461,7 +461,7 @@
       (and (= key-code KeyCodes.A) (= selection value)) (let [closest-node-page  (.. target (closest ".node-page"))
                                                               closest-block-page (.. target (closest ".block-page"))
                                                               closest            (or closest-node-page closest-block-page)
-                                                              block              (db/get-block [:block/uid (.. closest -dataset -uid)])
+                                                              block              (db/get-block [:block/uid (.getAttribute closest "data-uid")])
                                                               children           (->> (:block/children block)
                                                                                       (sort-by :block/order)
                                                                                       (mapv :block/uid))]


### PR DESCRIPTION
Followup on #1273 .

Turns out that prod build mangles `dataset` access.
Changed all usages of `dataset` to `.getAttribute` which is safe and working.