### PR TITLE
feat(rtc): add presence toolbar

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -58,7 +58,7 @@
                :zoom-level          1
                :graph-conf          default-graph-conf
                :presence/users      [{:username "Zeus", :color "#DDA74C", :block/uid ""}
-                                     {:username "Poseidon", :color "#C45042", :block/uid "51c3580f5"}
+                                     {:username "Poseidon", :color "#C45042", :block/uid "94272f778"}
                                      {:username "Hera", :color "#611A58", :block/uid "ed9f20b26"}
                                      {:username "Demeter", :color "#21A469", :block/uid "8b66a56f3"}
                                      {:username "Athena", :color "#009FB8", :block/uid "4135c0ecb"}

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -57,9 +57,9 @@
                :theme/dark          false
                :zoom-level          1
                :graph-conf          default-graph-conf
-               :presence/users      [{:username "Zeus", :color "#DDA74C", :block/uid ""}
-                                     {:username "Poseidon", :color "#C45042", :block/uid "94272f778"}
-                                     {:username "Hera", :color "#611A58", :block/uid "ed9f20b26"}
+               :presence/users      [{:username "Zeus", :color "#DDA74C", :block/uid "32b438543"}
+                                     {:username "Poseidon", :color "#C45042", :block/uid "aa5b9f8d1"}
+                                     {:username "Hera", :color "#611A58", :block/uid "3d3c77e46"}
                                      {:username "Demeter", :color "#21A469", :block/uid "8b66a56f3"}
                                      {:username "Athena", :color "#009FB8", :block/uid "4135c0ecb"}
                                      {:username "Apollo", :color "#0062BE", :block/uid ""}]})

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -56,7 +56,13 @@
                :selected/items      #{}
                :theme/dark          false
                :zoom-level          1
-               :graph-conf          default-graph-conf})
+               :graph-conf          default-graph-conf
+               :presence/users      [{:username "Zeus", :color "#DDA74C", :block/uid ""}
+                                     {:username "Poseidon", :color "#C45042", :block/uid "51c3580f5"}
+                                     {:username "Hera", :color "#611A58", :block/uid "ed9f20b26"}
+                                     {:username "Demeter", :color "#21A469", :block/uid "8b66a56f3"}
+                                     {:username "Athena", :color "#009FB8", :block/uid "4135c0ecb"}
+                                     {:username "Apollo", :color "#0062BE", :block/uid ""}]})
 
 
 ;; -- JSON Parsing ----------------------------------------------------
@@ -316,6 +322,15 @@
        shape-parent-query))
 
 
+(defn get-root-parent-page
+  "Returns the root parent page or returns the block because this block is a page."
+  [uid]
+  ;; make sure block first exists
+  (when-let [block (d/entity @dsdb [:block/uid uid])]
+    (let [opt1 (first (get-parents-recursively [:block/uid uid]))]
+      (or opt1 block))))
+
+
 (defn get-block
   [id]
   @(pull dsdb '[:db/id :node/title :block/uid :block/order :block/string {:block/children [:block/uid :block/order]} :block/open] id))
@@ -429,7 +444,7 @@
          (d/datoms @dsdb :aevt :node/title))))))
 
 
