### PR TITLE
fix(#1277): compare string without dangerous regex injection for slash cmd

### DIFF
--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -11,13 +11,12 @@
     [athens.util :refer [scroll-if-needed get-day get-caret-position shortcut-key? escape-str]]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [clojure.string :refer [replace-first blank?]]
+    [clojure.string :refer [replace-first blank? includes? lower-case]]
     [goog.dom :refer [getElement]]
     [goog.dom.selection :refer [setStart setEnd getText setCursorPosition getEndPoints]]
     [goog.events.KeyCodes :refer [isCharacterKey]]
     [goog.functions :refer [throttle #_debounce]]
-    [re-frame.core :refer [dispatch dispatch-sync subscribe]]
-    [clojure.string :refer [includes? lower-case]])
+    [re-frame.core :refer [dispatch dispatch-sync subscribe]])
   (:import
     (goog.events
       KeyCodes)))
@@ -118,6 +117,7 @@
                (includes? (lower-case text) (lower-case query)))
              slash-options)))
 
+
 (defn update-query
   "Used by backspace and write-char.
   write-char appends key character. Pass empty string during backspace.
@@ -144,6 +144,8 @@
              :search/index 0
              :search/query new-query
              :search/results results))))
+
+
 ;; https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
 ;; textarea setval will lose ability to undo/redo
 

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -113,10 +113,10 @@
 (defn filter-slash-options
   [query]
   (if (blank? query)
-      slash-options
-      #(filterv (fn [[text]]
-                  (includes? (lower-case text) (lower-case query)))
-                slash-options))
+    slash-options
+    (filterv (fn [[text]]
+               (includes? (lower-case text) (lower-case query)))
+             slash-options)))
 
 (defn update-query
   "Used by backspace and write-char.

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -112,14 +112,11 @@
 
 (defn filter-slash-options
   [query]
-  ((try
-     (if (blank? query)
-       slash-options
-       #(filterv (fn [[text]]
-                   (includes? (lower-case text) (lower-case query)))
-                 slash-options))
-     (catch js/Error _
-       slash-options))))
+  (if (blank? query)
+      slash-options
+      #(filterv (fn [[text]]
+                  (includes? (lower-case text) (lower-case query)))
+                slash-options))
 
 (defn update-query
   "Used by backspace and write-char.


### PR DESCRIPTION
Fixes #1277. `(re-pattern "invalid-pattern")` throws errors and Athens wouldn't handle those, prompting the user with javascript alerts.