### PR TITLE
Selection fixes.

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -33,7 +33,6 @@
 
 (defonce rfdb {:user                {:name (or (js/localStorage.getItem "user/name")
                                                "Socrates")}
-
                :db/filepath         nil
                :db/synced           true
                :db/mtime            nil
@@ -53,7 +52,8 @@
                :right-sidebar/width 32
                :mouse-down          false
                :daily-notes/items   []
-               :selected/items      #{}
+               :selection           {:items #{}
+                                     :order []}
                :theme/dark          false
                :zoom-level          1
                :graph-conf          default-graph-conf})

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -300,31 +300,39 @@
 (reg-event-db
   :selected/add-item
   (fn [db [_ uid]]
-    (update db :selected/items (fnil conj #{}) uid)))
+    (update-in db [:selection :items] (fnil conj #{}) uid)))
 
 
 (reg-event-db
   :selected/remove-item
   (fn [db [_ uid]]
-    (update db :selected/items disj uid)))
+    (update-in db [:selection :items] disj uid)))
 
 
 (reg-event-db
   :selected/remove-items
   (fn [db [_ uids]]
-    (update db :selected/items #(apply disj %1 %2) uids)))
+    (update-in db [:selection :items] #(apply disj %1 %2) uids)))
 
 
 (reg-event-db
   :selected/add-items
   (fn [db [_ uids]]
-    (update db :selected/items #(apply conj %1 %2) uids)))
+    (update-in db [:selection :items] #(apply conj %1 %2) uids)))
+
+
+(reg-event-db
+  :selected/items-order
+  (fn [db [_ items-order]]
+    (assoc-in db [:selection :order] items-order)))
 
 
 (reg-event-db
   :selected/clear-items
   (fn [db _]
-    (assoc db :selected/items #{})))
+    (-> db
+        (assoc-in [:selection :items] #{})
+        (assoc-in [:selection :order] []))))
 
 
 (defn select-up
@@ -368,7 +376,7 @@
 (reg-event-db
   :selected/up
   (fn [db [_ selected-items]]
-    (assoc db :selected/items (select-up selected-items))))
+    (assoc-in db [:selection :items] (select-up selected-items))))
 
 
 (defn select-down
@@ -399,7 +407,7 @@
 (reg-event-db
   :selected/down
   (fn [db [_ selected-items]]
-    (assoc db :selected/items (select-down selected-items))))
+    (assoc-in db [:selection :items] (select-down selected-items))))
 
 
 (defn delete-selected
@@ -438,7 +446,9 @@
           tx-data           (concat retract-vecs reindex-last-selected-parent)]
       {:fx [[:dispatch [:transact tx-data]]
             [:dispatch [:editing/uid nil]]]
-       :db (assoc db :selected/items [])})))
+       :db (-> db
+               (assoc-in [:selection :items] #{})
+               (assoc-in [:selection :order] []))})))
 
 
 ;; Alerts

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -177,9 +177,10 @@
   "If blocks are selected, copy blocks as markdown list.
   Use -event_ because goog events quirk "
   [^js e]
-  (let [uids @(subscribe [:selected/items])]
+  (let [uids  @(subscribe [:selected/items])
+        order @(subscribe [:selected/order])]
     (when (not-empty uids)
-      (let [copy-data (->> (map #(db/get-block-document [:block/uid %]) uids)
+      (let [copy-data (->> (map #(db/get-block-document [:block/uid %]) order)
                            (map #(blocks-to-clipboard-data 0 %))
                            (apply str))]
         (.. e preventDefault)
@@ -191,12 +192,8 @@
   [^js e]
   (let [uids @(subscribe [:selected/items])]
     (when (not-empty uids)
-      (let [copy-data (->> (map #(db/get-block-document [:block/uid %]) uids)
-                           (map #(blocks-to-clipboard-data 0 %))
-                           (apply str))]
-        (.. e preventDefault)
-        (.. e -event_ -clipboardData (setData "text/plain" copy-data))
-        (dispatch [:selected/delete uids])))))
+      (copy e)
+      (dispatch [:selected/delete uids]))))
 
 
 (defn prevent-save

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -106,7 +106,13 @@
 (re-frame/reg-sub
   :selected/items
   (fn [db _]
-    (:selected/items db)))
+    (get-in db [:selection :items])))
+
+
+(rf/reg-sub
+  :selected/order
+  (fn [db _]
+    (get-in db [:selection :order])))
 
 
 (re-frame/reg-sub

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -109,7 +109,7 @@
     (get-in db [:selection :items])))
 
 
-(rf/reg-sub
+(re-frame/reg-sub
   :selected/order
   (fn [db _]
     (get-in db [:selection :order])))


### PR DESCRIPTION
Mouse selection also deselects. Fix #1279
Original block order is preserved when Copy or Cut.