-(defn get-root-parent-node
+(defn get-root-parent-node-from-block
   [block]
   (loop [b block]
     (cond
@@ -455,7 +470,7 @@
          (d/pull-many @dsdb '[:db/id :block/uid :block/string :node/title {:block/_children ...}])
          (sequence
            (comp
-             (keep get-root-parent-node)
+             (keep get-root-parent-node-from-block)
              (map #(dissoc % :block/_children)))))))))
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -756,30 +756,39 @@
     {:dispatch [:transact (inverse-tx true)]}))
 
 
+
+(defn prev-block-uid-without-presence-recursively
+  "base case: prev block
+  recursive case: keep going until no longer present"
+  [uid]
+  (let [prev-block-uid (db/prev-block-uid uid)
+        has-presence? @(subscribe [:presence/has-presence prev-block-uid])]
+    (if has-presence?
+      (prev-block-uid-without-presence-recursively prev-block-uid)
+      prev-block-uid)))
+
+
 (reg-event-fx
   :up
-  (fn [_ [_ uid d-key-up]]
-    {:dispatch [:editing/uid
-                (or (when (= (some-> d-key-up :target
-                                     (.. (closest ".block-embed"))
-                                     (. -firstChild)
-                                     (.getAttribute "data-uid"))
-                             uid)
-                      uid)
-                    (db/prev-block-uid uid)
-                    uid)]}))
+  (fn [_ [_ uid]]
+    (let [prev-block-uid (prev-block-uid-without-presence-recursively uid)]
+      {:dispatch [:editing/uid (or prev-block-uid uid)]})))
+
+
+(defn next-block-uid-without-presence-recursively
+  [uid]
+  (let [next-block-uid (db/next-block-uid uid)
+        has-presence? @(subscribe [:presence/has-presence next-block-uid])]
+    (if has-presence?
+      (next-block-uid-without-presence-recursively next-block-uid)
+      next-block-uid)))
 
 
 (reg-event-fx
   :down
-  (fn [_ [_ uid _d-key-down]]
-    (let [[_o-uid o-embed-id] (db/uid-and-embed-id uid)
-          n-uid (or (db/next-block-uid uid) uid)]
-      {:dispatch [:editing/uid
-                  ;; down arrow from inside an embed(do no navigate away)
-                  (or (when (and o-embed-id (not= o-embed-id (-> n-uid db/uid-and-embed-id second)))
-                        uid)
-                      n-uid)]})))
+  (fn [_ [_ uid]]
+    (let [next-block-uid (next-block-uid-without-presence-recursively uid)]
+      {:dispatch [:editing/uid (or next-block-uid uid)]})))
 
 
 (defn backspace

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -25,6 +25,7 @@
     [athens.views.buttons :refer [button]]
     [athens.views.filesystem :as filesystem]
     [athens.views.presence :as presence]
+    [athens.views.toolbar-presence :as toolbar-presence]
     [athens.ws-client :as ws]
     [re-frame.core :refer [subscribe dispatch]]
     [reagent.core :as r]
@@ -238,7 +239,8 @@
         [:div (use-style app-header-secondary-controls-style)
          (if electron?
            [:<>
-            [presence/presence-popover-info]
+            [toolbar-presence/toolbar-presence]
+            #_[presence/presence-popover-info]
             (when (= @socket-status :closed)
               [button
                {:onClick #(ws/start-socket!

--- a/src/cljs/athens/views/blocks/content.cljs
+++ b/src/cljs/athens/views/blocks/content.cljs
@@ -52,6 +52,7 @@
                                  :opacity "0"
                                  :font-family "inherit"}]
                      [:&:hover [:textarea [(selectors/& (selectors/not :.is-editing)) {:line-height 2}]]]
+                     [:&.is-locked {:opacity "0.5"}]
                      [:.is-editing {:z-index 3
                                     :line-height "inherit"
                                     :opacity "1"}]
@@ -354,7 +355,7 @@
   The CSS class is-editing is used for many things, such as block selection.
   Opacity is 0 when block is selected, so that the block is entirely blue, rather than darkened like normal editing.
   is-editing can be used for shift up/down, so it is used in both editing and selection."
-  [block state]
+  [block state is-presence]
   (let [{:block/keys [uid original-uid header]} block
         editing? (rf/subscribe [:editing/is-editing uid])
         selected-items (rf/subscribe [:selected/items])]
@@ -364,7 +365,9 @@
                         2 "1.7em"
                         3 "1.3em"
                         "1em")]
-        [:div {:class "block-content" :style {:font-size font-size}}
+        [:div {:class ["block-content"
+                       (when is-presence "is-locked")]
+        :style {:font-size font-size}}
          ;; NOTE: komponentit forces reflow, likely a performance bottle neck
          ;; When block is in editing mode or the editing DOM elements are rendered
          (when (or (:show-editable-dom @state) editing?)

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -231,7 +231,7 @@
              {:keys [dragging]}    @state
              is-editing            @(rf/subscribe [:editing/is-editing uid])
              is-selected           @(rf/subscribe [:selected/is-selected uid])
-             present-user          @(rf/subscribe [:presence/inline-present? uid])
+             present-user          @(rf/subscribe [:presence/has-presence uid])
              is-presence           (not (nil? present-user))]
 
          ;; (prn uid is-selected)

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -31,63 +31,64 @@
 
 
 (def block-container-style
-  {:display "flex"
-   :line-height "2em"
-   :position "relative"
-   :border-radius "0.125rem"
+  {:display         "flex"
+   :line-height     "2em"
+   :position        "relative"
+   :border-radius   "0.125rem"
    :justify-content "flex-start"
-   :flex-direction "column"
-   ::stylefy/manual [[:&.show-tree-indicator:before {:content "''"
-                                                     :position "absolute"
-                                                     :width "1px"
-                                                     :left "calc(1.375em + 1px)"
-                                                     :top "2em"
-                                                     :bottom "0"
-                                                     :transform "translateX(50%)"
+   :flex-direction  "column"
+   ::stylefy/manual [[:&.show-tree-indicator:before {:content    "''"
+                                                     :position   "absolute"
+                                                     :width      "1px"
+                                                     :left       "calc(1.375em + 1px)"
+                                                     :top        "2em"
+                                                     :bottom     "0"
+                                                     :transform  "translateX(50%)"
                                                      :background (style/color :border-color)}]
-                     [:&:after {:content "''"
-                                :z-index -1
-                                :position "absolute"
-                                :top "0.75px"
-                                :right 0
-                                :bottom "0.75px"
-                                :left 0
-                                :opacity 0
+                     [:&:after {:content        "''"
+                                :z-index        -1
+                                :position       "absolute"
+                                :top            "0.75px"
+                                :right          0
+                                :bottom         "0.75px"
+                                :left           0
+                                :opacity        0
                                 :pointer-events "none"
-                                :border-radius "0.25rem"
-                                :transition "opacity 0.075s ease"
-                                :background (style/color :link-color :opacity-lower)}]
+                                :border-radius  "0.25rem"
+                                :transition     "opacity 0.075s ease"
+                                :background     (style/color :link-color :opacity-lower)}]
                      [:&.is-selected:after {:opacity 1}]
-                     [:.block-body {:display "grid"
+                     [:.block-body {:display               "grid"
                                     :grid-template-columns "1em 1em 1fr auto"
-                                    :grid-template-rows "0 1fr 0"
-                                    :grid-template-areas "
+                                    :grid-template-rows    "0 1fr 0"
+                                    :grid-template-areas   "
                                       'above above above above'
                                       'toggle bullet content refs'
                                       'below below below below'"
-                                    :border-radius "0.5rem"
-                                    :position "relative"}
-                      [:button.block-edit-toggle {:position "absolute"
+                                    :border-radius         "0.5rem"
+                                    :position              "relative"}
+                      [:button.block-edit-toggle {:position   "absolute"
                                                   :appearance "none"
-                                                  :width "100%"
+                                                  :width      "100%"
                                                   :background "none"
-                                                  :border 0
-                                                  :cursor "text"
-                                                  :display "block"
-                                                  :z-index 1
-                                                  :top 0
-                                                  :right 0
-                                                  :bottom 0
-                                                  :left 0}]]
-                     [:.block-content {:grid-area "content"
+                                                  :border     0
+                                                  :cursor     "text"
+                                                  :display    "block"
+                                                  :z-index    1
+                                                  :top        0
+                                                  :right      0
+                                                  :bottom     0
+                                                  :left       0}]]
+                     [:.block-content {:grid-area  "content"
                                        :min-height "1.5em"}]
                      ;; [:&:hover {:background (color :background-minus-1)}]]
                      ;; Darken block body when block editing,
                      [:&.is-linked-ref {:background-color (style/color :background-plus-2)}]
                      ;; [(selectors/> :.is-editing :.block-body) {:background (color :background-minus-1)}]
                      ;; Inset child blocks
+                     [:&.is-presence [:.block-content {:opacity 0.5}]]
                      [:.block-container {:margin-left "2rem"
-                                         :grid-area "body"}]]})
+                                         :grid-area   "body"}]]})
 
 
 (stylefy/class "block-container" block-container-style)
@@ -226,7 +227,9 @@
                                      block)
              {:keys [dragging]}    @state
              is-editing            @(rf/subscribe [:editing/is-editing uid])
-             is-selected           @(rf/subscribe [:selected/is-selected uid])]
+             is-selected           @(rf/subscribe [:selected/is-selected uid])
+             present-user          @(rf/subscribe [:presence/inline-present? uid])
+             is-presence           (not (nil? present-user))]
 
          ;; (prn uid is-selected)
 
@@ -242,7 +245,8 @@
                                (when is-editing "is-editing")
                                (when is-selected "is-selected")
                                (when (and (seq children) open) "show-tree-indicator")
-                               (when (and (false? initial-open) (= uid linked-ref-uid)) "is-linked-ref")]
+                               (when (and (false? initial-open) (= uid linked-ref-uid)) "is-linked-ref")
+                               (when is-presence "is-presence")]
            :data-uid          uid
            ;; need to know children for selection resolution
            :data-childrenuids children-uids
@@ -263,7 +267,8 @@
           (when (= (:drag-target @state) :above) [drop-area-indicator/drop-area-indicator {:grid-area "above"}])
 
           [:div.block-body
-           (when (seq children)
+           (when (and (seq children)
+                      (not is-presence))
              [toggle/toggle-el uid-sanitized-block state linked-ref])
            (when (:context-menu/show @state)
              [context-menu/context-menu-el uid-sanitized-block state])

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -13,7 +13,8 @@
     [athens.views.blocks.toggle :as toggle]
     [athens.views.blocks.tooltip :as tooltip]
     [athens.views.buttons :as buttons]
-    [athens.views.presence :as presence]
+    ;;[athens.views.presence :as presence]
+    [athens.views.toolbar-presence :as toolbar-presence]
     [cljsjs.react]
     [cljsjs.react.dom]
     [com.rpl.specter :as s]
@@ -256,7 +257,8 @@
            :on-drag-leave     (fn [e] (block-drag-leave e block state))
            :on-drop           (fn [e] (block-drop e block state))}
 
-          [presence/presence-popover-info uid {:inline? true}]
+          #_[presence/presence-popover-info uid {:inline? true}]
+          [toolbar-presence/inline-presence uid]
 
           (when (= (:drag-target @state) :above) [drop-area-indicator/drop-area-indicator {:grid-area "above"}])
 

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -44,7 +44,9 @@
                                                      :top        "2em"
                                                      :bottom     "0"
                                                      :transform  "translateX(50%)"
+                                                     :transition "background-color 0.2s ease-in-out"
                                                      :background (style/color :border-color)}]
+                     ["&.is-presence.show-tree-indicator:before" {:background [["var(--user-color)"]]}]
                      [:&:after {:content        "''"
                                 :z-index        -1
                                 :position       "absolute"
@@ -58,6 +60,10 @@
                                 :transition     "opacity 0.075s ease"
                                 :background     (style/color :link-color :opacity-lower)}]
                      [:&.is-selected:after {:opacity 1}]
+                     [:.user-avatar {:position "absolute"
+                     :transition "transform 0.3s ease"
+                                     :left "4px"
+                                     :top "4px"}]
                      [:.block-body {:display               "grid"
                                     :grid-template-columns "1em 1em 1fr auto"
                                     :grid-template-rows    "0 1fr 0"
@@ -80,13 +86,10 @@
                                                   :bottom     0
                                                   :left       0}]]
                      [:.block-content {:grid-area  "content"
-                                       :min-height "1.5em"}]
-                     ;; [:&:hover {:background (color :background-minus-1)}]]
-                     ;; Darken block body when block editing,
+                                       :min-height "1.5em"}
+                                       [:&:hover [:+ [:.user-avatar {:transform "translateX(-2em)"}]]]]
                      [:&.is-linked-ref {:background-color (style/color :background-plus-2)}]
