### PR TITLE
fix: problems in the daily page scroll

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -523,11 +523,11 @@
 (reg-event-fx
   :daily-note/next
   (fn [_ [_ {:keys [uid title]}]]
-    {:fx [(when-not (db/e-by-av :block/uid uid)
+    {:fx [(if (db/e-by-av :block/uid uid)
+            [:dispatch [:daily-note/add uid]]
             [:dispatch [:page/create {:title     title
                                       :page-uid  uid
-                                      :block-uid (gen-block-uid)}]])
-          [:dispatch [:daily-note/add uid]]]}))
+                                      :block-uid (gen-block-uid)}]])]}))
 
 
 (reg-event-fx
@@ -645,7 +645,11 @@
                                 [:right-sidebar/open-item page-uid]
 
                                 (not (util/is-daily-note page-uid))
-                                [:navigate :page {:id page-uid}])
+                                [:navigate :page {:id page-uid}]
+
+                                (util/is-daily-note page-uid)
+                                [:daily-note/add page-uid])
+
                               [:editing/uid block-uid]]]]})
         {:fx [[:dispatch
                [:remote/page-create page-uid block-uid title shift?]]]}))))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -496,8 +496,8 @@
 
 (reg-event-db
   :daily-note/reset
-  (fn [db _]
-    (assoc db :daily-notes/items [])))
+  (fn [db [_ uid]]
+    (assoc db :daily-notes/items uid)))
 
 
 (reg-event-db

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -5,6 +5,7 @@
     [athens.common-events.resolver :as resolver]
     [athens.common-events.schema   :as schema]
     [athens.db                     :as db]
+    [athens.util                    :as util]
     [malli.core                    :as m]
     [malli.error                   :as me]
     [re-frame.core                 :as rf]))
@@ -193,9 +194,13 @@
           {:keys [page-uid
                   block-uid]} (:event/args event)]
       (js/console.log ":remote/followup-page-create, page-uid" page-uid)
-      {:fx [[:dispatch-n [(if shift?
+      {:fx [[:dispatch-n [(cond
+                            shift?
                             [:right-sidebar/open-item page-uid]
+
+                            (not (util/is-daily-note page-uid))
                             [:navigate :page {:id page-uid}])
+
                           [:editing/uid block-uid]
                           [:remote/unregister-followup event-id]]]]})))
 

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -199,7 +199,10 @@
                             [:right-sidebar/open-item page-uid]
 
                             (not (util/is-daily-note page-uid))
-                            [:navigate :page {:id page-uid}])
+                            [:navigate :page {:id page-uid}]
+
+                            (util/is-daily-note page-uid)
+                            [:daily-note/add page-uid])
 
                           [:editing/uid block-uid]
                           [:remote/unregister-followup event-id]]]]})))

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -5,7 +5,7 @@
     [athens.common-events.resolver :as resolver]
     [athens.common-events.schema   :as schema]
     [athens.db                     :as db]
-    [athens.util                    :as util]
+    [athens.util                   :as util]
     [malli.core                    :as m]
     [malli.error                   :as me]
     [re-frame.core                 :as rf]))

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -116,8 +116,8 @@
   []
   (let [route-uid @(subscribe [:current-route/uid])]
     (if (util/is-daily-note route-uid)
-      (dispatch [:daily-notes/add route-uid])
-      (dispatch [:daily-notes/reset]))
+      (dispatch [:daily-note/add route-uid])
+      (dispatch [:daily-note/reset]))
     (navigate :home)))
 
 

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -116,8 +116,8 @@
   []
   (let [route-uid @(subscribe [:current-route/uid])]
     (if (util/is-daily-note route-uid)
-      (dispatch [:daily-note/add route-uid])
-      (dispatch [:daily-note/reset]))
+      (dispatch [:daily-note/reset [route-uid]])
+      (dispatch [:daily-note/reset []]))
     (navigate :home)))
 
 

