### PR TITLE
fix(block_embed): text overlaps the edit button

### DIFF
--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -55,7 +55,8 @@
   [content _uid]
   [span-click-stop
    [:div.media-16-9
-    [:iframe {:src   (str "https://www.youtube.com/embed/" (get (re-find #".*v=([a-zA-Z0-9_\-]+)" content) 1))
+    [:iframe {:src   (str "https://www.youtube.com/
+                          /" (get (re-find #".*v=([a-zA-Z0-9_\-]+)" content) 1))
               :allow "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"}]]])
 
 
@@ -78,6 +79,7 @@
   {:background (color :background-minus-2 :opacity-med)
    :position   "relative"
    ::stylefy/manual [[:>.block-container {:margin-left "0"
+                                          :padding-right "1.3rem"
                                           ::stylefy/manual [[:textarea {:background "transparent"}]]}]
                      [:>svg              {:position   "absolute"
                                           :right      "5px"


### PR DESCRIPTION
Adds a bit of padding to the block embed view 

![Image](https://user-images.githubusercontent.com/80150109/130099103-eaef14aa-7ac8-4b5a-9e32-b9f87ced4489.jpg)

close #1328
close #817