-                     ;; [(selectors/> :.is-editing :.block-body) {:background (color :background-minus-1)}]
                      ;; Inset child blocks
-                     [:&.is-presence [:.block-content {:opacity 0.5}]]
                      [:.block-container {:margin-left "2rem"
                                          :grid-area   "body"}]]})
 
@@ -247,6 +250,7 @@
                                (when (and (seq children) open) "show-tree-indicator")
                                (when (and (false? initial-open) (= uid linked-ref-uid)) "is-linked-ref")
                                (when is-presence "is-presence")]
+           :style             {"--user-color" (if is-presence (:color present-user) nil)}
            :data-uid          uid
            ;; need to know children for selection resolution
            :data-childrenuids children-uids
@@ -261,20 +265,19 @@
            :on-drag-leave     (fn [e] (block-drag-leave e block state))
            :on-drop           (fn [e] (block-drop e block state))}
 
-          #_[presence/presence-popover-info uid {:inline? true}]
-          [toolbar-presence/inline-presence uid]
-
           (when (= (:drag-target @state) :above) [drop-area-indicator/drop-area-indicator {:grid-area "above"}])
 
           [:div.block-body
-           (when (and (seq children)
-                      (not is-presence))
+           (when (seq children)
              [toggle/toggle-el uid-sanitized-block state linked-ref])
            (when (:context-menu/show @state)
              [context-menu/context-menu-el uid-sanitized-block state])
            [bullet/bullet-el block state linked-ref]
            [tooltip/tooltip-el uid-sanitized-block state]
-           [content/block-content-el block state]
+           [content/block-content-el block state is-presence]
+
+          #_[presence/presence-popover-info uid {:inline? true}]
+          [toolbar-presence/inline-presence uid]
 
            (when (and (> (count _refs) 0) (not= :block-embed? opts))
              [block-refs-count-el (count _refs) uid])]

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -2,8 +2,8 @@
   (:require
     ["@material-ui/core/Popover" :as Popover]
     ["@material-ui/icons/Link" :default Link]
-    [athens.style :refer [color]]
-    [athens.views.buttons :refer [button]]
+    [athens.style :as style]
+    [athens.views.buttons :refer [button buttons-style]]
     [clojure.string :as str]
     [re-frame.core :refer [subscribe]]
     [reagent.core :as r]
@@ -16,12 +16,12 @@
 ;; Data
 
 (def PALETTE
-  ["#21A469",
-   "#DDA74C",
-   "#009FB8",
-   "#0062BE"
-   "yellow"
-   "red"])
+  ["#DDA74C"
+   "#C45042"
+   "#611A58"
+   "#21A469"
+   "#009FB8"
+   "#0062BE"])
 
 
 (def NAMES
@@ -70,8 +70,7 @@
   [:svg (merge (use-style {:height          "1.5em"
                            :width           "1.5em"
                            :overflow        "visible"
-                           ::stylefy/manual [[:circle {:stroke-width "0.2px"}]
-                                             [:text {:font-weight "bold"}]]})
+                           ::stylefy/manual [[:text {:font-weight "bold"}]]})
                props)
    children])
 
