### PR TITLE
fix: broadcast username on update

### DIFF
--- a/src/clj/athens/self_hosted/web/presence.clj
+++ b/src/clj/athens/self_hosted/web/presence.clj
@@ -18,7 +18,7 @@
 (def supported-event-types
   #{:presence/hello
     :presence/editing
-    :presence/username
+    :presence/rename
     :presence/goodbye})
 
 
@@ -59,15 +59,15 @@
         (common-events/build-event-accepted id max-tx)))))
 
 
-(defn username-handler
+(defn rename-handler
   [datahike channel {:event/keys [id args]}]
   (let [{:keys
          [current-username
           new-username]}         args
         max-tx                   (:max-tx @datahike)
-        broadcast-username-event (common-events/build-presence-broadcast-username-event max-tx
-                                                                                        current-username
-                                                                                        new-username)]
+        broadcast-username-event (common-events/build-presence-broadcast-rename-event max-tx
+                                                                                      current-username
+                                                                                      new-username)]
 
     (clients/add-client! channel new-username)
     (clients/broadcast! broadcast-username-event)
@@ -85,5 +85,5 @@
   (condp = type
     :presence/hello   (hello-handler datahike channel event)
     :presence/editing (editing-handler datahike channel event)
-    :presence/username (username-handler datahike channel event)
+    :presence/rename (rename-handler datahike channel event)
     #_#_:presence/goodbye (goodbye-handler channel event)))

--- a/src/clj/athens/self_hosted/web/presence.clj
+++ b/src/clj/athens/self_hosted/web/presence.clj
@@ -18,6 +18,7 @@
 (def supported-event-types
   #{:presence/hello
     :presence/editing
+    :presence/username
     :presence/goodbye})
 
 
@@ -58,6 +59,21 @@
         (common-events/build-event-accepted id max-tx)))))
 
 
+(defn username-handler
+  [datahike channel {:event/keys [id args]}]
+  (let [{:keys
+         [current-username
+          new-username]}         args
+        max-tx                   (:max-tx @datahike)
+        broadcast-username-event (common-events/build-presence-broadcast-username-event max-tx
+                                                                                        current-username
+                                                                                        new-username)]
+
+    (clients/add-client! channel new-username)
+    (clients/broadcast! broadcast-username-event)
+    (common-events/build-event-accepted id max-tx)))
+
+
 (defn goodbye-handler
   [channel _event]
   (let [_username (clients/get-client-username channel)]
@@ -69,4 +85,5 @@
   (condp = type
     :presence/hello   (hello-handler datahike channel event)
     :presence/editing (editing-handler datahike channel event)
+    :presence/username (username-handler datahike channel event)
     #_#_:presence/goodbye (goodbye-handler channel event)))

--- a/src/clj/athens/self_hosted/web/presence.clj
+++ b/src/clj/athens/self_hosted/web/presence.clj
@@ -65,12 +65,12 @@
          [current-username
           new-username]}         args
         max-tx                   (:max-tx @datahike)
-        broadcast-username-event (common-events/build-presence-broadcast-rename-event max-tx
-                                                                                      current-username
-                                                                                      new-username)]
+        broadcast-rename-event (common-events/build-presence-broadcast-rename-event max-tx
+                                                                                    current-username
+                                                                                    new-username)]
 
     (clients/add-client! channel new-username)
-    (clients/broadcast! broadcast-username-event)
+    (clients/broadcast! broadcast-rename-event)
     (common-events/build-event-accepted id max-tx)))
 
 

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -663,23 +663,23 @@
                      :block-uid block-uid}}))
 
 
-(defn build-presence-username-event
+(defn build-presence-rename-event
   "Sent by client when username is updated"
   [last-tx current-username new-username]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
-     :event/type    :presence/username
+     :event/type    :presence/rename
      :event/args    {:current-username current-username
                      :new-username new-username}}))
 
 
-(defn build-presence-broadcast-username-event
+(defn build-presence-broadcast-rename-event
   "Sent by server when the updated username is broadcasted"
   [last-tx current-username new-username]
   (let [event-id (gen-event-id)]
     {:event/id      event-id
      :event/last-tx last-tx
-     :event/type    :presence/broadcast-username
+     :event/type    :presence/broadcast-rename
      :event/args    {:current-username current-username
                      :new-username new-username}}))

--- a/src/cljc/athens/common_events.cljc
+++ b/src/cljc/athens/common_events.cljc
@@ -661,3 +661,25 @@
      :event/type    :presence/broadcast-editing
      :event/args    {:username  username
                      :block-uid block-uid}}))
