### PR TITLE
fix: all pages is slow when a page has 100+ blocks

### DIFF
--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -413,6 +413,15 @@
        (get-data db)))
 
 
+(defn get-all-pages
+  [db]
+  (->> (d/q '[:find [?e ...]
+              :where
+              [?e :node/title ?t]]
+            db)
+       (d/pull-many db '[* :block/_refs])))
+
+
 (defn not-contains?
   [coll v]
   (not (contains? coll v)))


### PR DESCRIPTION
Fixes #1638 

Changes:
1. Removed the "Body" column because it's the main cause of the slow performance. But @shanberg needs to look at this. 🕶
2. Moved the query fn to `common-db`
3. Removed the `preview-body` fn because it's not needed