@@ -83,35 +82,36 @@
    [avatar-el member {:filled true}])
   ([{:keys [username color]} {:keys [filled]}]
    (let [initials (first username)]
-     [avatar-svg {:viewBox "0 0 4 4"}
-      [:circle {:cx          2
-                :cy          2
-                :r           2
-                :fill        (when filled color)
-                :stroke      (when filled color)
+     [avatar-svg {:viewBox "0 0 24 24"
+                  :vectorEffect "non-scaling-stroke"}
+      [:circle {:cx          12
+                :cy          12
+                :r           12
+                :fill        color
+                :stroke      color
                 :fillOpacity (when-not filled 0.1)
-
-                :strokeWidth "1px"}]
-      [:text {:width      4
-              :x          2
+                :strokeWidth (if filled 0 "1px")}]
+      [:text {:width      24
+              :x          12
               :y          "72%"
-              :font-size  "18%"
+              :font-size  16
               :fill       (if filled "#fff" color)
               :textAnchor "middle"}
        initials]])))
 
 
+
+(def avatar-stack-style
+  {:display "grid"
+   :grid-auto-flow "column"
+   :grid-template-columns "repeat(auto-fit, 1em)"
+   ::stylefy/manual [[:svg ["&:last-child" {:margin-right "-1.25rem"}]]]})
+
+
 (defn avatar-stack-el
   [& children]
-  [:div (use-style {:display "grid"
-                    :grid-auto-flow "column"
-                    :grid-template-columns "repeat(auto-fit, 1em)"
-                    :svg {:mask-image "radial-gradient(
-                         1.5em 1.15em at 150% 50%
-                         transparent calc(96%)
-                         #000 100%)"}})
+  [:div (use-style avatar-stack-style)
    children])
-
 
 
 ;; List
@@ -166,11 +166,33 @@
                    :border-bottom "1px solid #ddd"})])
 
 
+(def member-list-item-style
+  {:padding "6px 16px"
+   :display "flex"
+   :font-size "14px"
+   :align-items "center"
+   :cursor "pointer"
+   :font-weight "600"
+   :color (style/color :body-text-color :opacity-higher)
+   :transition "backdrop-filter 0.1s ease"
+   ::stylefy/manual [[:svg {:margin-right "0.25rem"}]
+                     [:&:hover {:background (style/color :body-text-color :opacity-lower)}]
+                     [:&:active
+                      :&:hover:active
+                      :&.is-active {:color (style/color :body-text-color)
+                                    :background (style/color :body-text-color :opacity-lower)}]
+                     [:&:active
+                      :&:hover:active
+                      :&:active.is-active {:background (style/color :body-text-color :opacity-low)}]
+                     [:&:disabled :&:disabled:active {:color (style/color :body-text-color :opacity-low)
+                                                      :background (style/color :body-text-color :opacity-lower)
+                                                      :cursor "default"}]]})
+
+
 (defn MemberListItem
   [& children]
-  [:li (use-style {:padding "8px 16px"
-                   :cursor "pointer"
-                   :transition "backdrop-filter 0.1s ease"})
+  [:li (use-style member-list-item-style
+                  {:on-click #(prn "hi")})
    children])
 
 
@@ -215,7 +237,7 @@
                                         :horizontal "center"}}
                   [list-header-el
                    [list-header-url-el "ath.ns/34op5fds0a"]
-                   [:> Link]]
+                   [button [:> Link]]]
                   [list-el
 
                    ;; On same page

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -138,9 +138,10 @@
                            :width           "1.5em"
                            :overflow        "hidden"
                            :border-radius   "1000em"}
-                           {:class "user-avatar"})
+                          {:class "user-avatar"})
                props)
    children])