+
+
+(defn build-presence-username-event
+  "Sent by client when username is updated"
+  [last-tx current-username new-username]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :presence/username
+     :event/args    {:current-username current-username
+                     :new-username new-username}}))
+
+
+(defn build-presence-broadcast-username-event
+  "Sent by server when the updated username is broadcasted"
+  [last-tx current-username new-username]
+  (let [event-id (gen-event-id)]
+    {:event/id      event-id
+     :event/last-tx last-tx
+     :event/type    :presence/broadcast-username
+     :event/args    {:current-username current-username
+                     :new-username new-username}}))

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -10,7 +10,8 @@
 (def event-type-presence
   [:enum
    :presence/hello
-   :presence/editing])
+   :presence/editing
+   :presence/username])
 
 
 (def event-type-presence-server
@@ -18,7 +19,8 @@
    :presence/online
    :presence/all-online
    :presence/offline
-   :presence/broadcast-editing])
+   :presence/broadcast-editing
+   :presence/broadcast-username])
 
 
 (def event-type-graph
@@ -112,6 +114,14 @@
     [:map
      [:username string?]
      [:block-uid string?]]]])
+
+
+(def presence-username
+  [:map
+   [:event/args
+    [:map
+     [:current-username string?]
+     [:new-username string?]]]])
 
 
 (def datascript-create-page
@@ -448,6 +458,7 @@
   [:multi {:dispatch :event/type}
    (dispatch :presence/hello presence-hello-args)
    (dispatch :presence/editing presence-editing)
+   (dispatch :presence/username presence-username)
    (dispatch :datascript/create-page datascript-create-page)
    (dispatch :datascript/rename-page datascript-rename-page)
    ;; Same args as `datascript-rename-page`
@@ -605,6 +616,14 @@
      [:block-uid string?]]]])
 
 
+(def presence-broadcast-username
+  [:map
+   [:event/args
+    [:map
+     [:current-username string?]
+     [:new-username string?]]]])
+
+
 (def server-event
   [:multi {:dispatch :event/type}
    ;; client forwardable events
@@ -657,7 +676,8 @@
    (dispatch :presence/online presence-online true)
    (dispatch :presence/all-online presence-all-online true)
    (dispatch :presence/offline presence-offline true)
-   (dispatch :presence/broadcast-editing presence-broadcast-editing true)])
+   (dispatch :presence/broadcast-editing presence-broadcast-editing true)
+   (dispatch :presence/broadcast-username presence-broadcast-username true)])
 
 
 (def valid-server-event?

--- a/src/cljc/athens/common_events/schema.cljc
+++ b/src/cljc/athens/common_events/schema.cljc
@@ -11,7 +11,7 @@
   [:enum
    :presence/hello
    :presence/editing
-   :presence/username])
+   :presence/rename])
 
 
 (def event-type-presence-server
@@ -20,7 +20,7 @@
    :presence/all-online
    :presence/offline
    :presence/broadcast-editing
-   :presence/broadcast-username])
+   :presence/broadcast-rename])
 
 
 (def event-type-graph
@@ -116,7 +116,7 @@
      [:block-uid string?]]]])
 
 
