### PR TITLE
refactor: use MUI/Dialog for Athena

### DIFF
--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -308,8 +308,8 @@
                                                              (let [uid (gen-block-uid)]
                                                                (dispatch [:athena/toggle])
                                                                (dispatch [:page/create query uid])
-                                                                          ;; TODO(agentydragon): Open the new page in sidebar if Shift is pressed.
-                                                                          ;; (navigate-uid uid e) does not work, because the page does not exist yet.
+                                                               ;; TODO(agentydragon): Open the new page in sidebar if Shift is pressed.
+                                                               ;; (navigate-uid uid e) does not work, because the page does not exist yet.
                                                                (navigate-uid uid)))
                                                  :class    (when (= i index) "selected")})
 


### PR DESCRIPTION
Main changes made:
1. used MUI/Dialog https://material-ui.com/api/dialog/
2. removed the key-handler for `esc` key because the Dialog component can handle that already.