+
 
 
 (defn avatar-el
@@ -341,7 +342,7 @@
 ;; inline
 
 (rf/reg-sub
-  :presence/inline-present?
+  :presence/has-presence
   :<- [:presence/users-with-page-data]
   (fn [users [_ uid]]
     (-> (filter (fn [user]
@@ -352,6 +353,6 @@
 
 (defn inline-presence
   [uid]
-  (let [inline-present? (rf/subscribe [:presence/inline-present? uid])]
+  (let [inline-present? (rf/subscribe [:presence/has-presence uid])]
     (when @inline-present?
       [avatar-el @inline-present?])))

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -64,8 +64,7 @@
   [:svg (merge (use-style {:height          "1.5em"
                            :width           "1.5em"
                            :overflow        "hidden"
-                           :border-radius   "1000em"
-                           ::stylefy/manual [[:text {:font-weight "bold"}]]})
+                           :border-radius   "1000em"})
                props)
    children])
 
@@ -76,7 +75,7 @@
   ([member]
    [avatar-el member {:filled true}])
   ([{:keys [username color]} {:keys [filled]}]
-   (let [initials (first username)]
+   (let [initials (subs username 0 2)]
      [avatar-svg {:viewBox "0 0 24 24"
                   :vectorEffect "non-scaling-stroke"}
       [:circle {:cx          12
@@ -89,8 +88,9 @@
                 :key "circle"}]
       [:text {:width      24
               :x          12
-              :y          "72%"
-              :font-size  16
+              :y          16.5
+              :font-size  14
+              :font-weight 600
               :fill       (if filled "#fff" color)
               :textAnchor "middle"
               :key "text"}

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -1,0 +1,232 @@
+(ns athens.views.toolbar-presence
+  (:require
+    ["@material-ui/core/Popover" :as Popover]
+    ["@material-ui/icons/Link" :default Link]
+    [athens.style :refer [color]]
+    [athens.views.buttons :refer [button]]
+    [clojure.string :as str]
+    [re-frame.core :refer [subscribe]]
+    [reagent.core :as r]
+    [stylefy.core :as stylefy :refer [use-style]]))
+
+
+(def m-popover (r/adapt-react-class (.-default Popover)))
+
+
+;; Data
+
+(def PALETTE
+  ["#21A469",
+   "#DDA74C",
+   "#009FB8",
+   "#0062BE"
+   "yellow"
+   "red"])
+
+
+(def NAMES
+  ["Zeus"
+   "Poseidon"
+   "Hera"
+   "Demeter"
+   "Athena"
+   "Apollo"])
+   ;;"Artemis"
+   ;;"Ares"
+   ;;"Aphrodite"
+   ;;"Hephaestus"
+   ;;"Hermes"
+   ;;"Hestia"
+   ;;"Dionysus"
+   ;;"Hades"])
+
+
+(def BLOCK-UIDS
+  ["" ;; on page, not block
+   "51c3580f5" ;; poseidon
+   "ed9f20b26" ;; way down
+   "8b66a56f3" ;; different page
+   "4135c0ecb" ;; different page on a block
+   ""])
+
+
+(def MEMBERS
+  (mapv
+    (fn [username color uid]
+      {:username username :color color :block/uid uid})
+    NAMES PALETTE BLOCK-UIDS))
+
+
+;; Avatar
+
+(defn avatars
+  [members]
+  (mapv (fn [{}])
+        members))
+
+
+(defn avatar-svg
+  [props & children]
+  [:svg (merge (use-style {:height          "1.5em"
+                           :width           "1.5em"
+                           :overflow        "visible"
+                           ::stylefy/manual [[:circle {:stroke-width "0.2px"}]
+                                             [:text {:font-weight "bold"}]]})
+               props)
+   children])
+
+
+(defn avatar-el
+  "Takes a member map for the user data.
+  Optionally takes some props for things like fill."
+  ([member]
+   [avatar-el member {:filled true}])
+  ([{:keys [username color]} {:keys [filled]}]
+   (let [initials (first username)]
+     [avatar-svg {:viewBox "0 0 4 4"}
+      [:circle {:cx          2
+                :cy          2
+                :r           2
+                :fill        (when filled color)
+                :stroke      (when filled color)
+                :fillOpacity (when-not filled 0.1)
+
+                :strokeWidth "1px"}]
+      [:text {:width      4
+              :x          2
+              :y          "72%"
+              :font-size  "18%"
+              :fill       (if filled "#fff" color)
+              :textAnchor "middle"}
+       initials]])))
+
+
+(defn avatar-stack-el
+  [& children]
+  [:div (use-style {:display "grid"
+                    :grid-auto-flow "column"
+                    :grid-template-columns "repeat(auto-fit, 1em)"
+                    :svg {:mask-image "radial-gradient(
+                         1.5em 1.15em at 150% 50%
+                         transparent calc(96%)
+                         #000 100%)"}})
+   children])
+
+
+
+;; List
+
+(defn list-el
+  [& children]
+  [:ul (use-style {:padding        0
+                   :margin         0
+                   :display        "flex"
+                   :flex-direction "column"
+                   :list-style     "none"})
+   children])
+
+
+(defn list-header-el
+  [& children]
+  [:header (use-style {:border-bottom "1px solid #ddd"
+                       :padding "4px 8px"
+                       :display "flex"
+                       :justify-content "space-between"
+                       :align-items "center"})
+   children])
+
+
+
+(defn list-section-header-el
+  [& children]
+  [:li (use-style {:font-size "12px"
+                   :font-weight "bold"
+                   :opacity "0.5"
+                   :padding "16px 16px 4px"})
+   children])
+
+
+(defn list-header-url-el
+  [& children]
+  [:span (use-style {:font-size     "12px"
+                     :font-weight   "700"
+                     :display       "inline-block"
+                     :opacity       "0.5"
+                     :padding       "8px"
+                     :margin-right  "1em"
+                     :flex          "1 1 100%"
+                     :white-space   "nowrap"
+                     :text-overflow "hidden"})
+   children])
+
+
+(defn list-separator-el
+  []
+  [:li (use-style {:margin "5px 0 6px 16px"
+                   :border-bottom "1px solid #ddd"})])
+
+
+(defn MemberListItem
+  [& children]
+  [:li (use-style {:padding "8px 16px"
+                   :cursor "pointer"
+                   :transition "backdrop-filter 0.1s ease"})
+   children])
+
+
+(defn member-item-el
+  [member filled?]
+  [:<>
+   [avatar-el member filled?]
+   (:username member)])
+
+;;&hover {
+;;        :backdrop-filter "brightness(95%)"}
+;;
+;;
+;;&active {
+;;         :backdrop-filter "brightness(92%)"}
+;;
+;;(defn ListItem = styled.li``
+
+
+(defn toolbar-presence
+  []
+  (r/with-let [ele (r/atom nil)]
+              (let [same-page-members (take 3 MEMBERS)
+                    online-members    (drop 3 MEMBERS)]
+                [:<>
+
+                 ;; Preview
+                 [button {:on-click #(reset! ele (.-currentTarget %))}
+                  [:<>
+                   [avatar-stack-el
+                    (for [member same-page-members]
+                      [avatar-el member])]]]
+
+                 ;; Dropdown
+                 [m-popover
+                  {:open            (boolean (and @ele))
+                   :anchorEl        @ele
+                   :onClose         #(reset! ele nil)
+                   :anchorOrigin    #js{:vertical   "bottom"
+                                        :horizontal "center"}
+                   :transformOrigin #js{:vertical   "top"
+                                        :horizontal "center"}}
+                  [list-header-el
+                   [list-header-url-el "ath.ns/34op5fds0a"]
+                   [:> Link]]
+                  [list-el
+
+                   ;; On same page
+                   [list-section-header-el "On This Page"]
+                   (for [member same-page-members]
+                     [MemberListItem
+                      [member-item-el member]])
+
+                   ;; Online, different page
+                   [list-separator-el]
+                   (for [member online-members]
+                     [MemberListItem
+                      [member-item-el member]])]]])))
+

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -48,7 +48,7 @@
 
 (def BLOCK-UIDS
   ["" ;; on page, not block
-   "51c3580f5" ;; poseidon
+   "6b8c28b09" ;; poseidon
    "ed9f20b26" ;; way down
    "8b66a56f3" ;; different page
    "4135c0ecb" ;; different page on a block
@@ -137,7 +137,8 @@
   [:svg (merge (use-style {:height          "1.5em"
                            :width           "1.5em"
                            :overflow        "hidden"
-                           :border-radius   "1000em"})
+                           :border-radius   "1000em"}
+                           {:class "user-avatar"})
                props)
    children])
 

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -289,14 +289,25 @@
 
        ;; Preview
        [button {:on-click #(reset! ele (.-currentTarget %))}
-        [:<>
-         [avatar-stack-el
-          (for [user @same-page-users]
-            [avatar-el user {:filled true}])
-          (for [user @diff-page-users]
-            [avatar-el user {:filled false}])
-          #_(for [user @users]
-              [avatar-el user {:filled false}])]]]
+        [avatar-stack-el
+         (cond
+
+           (= @current-route-name :page)
+           [:<>
+            ;; same page
+            (for [user @same-page-users]
+              [avatar-el user {:filled true}])
+            ;; diff page but online
+            (for [user @diff-page-users]
+              [avatar-el user {:filled false}])]
+
+           ;; TODO: capture what page user is scrolled to on Daily Notes
+           (= @current-route-name :home)
+           [:div "TODO"]
+
+           ;; default to showing all users
+           :else (for [user @users]
+                   [avatar-el user {:filled false}]))]]
 
        ;; Dropdown
        [m-popover
@@ -313,12 +324,15 @@
 
         [list-el
          ;; On same page
-         [list-section-header-el "On This Page"]
-         (for [user @same-page-users]
-           [member-item-el user {:filled true}])
+
+         (when-not (empty? @same-page-users)
+           [:<>
+            [list-section-header-el "On This Page"]
+            (for [user @same-page-users]
+              [member-item-el user {:filled true}])
+            [list-separator-el]])
 
          ;; Online, different page
-         [list-separator-el]
          (for [user @diff-page-users]
            [member-item-el user {:filled false}])]]])))
 

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -283,16 +283,20 @@
   (r/with-let [ele (r/atom nil)]
     (let [users (rf/subscribe [:presence/users-with-page-data])
           same-page-users (rf/subscribe [:presence/same-page])
-          diff-page-users (rf/subscribe [:presence/diff-page])]
+          diff-page-users (rf/subscribe [:presence/diff-page])
+          current-route-name (rf/subscribe [:current-route/name])]
       [:<>
 
        ;; Preview
        [button {:on-click #(reset! ele (.-currentTarget %))}
         [:<>
          [avatar-stack-el
-
-          (for [user @users]
-            [avatar-el user {:filled false}])]]]
+          (for [user @same-page-users]
+            [avatar-el user {:filled true}])
+          (for [user @diff-page-users]
+            [avatar-el user {:filled false}])
+          #_(for [user @users]
+              [avatar-el user {:filled false}])]]]
 
        ;; Dropdown
        [m-popover
@@ -318,3 +322,22 @@
          (for [user @diff-page-users]
            [member-item-el user {:filled false}])]]])))
 
