### PR TITLE
feat: replace block refs with content

### DIFF
--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -124,39 +124,6 @@
           eid))
 
 
-(defn replace-page-refs-tx
-  "For a given title, unlinks [[brackets]], #[[brackets]], #brackets."
-  [db title]
-  (let [pattern (patterns/linked title)]
-    (->> pattern
-         (get-ref-ids db)
-         (d/pull-many db [:db/id :block/string])
-         (mapv (fn [block]
-                 (let [new-str (string/replace (:block/string block) pattern title)]
-                   (assoc block :block/string new-str)))))))
-
-
-(defn replace-block-refs-tx
-  "For a given block, unlinks ((brackets))."
-  [db uids]
-  (let [block-refs-ids (sequence (comp (map #(patterns/linked %))
-                                       (mapcat #(get-ref-ids db %))
-                                       (distinct))
-                                 uids)
-        block-refs     (d/pull-many db [:db/id :block/string] block-refs-ids)
-        blocks         (sequence (comp (map #(get-block db [:block/uid %]))
-                                       (map #(assoc % :block/pattern (patterns/linked (:block/uid %))))
-                                       (map #(select-keys % [:block/string :block/pattern])))
-                                 uids)]
-    (mapv (fn [block-ref]
-            (let [updated-content (reduce (fn [content {:keys [block/pattern block/string]}]
-                                            (string/replace content pattern string))
-                                          (:block/string block-ref)
-                                          blocks)]
-              (assoc block-ref :block/string updated-content)))
-          block-refs)))
-
-
 (defn get-parent
   "Given `:db/id` find it's parent."
   [db eid]

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -107,15 +107,17 @@
 
 
 (defn replace-linked-refs-tx
-  "For a given title, unlinks [[brackets]], #[[brackets]], and #brackets."
-  [db title]
-  (let [pattern (patterns/linked title)]
-    (->> pattern
-         (get-ref-ids db)
-         (d/pull-many db [:db/id :block/string])
-         (mapv (fn [x]
-                 (let [new-str (string/replace (:block/string x) pattern title)]
-                   (assoc x :block/string new-str)))))))
+  "For a given title, unlinks [[brackets]], #[[brackets]], #brackets, and ((brackets))."
+  ([db title]
+   (replace-linked-refs-tx db title title))
+  ([db uid replacement]
+   (let [pattern (patterns/linked uid)]
+     (->> pattern
+          (get-ref-ids db)
+          (d/pull-many db [:db/id :block/string])
+          (mapv (fn [block]
+                  (let [new-str (string/replace (:block/string block) pattern replacement)]
+                    (assoc block :block/string new-str))))))))
 
 
 (defn get-block

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -135,7 +135,7 @@
                                   db uid))
         retract-blocks     (common-db/retract-uid-recursively-tx db uid)
         delete-linked-refs (->> title
-                                (into [])
+                                vector
                                 (map #(common-db/get-page-uid-by-title db %))
                                 (map #(common-db/get-block db [:block/uid %]))
                                 (replace-linked-refs-tx db))

--- a/src/cljc/athens/common_events/resolver.cljc
+++ b/src/cljc/athens/common_events/resolver.cljc
@@ -1119,13 +1119,10 @@
                                                                  order
                                                                  n)
         retracted-vec                     (mapcat #(common-db/retract-uid-recursively-tx db %) uids)
-        block-refs-replace                (sequence
-                                            (comp
-                                              (map #(common-db/get-block db [:block/uid %]))
-                                              (map #(select-keys % [:block/string :block/uid]))
-                                              (map #(common-db/replace-linked-refs-tx db (:block/uid %) (:block/string %)))
-                                              cat)
-                                            uids)
+        block-refs-replace                (sequence (comp (map #(common-db/get-block db [:block/uid %]))
+                                                          (map #(select-keys % [:block/string :block/uid]))
+                                                          (mapcat #(common-db/replace-linked-refs-tx db (:block/uid %) (:block/string %))))
+                                                    uids)
         tx-data                           (concat retracted-vec
                                                   reindex
                                                   block-refs-replace)]

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -402,7 +402,7 @@
   [:map
    [:event/args
     [:map
-     [:uids [:set string?]]]]])
+     [:uids [:vector string?]]]]])
 
 
 (def datascript-block-open

--- a/src/cljc/athens/patterns.cljc
+++ b/src/cljc/athens/patterns.cljc
@@ -1,14 +1,15 @@
 (ns athens.patterns)
 
 
-;; match [[title]] or #title or #[[title]]
+;; match [[title]] or #title or #[[title]] or ((uid))
 ;; provides groups useful for replacing
 ;; e.g.: $1$3$4new-string$2$5
 (defn linked
   [string]
   (re-pattern (str "(\\[{2})" string "(\\]{2})"
                    "|" "(#)" string
-                   "|" "(#\\[{2})" string "(\\]{2})")))
+                   "|" "(#\\[{2})" string "(\\]{2})"
+                   "|" "(\\({2})" string "(\\){2})")))
 
 
 (defn unlinked


### PR DESCRIPTION
closes #1448 

- [x] replace block refs with content after merge-delete block - local
- [x] replace block refs with content after merge-delete block - remote
- [x] replace block refs with content after multiple selection delete - local
- [x] replace block refs with content after multiple selection delete - remote
- [x] replace multiple block refs with text content
- [x] add tests