### PR TITLE
Fix: presence bugs, the easy ones

### DIFF
--- a/src/clj/athens/self_hosted/clients.clj
+++ b/src/clj/athens/self_hosted/clients.clj
@@ -51,7 +51,9 @@
             valid-server-event?)
       (http/send! channel (->transit data))
       ;; TODO internal failure mode, collect in reporting
-      (log/error "->" (get @clients channel) ", invalid schema:"
+      (log/error "->" (get @clients channel)
+                 ", event:" (pr-str data)
+                 ", invalid schema:"
                  "event-response take:" (str (schema/explain-event-response data))
                  ", server-event take:" (str (schema/explain-server-event data))))))
 

--- a/src/clj/athens/self_hosted/components/web.clj
+++ b/src/clj/athens/self_hosted/components/web.clj
@@ -38,21 +38,22 @@
       (clients/send! channel (common-events/build-event-rejected id
                                                                  :introduce-yourself
                                                                  {:protocol-error :client-not-introduced})))
-    (let [result (cond
-                   (contains? presence/supported-event-types type)
-                   (presence/presence-handler (:conn datahike) channel data)
+    (if-let [result (cond
+                      (contains? presence/supported-event-types type)
+                      (presence/presence-handler (:conn datahike) channel data)
 
-                   (contains? datascript/supported-event-types type)
-                   (datascript/datascript-handler (:conn datahike) channel data)
+                      (contains? datascript/supported-event-types type)
+                      (datascript/datascript-handler (:conn datahike) channel data)
 
-                   :else
-                   (do
-                     (log/error "receive-handler, unsupported event:" (pr-str type))
-                     (common-events/build-event-rejected id
-                                                         (str "Unsupported event: " type)
-                                                         {:unsupported-type type})))]
+                      :else
+                      (do
+                        (log/error "receive-handler, unsupported event:" (pr-str type))
+                        (common-events/build-event-rejected id
+                                                            (str "Unsupported event: " type)
+                                                            {:unsupported-type type})))]
       (merge {:event/id id}
-             result))))
+             result)
+      (log/error "No result for `valid-event-handler`, input data:" (pr-str data)))))
 
 
 (def ^:private forwardable-events

--- a/src/clj/athens/self_hosted/web/presence.clj
+++ b/src/clj/athens/self_hosted/web/presence.clj
@@ -28,15 +28,15 @@
     (log/info channel "New Client Intro:" username)
     (clients/add-client! channel username)
 
-    (let [datoms (d/datoms @datahike :eavt) #_(map (fn [{:keys [e a v tx added]}]
-                        [e a v tx added])
-                      (d/datoms @datahike :eavt))]
+    (let [datoms (d/datoms @datahike :eavt)]
       (log/debug channel "Sending" (count datoms) "eavt")
       (clients/send! channel
                      (common-events/build-db-dump-event max-tx datoms))
       (clients/send! channel
                      (common-events/build-presence-all-online-event max-tx
-                                                                    (clients/get-clients-usernames))))
+                                                                    (clients/get-clients-usernames)))
+      (clients/broadcast! (common-events/build-presence-online-event max-tx
+                                                                     username)))
 
     ;; TODO Recipe for diff/patch updating client
     ;; 1. query for tx-ids since `last-tx`

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -642,7 +642,8 @@
     {:event/id      event-id
      :event/last-tx last-tx
      :event/type    :presence/editing
-     :event/args    {:username username :block/uid uid}}))
+     :event/args    {:username  username
+                     :block-uid uid}}))
 
 
 (defn build-presence-broadcast-editing-event
@@ -652,4 +653,5 @@
     {:event/id      event-id
      :event/last-tx last-tx
      :event/type    :presence/broadcast-editing
-     :event/args    {:username username :block/uid block-uid}}))
+     :event/args    {:username  username
+                     :block-uid block-uid}}))

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -111,9 +111,7 @@
    [:event/args
     [:map
      [:username string?]
-     ;; how to make block/uid string? or nil?
-     ;; why would it be `nil?`
-     #_[:block/uid  string?]]]])
+     [:block-uid string?]]]])
 
 
 (def datascript-create-page
@@ -596,7 +594,7 @@
    [:event/args
     [:map
      [:username string?]
-     [:block/uid string?]]]])
+     [:block-uid string?]]]])
 
 
 (def server-event

--- a/src/cljs/athens/self_hosted/presence/events.cljs
+++ b/src/cljs/athens/self_hosted/presence/events.cljs
@@ -30,6 +30,6 @@
 
 (rf/reg-event-db
   :presence/update-editing
-  (fn [db [_ {:keys [username block/uid]}]]
-    (update-in db [:presence :users username] assoc :block/uid uid)))
+  (fn [db [_ {:keys [username block-uid]}]]
+    (update-in db [:presence :users username] assoc :block/uid block-uid)))
 


### PR DESCRIPTION
Logs event itself when schema validation fails.
Confirm `:presence/editing` event.
Use plain keywords (instead of namespaced ones) in `:event/args`.
Broadcast new username when new player joins.
Logs when handler doesn't return handle status event.