+
+;; inline
+
+(rf/reg-sub
+  :presence/inline-present?
+  :<- [:presence/users-with-page-data]
+  ;;:<- [:editing/uid]
+  (fn [users [_ uid]]
+    (-> (filter (fn [user]
+                  (= uid (:block/uid user)))
+                users)
+        first)))
+
+
+(defn inline-presence
+  [uid]
+  (let [inline-present? (rf/subscribe [:presence/inline-present? uid])]
+    (when @inline-present?
+      [avatar-el @inline-present?])))

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -342,7 +342,6 @@
 (rf/reg-sub
   :presence/inline-present?
   :<- [:presence/users-with-page-data]
-  ;;:<- [:editing/uid]
   (fn [users [_ uid]]
     (-> (filter (fn [user]
                   (= uid (:block/uid user)))

--- a/src/cljs/athens/views/toolbar_presence.cljs
+++ b/src/cljs/athens/views/toolbar_presence.cljs
@@ -59,12 +59,6 @@
 
 ;; Avatar
 
-(defn avatars
-  [members]
-  (mapv (fn [{}])
-        members))
-
-
 (defn avatar-svg
   [props & children]
   [:svg (merge (use-style {:height          "1.5em"
@@ -90,13 +84,15 @@
                 :fill        color
                 :stroke      color
                 :fillOpacity (when-not filled 0.1)
-                :strokeWidth (if filled 0 "1px")}]
+                :strokeWidth (if filled 0 "1px")
+                :key "circle"}]
       [:text {:width      24
               :x          12
               :y          "72%"
               :font-size  16
               :fill       (if filled "#fff" color)
-              :textAnchor "middle"}
+              :textAnchor "middle"
+              :key "text"}
        initials]])))
 
 