--- a/src/cljs/athens/views/pages/core.cljs
+++ b/src/cljs/athens/views/pages/core.cljs
@@ -53,5 +53,5 @@
   (let [route-name (rf/subscribe [:current-route/name])]
     [:div (stylefy/use-style main-content-style
                              {:on-scroll (when (= @route-name :home)
-                                           #(daily-notes/db-scroll-daily-notes %))})
+                                           #(rf/dispatch [:daily-note/scroll]))})
      [match-page @route-name]]))

--- a/src/cljs/athens/views/pages/daily_notes.cljs
+++ b/src/cljs/athens/views/pages/daily_notes.cljs
@@ -3,12 +3,10 @@
     [athens.common-db :as common-db]
     [athens.db :as db]
     [athens.style :refer [DEPTH-SHADOWS]]
-    [athens.util :refer [get-day uid-to-date]]
+    [athens.util :refer [get-day]]
     [athens.views.pages.node-page :as node-page]
     [cljsjs.react]
     [cljsjs.react.dom]
-    [goog.dom :refer [getElement]]
-    [goog.functions :refer [debounce]]
     [re-frame.core :refer [dispatch subscribe]]
     [stylefy.core :refer [use-style]]))
 
@@ -39,30 +37,6 @@
 (def daily-notes-notional-page-style
   (merge daily-notes-page-style {:box-shadow (:4 DEPTH-SHADOWS)
                                  :opacity "0.5"}))
-
-
-;; Helpers
-
-
-
-(defn scroll-daily-notes
-  [_]
-  (let [daily-notes @(subscribe [:daily-notes/items])
-        el          (getElement "daily-notes")
-        offset-top  (.. el -offsetTop)
-        rect        (.. el getBoundingClientRect)
-        from-bottom (.. rect -bottom)
-        from-top    (.. rect -top)
-        doc-height  (.. js/document -documentElement -scrollHeight)
-        top-delta   (- offset-top from-top)
-        bottom-delta (- from-bottom doc-height)]
-    ;; Don't allow user to scroll up for now.
-    (cond
-      (< top-delta 1) nil #_(dispatch [:daily-note/prev (get-day (uid-to-date (first daily-notes)) -1)])
-      (< bottom-delta 1) (dispatch [:daily-note/next (get-day (uid-to-date (last daily-notes)) 1)]))))
-
-
-(def db-scroll-daily-notes (debounce scroll-daily-notes 100))
 
 
 (defn safe-pull-many

--- a/src/cljs/athens/views/pages/daily_notes.cljs
+++ b/src/cljs/athens/views/pages/daily_notes.cljs
@@ -1,5 +1,6 @@
 (ns athens.views.pages.daily-notes
   (:require
+    [athens.common-db :as common-db]
     [athens.db :as db]
     [athens.style :refer [DEPTH-SHADOWS]]
     [athens.util :refer [get-day uid-to-date]]
@@ -8,7 +9,6 @@
     [cljsjs.react.dom]
     [goog.dom :refer [getElement]]
     [goog.functions :refer [debounce]]
-    [posh.reagent :refer [pull]]
     [re-frame.core :refer [dispatch subscribe]]
     [stylefy.core :refer [use-style]]))
 
@@ -71,15 +71,11 @@
 
   Bug: It's still possible for a day to not get created. The UI for this just shows an empty page without a title. Acceptable bug :)"
   [ids]
-  (->> ids
-       (map (fn [x] [:block/uid x]))
-       (map (fn [x]
-              (try
-                @(pull db/dsdb '[*] x)
-                (catch js/Error _e
-                  nil))))
-       (filter (fn [x]
-                 (not (nil? x))))))
+  (keep
+    (fn [uid]
+      (try (common-db/get-block @db/dsdb [:block/uid uid])
+           (catch js/Error _e nil)))
+    ids))
 
 
 ;; Components


### PR DESCRIPTION
fixes #1492

From the issue:
- [x] If the daily page already exists, it will act as usual
- [x] If the daily page doesn't exist, it should create it but it shouldn't open that date's node-page.
- [x]  (feature request) ~~when I click on the "daily page" button, it will jump to the latest opened daily page (not today's page).~~ (I decided to maintain the current behavior)

Additional check:

- [x] ~~In remote, after creating a new daily page via scrolling, the new page should be displayed immediately. The delayed response from the server is the issue.~~ CORRECTION: The problem is that the `:daily-notes/items` in app-db is updated first before the page is created.