-(def presence-username
+(def presence-rename
   [:map
    [:event/args
     [:map
@@ -458,7 +458,7 @@
   [:multi {:dispatch :event/type}
    (dispatch :presence/hello presence-hello-args)
    (dispatch :presence/editing presence-editing)
-   (dispatch :presence/username presence-username)
+   (dispatch :presence/rename presence-rename)
    (dispatch :datascript/create-page datascript-create-page)
    (dispatch :datascript/rename-page datascript-rename-page)
    ;; Same args as `datascript-rename-page`
@@ -616,7 +616,7 @@
      [:block-uid string?]]]])
 
 
-(def presence-broadcast-username
+(def presence-broadcast-rename
   [:map
    [:event/args
     [:map
@@ -677,7 +677,7 @@
    (dispatch :presence/all-online presence-all-online true)
    (dispatch :presence/offline presence-offline true)
    (dispatch :presence/broadcast-editing presence-broadcast-editing true)
-   (dispatch :presence/broadcast-username presence-broadcast-username true)])
+   (dispatch :presence/broadcast-rename presence-broadcast-rename true)])
 
 
 (def valid-server-event?

--- a/src/cljs/athens/self_hosted/client.cljs
+++ b/src/cljs/athens/self_hosted/client.cljs
@@ -305,6 +305,12 @@
   (rf/dispatch [:presence/update-editing args]))
 
 
+(defn- presence-receive-username
+  [args]
+  (js/console.log "User username:" (pr-str args))
+  (rf/dispatch [:presence/update-username args]))
+
+
 (defn- forwarded-event-handler
   [args]
   (js/console.log "Forwarded event:" (pr-str args))
@@ -323,6 +329,7 @@
       #{:presence/all-online} (presence-all-online-handler args)
       #{:presence/offline} (presence-offline-handler args)
       #{:presence/broadcast-editing} (presence-receive-editing args)
+      #{:presence/broadcast-username} (presence-receive-username args)
       #{:datascript/create-page
         :datascript/rename-page
         :datascript/merge-page

--- a/src/cljs/athens/self_hosted/client.cljs
+++ b/src/cljs/athens/self_hosted/client.cljs
@@ -305,10 +305,10 @@
   (rf/dispatch [:presence/update-editing args]))
 
 
-(defn- presence-receive-username
+(defn- presence-receive-rename
   [args]
-  (js/console.log "User username:" (pr-str args))
-  (rf/dispatch [:presence/update-username args]))
+  (js/console.log "User rename:" (pr-str args))
+  (rf/dispatch [:presence/update-rename args]))
 
 
 (defn- forwarded-event-handler
@@ -329,7 +329,7 @@
       #{:presence/all-online} (presence-all-online-handler args)
       #{:presence/offline} (presence-offline-handler args)
       #{:presence/broadcast-editing} (presence-receive-editing args)
-      #{:presence/broadcast-username} (presence-receive-username args)
+      #{:presence/broadcast-rename} (presence-receive-rename args)
       #{:datascript/create-page
         :datascript/rename-page
         :datascript/merge-page

--- a/src/cljs/athens/self_hosted/presence/events.cljs
+++ b/src/cljs/athens/self_hosted/presence/events.cljs
@@ -36,7 +36,7 @@
 
 
 (rf/reg-event-db
-  :presence/update-username
+  :presence/update-rename
   (fn [db [_ {:keys [current-username new-username]}]]
     (-> db
         (update-in [:presence :users] set/rename-keys {current-username new-username})
@@ -44,6 +44,6 @@
 
 
 (rf/reg-event-fx
-  :presence/send-username
+  :presence/send-rename
   (fn [_ [_ current-username new-username]]
-    {:fx [[:presence/send-username! [current-username new-username]]]}))
+    {:fx [[:presence/send-rename! [current-username new-username]]]}))

--- a/src/cljs/athens/self_hosted/presence/events.cljs
+++ b/src/cljs/athens/self_hosted/presence/events.cljs
@@ -35,12 +35,12 @@
 
 
 (rf/reg-event-db
- :presence/update-username
- (fn [db [_ {:keys [current-username new-username]}]]
-   (-> db
-       (update-in [:presence :users] assoc new-username (get-in db [:presence :users current-username]))
-       (update-in [:presence :users new-username] assoc :username new-username)
-       (update-in [:presence :users] dissoc current-username))))
+  :presence/update-username
+  (fn [db [_ {:keys [current-username new-username]}]]
+    (-> db
+        (update-in [:presence :users] assoc new-username (get-in db [:presence :users current-username]))
+        (update-in [:presence :users new-username] assoc :username new-username)
+        (update-in [:presence :users] dissoc current-username))))
 
 
 (rf/reg-event-fx

--- a/src/cljs/athens/self_hosted/presence/events.cljs
+++ b/src/cljs/athens/self_hosted/presence/events.cljs
@@ -34,13 +34,13 @@
     (update-in db [:presence :users username] assoc :block/uid block-uid)))
 
 
-(rf/reg-event-fx
-  :presence/update-username
-  (fn [{db :db} [_ {:keys [current-username new-username]}]]
-    {:db (-> db
-             (update-in [:presence :users] assoc new-username (get-in db [:presence :users current-username]))
-             (update-in [:presence :users new-username] assoc :username new-username)
-             (update-in [:presence :users] dissoc current-username))}))
+(rf/reg-event-db
+ :presence/update-username
+ (fn [db [_ {:keys [current-username new-username]}]]
+   (-> db
+       (update-in [:presence :users] assoc new-username (get-in db [:presence :users current-username]))
+       (update-in [:presence :users new-username] assoc :username new-username)
+       (update-in [:presence :users] dissoc current-username))))
 
 
 (rf/reg-event-fx

--- a/src/cljs/athens/self_hosted/presence/events.cljs
+++ b/src/cljs/athens/self_hosted/presence/events.cljs
@@ -33,3 +33,17 @@
   (fn [db [_ {:keys [username block-uid]}]]
     (update-in db [:presence :users username] assoc :block/uid block-uid)))
 
+
+(rf/reg-event-fx
+  :presence/update-username
+  (fn [{db :db} [_ {:keys [current-username new-username]}]]
+    {:db (-> db
+             (update-in [:presence :users] assoc new-username (get-in db [:presence :users current-username]))
+             (update-in [:presence :users new-username] assoc :username new-username)
+             (update-in [:presence :users] dissoc current-username))}))
+
+
+(rf/reg-event-fx
+  :presence/send-username
+  (fn [_ [_ current-username new-username]]
+    {:fx [[:presence/send-username! [current-username new-username]]]}))

--- a/src/cljs/athens/self_hosted/presence/events.cljs
+++ b/src/cljs/athens/self_hosted/presence/events.cljs
@@ -1,6 +1,7 @@
 (ns athens.self-hosted.presence.events
   (:require
     [athens.self-hosted.presence.utils :as utils]
+    [clojure.set :as set]
     [re-frame.core :as rf]))
 
 
@@ -38,9 +39,8 @@
   :presence/update-username
   (fn [db [_ {:keys [current-username new-username]}]]
     (-> db
-        (update-in [:presence :users] assoc new-username (get-in db [:presence :users current-username]))
-        (update-in [:presence :users new-username] assoc :username new-username)
-        (update-in [:presence :users] dissoc current-username))))
+        (update-in [:presence :users] set/rename-keys {current-username new-username})
+        (update-in [:presence :users new-username] assoc :username new-username))))
 
 
 (rf/reg-event-fx

--- a/src/cljs/athens/self_hosted/presence/fx.cljs
+++ b/src/cljs/athens/self_hosted/presence/fx.cljs
@@ -12,6 +12,6 @@
 
 
 (rf/reg-fx
-  :presence/send-username!
+  :presence/send-rename!
   (fn [[current-username new-username]]
-    (client/send! (common-events/build-presence-username-event 42 current-username new-username))))
+    (client/send! (common-events/build-presence-rename-event 42 current-username new-username))))