@@ -171,45 +167,40 @@
    :display "flex"
    :font-size "14px"
    :align-items "center"
-   :cursor "pointer"
    :font-weight "600"
    :color (style/color :body-text-color :opacity-higher)
    :transition "backdrop-filter 0.1s ease"
-   ::stylefy/manual [[:svg {:margin-right "0.25rem"}]
-                     [:&:hover {:background (style/color :body-text-color :opacity-lower)}]
-                     [:&:active
-                      :&:hover:active
-                      :&.is-active {:color (style/color :body-text-color)
-                                    :background (style/color :body-text-color :opacity-lower)}]
-                     [:&:active
-                      :&:hover:active
-                      :&:active.is-active {:background (style/color :body-text-color :opacity-low)}]
-                     [:&:disabled :&:disabled:active {:color (style/color :body-text-color :opacity-low)
-                                                      :background (style/color :body-text-color :opacity-lower)
-                                                      :cursor "default"}]]})
+   ;;:cursor "pointer"
+   ::stylefy/manual [[:svg {:margin-right "0.25rem"}]]})
+;; turn off interactive button stylings until we implement interactions like "jump" or "follow"
+                     ;;[:&:hover {:background (style/color :body-text-color :opacity-lower)}]
+                     ;;[:&:active
+                     ;; :&:hover:active
+                     ;; :&.is-active {:color (style/color :body-text-color)
+                     ;;               :background (style/color :body-text-color :opacity-lower)}]
+                     ;;[:&:active
+                     ;; :&:hover:active
+                     ;; :&:active.is-active {:background (style/color :body-text-color :opacity-low)}]
+                     ;;[:&:disabled :&:disabled:active {:color (style/color :body-text-color :opacity-low)
+                     ;;                                 :background (style/color :body-text-color :opacity-lower)
+                     ;;                                 :cursor "default"}]]})
 
 
-(defn MemberListItem
-  [& children]
-  [:li (use-style member-list-item-style
-                  {:on-click #(prn "hi")})
-   children])
+
+;; event
+:presence/ping
+
+;; re-frame db
+{:presence/users {"user-id-1" {:username  "Zeus"
+                               :block/uid "asd123"
+                               :page/uid  "page-1"}}}
 
 
 (defn member-item-el
   [member filled?]
-  [:<>
+  [:li (use-style member-list-item-style #_{:on-click #(prn member)})
    [avatar-el member filled?]
    (:username member)])
-
-;;&hover {
-;;        :backdrop-filter "brightness(95%)"}
-;;
-;;
-;;&active {
-;;         :backdrop-filter "brightness(92%)"}
-;;
-;;(defn ListItem = styled.li``
 
 
 (defn toolbar-presence
@@ -238,17 +229,15 @@
                   [list-header-el
                    [list-header-url-el "ath.ns/34op5fds0a"]
                    [button [:> Link]]]
-                  [list-el
 
+                  [list-el
                    ;; On same page
                    [list-section-header-el "On This Page"]
                    (for [member same-page-members]
-                     [MemberListItem
-                      [member-item-el member]])
+                     [member-item-el member {:filled true}])
 
                    ;; Online, different page
                    [list-separator-el]
                    (for [member online-members]
-                     [MemberListItem
-                      [member-item-el member]])]]])))
+                     [member-item-el member {:filled false}])]]])))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8952138/122217812-a1b45900-ce62-11eb-8a1b-9f89f9ce7d50.png)

# Todos

- [X] implement UI
- [x] hook up to re-frame
  - [x] subscription
  - [x] event
  - [x] mock db data
- [ ] hook up to backend
  - [ ] creating event and dispatches for `:presence/hello` / `:presence/viewing` / `:presence/editing` -> update `:presence/users`
- [ ] Daily Notes edge case - in this case, the user on a page, but the route is `/home` rather than than `/page/{block-uid}`
  - use https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
  - use React Hooks https://non-traditional.dev/a-beginners-guide-to-dealing-with-refs-in-react-7dac6a355964
  - React hooks in cljs/reagent https://cljdoc.org/d/reagent/reagent/1.1.0/doc/tutorials/react-features
  - could probably refactor the current `db-scroll-daily-notes` as well
