### PR TITLE
Fix: RTC timeout in docker-compose setup

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,9 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
-        }
+            proxy_connect_timeout 7d;
+            proxy_send_timeout 7d;
+            proxy_read_timeout 7d;
+       }
     }
 }


### PR DESCRIPTION
Configured timeouts for proxy so it doesn't tread WebSocket connections as normal short lived HTTP connections.