--- a/src/cljs/athens/self_hosted/presence/fx.cljs
+++ b/src/cljs/athens/self_hosted/presence/fx.cljs
@@ -10,3 +10,8 @@
   (fn [uid]
     (client/send! (common-events/build-presence-editing-event 42 @(rf/subscribe [:username]) uid))))
 
+
+(rf/reg-fx
+  :presence/send-username!
+  (fn [[current-username new-username]]
+    (client/send! (common-events/build-presence-username-event 42 current-username new-username))))

--- a/src/cljs/athens/views/pages/settings.cljs
+++ b/src/cljs/athens/views/pages/settings.cljs
@@ -226,7 +226,7 @@
     [:main
      [textinput/textinput {:type         "text"
                            :placeholder  "Username"
-                           :on-blur      #(update-fn (js-event->val %))
+                           :on-blur      #(update-fn username (js-event->val %))
                            :defaultValue username}]
      [:aside
       [:p "For now, a username is only needed if you are connected to a server."]]]]])
@@ -272,5 +272,7 @@
                                  (dispatch [:settings/update :backup-time x])
                                  (dispatch [:fs/update-write-db]))]
       [remote-backups-comp]
-      [remote-username-comp username #(dispatch [:settings/update :username %])]
+      [remote-username-comp username (fn [current-username new-username]
+                                       (dispatch [:presence/send-username current-username new-username])
+                                       (dispatch [:settings/update :username new-username]))]
       [reset-settings-comp #(dispatch [:settings/reset])]]]))

--- a/src/cljs/athens/views/pages/settings.cljs
+++ b/src/cljs/athens/views/pages/settings.cljs
@@ -273,6 +273,6 @@
                                  (dispatch [:fs/update-write-db]))]
       [remote-backups-comp]
       [remote-username-comp username (fn [current-username new-username]
-                                       (dispatch [:presence/send-username current-username new-username])
+                                       (dispatch [:presence/send-rename current-username new-username])
                                        (dispatch [:settings/update :username new-username]))]
       [reset-settings-comp #(dispatch [:settings/reset])]]]))


### PR DESCRIPTION
- This PR fixes #1514.
- This will now allow the username to be updated to every client in the lan-party when one of the clients updated the user name.
- A new event to send the new user is created in the presence module on the client-side. This event will be triggered when the username on the settings page is updated.
- A new event is added on the server-side to broadcast the new user name.
- On the server-side, the atom, `athens.self-hosted.clients/clients` is also updated when the user name is changed. This is to ensure that the newly connected clients will get the latest list of user names.
- ~~On the server-side, I'm also thinking if the `editing-handler` and `username-handler` can be generalized but I'm unsure yet on how to do it.~~