### PR TITLE
fix: node page title shows parsed and unparsed title at the same time, and also shows the scrollbar

### DIFF
--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -26,7 +26,6 @@
     [cljsjs.react.dom]
     [clojure.string :as str]
     [datascript.core :as d]
-    [garden.selectors :as selectors]
     [komponentit.autosize :as autosize]
     [re-frame.core :refer [dispatch subscribe]]
     [reagent.core :as r]


### PR DESCRIPTION
fix #1394 