### PR TITLE
doc: fix "open all-pages" keybinding on Welcome

### DIFF
--- a/src/cljs/athens/athens_datoms.cljs
+++ b/src/cljs/athens/athens_datoms.cljs
@@ -212,7 +212,7 @@
                                                                                       :open true,
                                                                                       :order 4}
                                                                               #:block{:uid "13esc72bd",
-                                                                                      :string "`alt-g`: open all-pages view",
+                                                                                      :string "`alt-a`: open all-pages view",
                                                                                       :open true,
                                                                                       :order 5}
                                                                               #:block{:uid "13efc72bd",


### PR DESCRIPTION
On the "Welcome" Page, currently the documented "open all-pages view" keybinding overlaps with "open graph view" keybinding . The proper keybinding appears to be "alt-a".