### PR TITLE
fix: deleted daily page is blank to other clients

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -6,7 +6,8 @@
     [clojure.string :as string]
     [datascript.core :as d]
     [posh.reagent :refer [posh! pull q]]
-    [re-frame.core :refer [dispatch]]))
+    [re-frame.core :refer [dispatch]]
+    [reagent.core :as r]))
 
 
 ;; -- Example Roam DBs ---------------------------------------------------
@@ -220,6 +221,12 @@
 
 
 (defonce dsdb (d/create-conn schema))
+
+
+(defonce tx-update (r/atom {}))
+
+
+(d/listen! dsdb :tx-update #(reset! tx-update %))
 
 
 ;; todo: turn into an effect

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -457,6 +457,12 @@
     (update db :daily-notes/items (comp rseq sort distinct conj) uid)))
 
 
+(reg-event-db
+  :daily-note/remove
+  (fn [db [_ uid]]
+    (update db :daily-notes/items (fn [xs] (remove #(= % uid) xs)))))
+
+
 (reg-event-fx
   :daily-note/prev
   (fn [{:keys [db]} [_ {:keys [uid title]}]]


### PR DESCRIPTION
Fixes #1623

Changes:
1. Added the `d/listen!` fn to let the daily pages know if the datascript db is updated.
2. Added the `:daily-note/remove` event to remove the deleted daily note from daily notes page.