### PR TITLE
Update style variables

### DIFF
--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -21,8 +21,7 @@
     [goog.dom :refer [getElement]]
     [goog.object :as gobj]
     [re-frame.core :as rf]
-    [reagent.dom :as r-dom]
-    [stylefy.core :as stylefy]))
+    [reagent.dom :as r-dom]))
 
 
 (goog-define SENTRY_DSN "")

--- a/src/cljs/athens/core.cljs
+++ b/src/cljs/athens/core.cljs
@@ -114,7 +114,6 @@
   (init-sentry)
   (init-ipcRenderer)
   (style/init)
-  (stylefy/tag "body" style/app-styles)
   (listeners/init)
   (init-datalog-console)
   (rf/dispatch-sync (boot-evts))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -548,8 +548,7 @@
 (reg-event-fx
   :theme/set
   (fn [{:keys [db]} _]
-    (let [theme (if (-> db :athens/persist :theme/dark) style/THEME-DARK style/THEME-LIGHT)]
-      {:stylefy/tag [":root" (style/permute-color-opacities theme)]})))
+    (if (-> db :athens/persist :theme/dark) style/THEME-DARK style/THEME-LIGHT)))
 
 
 (reg-event-fx

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -2,7 +2,6 @@
   (:require
     [athens.config :as config]
     [athens.util :as util]
-    [garden.color :refer [opacify hex->hsl]]
     [re-frame.core :refer [reg-sub subscribe]]
     [stylefy.core :as stylefy]
     [stylefy.reagent :as stylefy-reagent]))

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -98,7 +98,6 @@
           ")"))))
 
 
-
 (reg-sub
   :zoom-level
   (fn [db _]

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -99,81 +99,6 @@
           ")"))))
 
 
-;; Base Styles
-
-(def base-styles
-  {:background-color (color :background-color)
-   :font-family      "IBM Plex Sans, Sans-Serif"
-   :color            (color :body-text-color)
-   :font-size        "16px"                                 ; Sets the Rem unit to 16px
-   :line-height      "1.5"
-   ::stylefy/manual  [[:a {:color (color :link-color)}]
-                      [:h1 :h2 :h3 :h4 :h5 :h6 {:margin      "0.2em 0"
-                                                :line-height "1.3"
-                                                :color       (color :header-text-color)}]
-                      [:h1 {:font-size      "3.125em"
-                            :font-weight    600
-                            :letter-spacing "-0.03em"}]
-                      [:h2 {:font-size      "2.375em"
-                            :font-weight    500
-                            :letter-spacing "-0.03em"}]
-                      [:h3 {:font-size      "1.75em"
-                            :font-weight    500
-                            :letter-spacing "-0.02em"}]
-                      [:h4 {:font-size "1.3125em"}]
-                      [:h5 {:font-size      "0.75em"
-                            :font-weight    500
-                            :line-height    "1em"
-                            :letter-spacing "0.08em"
-                            :text-transform "uppercase"}]
-                      [:.MuiSvgIcon-root {:font-size "1.5rem"}]
-                      [:input {:font-family "inherit"}]
-                      [:mark {:background-color (color :text-highlight-color)
-                              :border-radius "0.25rem"
-                              :color "#000"}]
-                      [:kbd {:text-transform "uppercase"
-                             :font-family    "inherit"
-                             :font-size      "0.85em"
-                             :letter-spacing "0.05em"
-                             :font-weight    600
-                             :display        "inline-flex"
-                             :background     (color :body-text-color :opacity-lower)
-                             :border-radius  "0.25rem"
-                             :padding        "0.25em 0.5em"}]
-                      [:img {:max-width "100%"
-                             :height    "auto"}]
-                      [":focus" {:outline-width 0}]
-                      [":focus-visible" {:outline-width "1px"}]]})
-
-
-(def app-styles
-  {:overflow "hidden"
-   :height   "100vh"
-   :width    "100vw"})
-
-
-(def codemirror-styles
-  {:z-index 10
-   :height  "min-content"})
-
-
-(defn permute-color-opacities
-  "Permutes all colors and opacities.
-  There are 5 opacities and 12 colors. There are 72 keys (includes default opacity, 1.0)"
-  [theme]
-  (->> theme
-       (mapcat (fn [[color-k color-v]]
-                 (concat [(keyword (str "--" (symbol color-k)))
-                          color-v]
-                         (mapcat (fn [[opacity-k opacity-v]]
-                                   [(keyword (str "--"
-                                                  (symbol color-k)
-                                                  "---"
-                                                  (symbol opacity-k)))
-                                    (opacify (hex->hsl color-v) opacity-v)])
-                                 OPACITIES))))
-       (apply hash-map)))
-
 
 (reg-sub
   :zoom-level
@@ -227,9 +152,6 @@
 (defn init
   []
   (stylefy/init {:dom (stylefy-reagent/init)})
-  (stylefy/tag "html" base-styles)
-  (stylefy/tag "*" {:box-sizing "border-box"})
-  (stylefy/class "CodeMirror" codemirror-styles)
   ;; hide re-frame-10x by default
   (when config/debug?
     (util/hide-10x)))

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -230,11 +230,6 @@
   (stylefy/tag "html" base-styles)
   (stylefy/tag "*" {:box-sizing "border-box"})
   (stylefy/class "CodeMirror" codemirror-styles)
-  (let [permute-light (permute-color-opacities THEME-LIGHT)
-        permute-dark  (permute-color-opacities THEME-DARK)]
-    (stylefy/tag ":root" (merge permute-light
-                                {:font-size "16px"
-                                 ::stylefy/media {{:prefers-color-scheme "dark"} permute-dark}})))
   ;; hide re-frame-10x by default
   (when config/debug?
     (util/hide-10x)))

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -269,7 +269,7 @@
       :mac "os-mac"
       :linux "os-linux")
     (if electron? "is-electron" "is-web")
-    (if theme-dark? "theme-dark" "theme-light")
+    (if theme-dark? "is-theme-dark" "is-theme-light")
     (when win-focused? "is-focused")
     (when win-fullscreen? "is-fullscreen")
     (when win-maximized? "is-maximized")]))

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -1,5 +1,6 @@
 (ns athens.views
   (:require
+    ["/components/utils/style/style" :refer [GlobalStyles]]
     ["@material-ui/core/Snackbar" :as Snackbar]
     [athens.config]
     [athens.electron.db-modal :as db-modal]
@@ -70,6 +71,7 @@
     (fn []
       [:div (merge {:style {:display "contents"}}
                    (zoom))
+        [:> GlobalStyles]
        [alert]
        (let [{:keys [msg type]} @(rf/subscribe [:db/snack-msg])]
          [m-snackbar

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -70,10 +70,10 @@
         modal      (rf/subscribe [:modal])
         theme-dark (rf/subscribe [:theme/dark])]
     (fn []
-      [:div {:class (app-classes {:os os
-                                  :electron? electron?
-                                  :theme-dark? @theme-dark})}
-            (merge {:style {:display "contents"}}
+      [:div (merge {:class (app-classes {:os os
+                                         :electron? electron?
+                                         :theme-dark? @theme-dark})}
+                   {:style {:display "contents"}}
                    (zoom))
         [:> GlobalStyles]
        [alert]

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -6,7 +6,7 @@
     [athens.electron.db-modal :as db-modal]
     [athens.style :refer [zoom]]
     [athens.subs]
-    [athens.util :refer [get-os electron?]]
+    [athens.util :refer [get-os electron? app-classes]]
     [athens.views.app-toolbar :as app-toolbar]
     [athens.views.athena :refer [athena-component]]
     [athens.views.devtool :refer [devtool-component]]
@@ -67,9 +67,13 @@
   (let [loading    (rf/subscribe [:loading?])
         os         (get-os)
         electron?  (electron?)
-        modal      (rf/subscribe [:modal])]
+        modal      (rf/subscribe [:modal])
+        theme-dark (rf/subscribe [:theme/dark])]
     (fn []
-      [:div (merge {:style {:display "contents"}}
+      [:div {:class (app-classes {:os os
+                                  :electron? electron?
+                                  :theme-dark? @theme-dark})}
+            (merge {:style {:display "contents"}}
                    (zoom))
         [:> GlobalStyles]
        [alert]

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -75,7 +75,7 @@
                                          :theme-dark? @theme-dark})}
                    {:style {:display "contents"}}
                    (zoom))
-        [:> GlobalStyles]
+       [:> GlobalStyles]
        [alert]
        (let [{:keys [msg type]} @(rf/subscribe [:db/snack-msg])]
          [m-snackbar

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -46,9 +46,9 @@
                                               :justify-content "center"
                                               :border 0}
                                      [:svg {:font-size "16px"}]]
-                      [:&.theme-light [:button:hover {:filter "brightness(92%)"}]]
-                      [:&.theme-dark [:button:hover {:filter "brightness(150%)"}]]
-                      [:&.theme-dark :&.theme-light [:button.close:hover {:background "#E81123" ; Windows close button background color
+                      [:&.is-theme-light [:button:hover {:filter "brightness(92%)"}]]
+                      [:&.is-theme-dark [:button:hover {:filter "brightness(150%)"}]]
+                      [:&.is-theme-dark :&.theme-light [:button.close:hover {:background "#E81123" ; Windows close button background color
                                                                           :filter "none"
                                                                           :color "#fff"}]]]
                      ;; Styles for linux (Ubuntu)
@@ -79,8 +79,8 @@
                        [:&.minimize [:svg {:position "relative"
                                            :top "5px"}]]
                        [:svg {:font-size "12px"}]]
-                      [:&.theme-light [:button:hover {:filter "brightness(92%)"}]]
-                      [:&.theme-dark [:button:hover {:filter "brightness(150%)"}]]
+                      [:&.is-theme-light [:button:hover {:filter "brightness(92%)"}]]
+                      [:&.is-theme-dark [:button:hover {:filter "brightness(150%)"}]]
                       [:&.is-focused ["button.close::before" {:background "#E9541F"}]]]]})
 
 

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -49,8 +49,8 @@
                       [:&.is-theme-light [:button:hover {:filter "brightness(92%)"}]]
                       [:&.is-theme-dark [:button:hover {:filter "brightness(150%)"}]]
                       [:&.is-theme-dark :&.theme-light [:button.close:hover {:background "#E81123" ; Windows close button background color
-                                                                          :filter "none"
-                                                                          :color "#fff"}]]]
+                                                                             :filter "none"
+                                                                             :color "#fff"}]]]
                      ;; Styles for linux (Ubuntu)
                      [:&.os-linux {:display "grid"
                                    :padding "4px"

--- a/src/js/components/concept/AppToolbar/components/WindowButtons.tsx
+++ b/src/js/components/concept/AppToolbar/components/WindowButtons.tsx
@@ -33,7 +33,7 @@ const Wrapper = styled.div`
       &:hover {
         backdrop-filter: brightness(92%);
 
-        .theme-dark & {
+        .is-theme-dark & {
           backdrop-filter: brightness(150%);
         }
       }
@@ -109,12 +109,12 @@ const Wrapper = styled.div`
         font-size: 12px;
       }
 
-      .theme-light & {
+      .is-theme-light & {
         button:hover:before {
           backdrop-filter: brightness(92%);
         }
       }
-      .theme-dark & {
+      .is-theme-dark & {
         button:hover:before {
           backdrop-filter: brightness(150%);
         }

--- a/src/js/components/utils/style/style.ts
+++ b/src/js/components/utils/style/style.ts
@@ -127,19 +127,102 @@ export const GlobalStyles = createGlobalStyle`
     }
   }
 
-  body {
-    min-height: 100vh;
-    background: var(--background-color);
-    font-family: var(--font-family-default);
-    color: var(--body-text-color);
-    font-size: 16px;
-    line-height: 1.5;
+  * {
+    box-sizing: border-box;
   }
 
   html {
     padding: 0;
     margin: 0;
     height: 100vh;
+    background: var(--background-color);
+    font-family: var(--font-family-default);
+    color: var(--body-text-color);
+    font-size: 16px;
+    line-height: 1.5;
+
+    a {
+      color: var(--link-color);
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin: 0.2em 0;
+      line-height: 1.3;
+      color: var(--header-text-color);
+    }
+
+    h1 {
+      font-size: 3.123em;
+      font-weight: 600;
+      letter-spacing: -0.03em;
+    }
+
+    h2 {
+      font-size: 2.375em;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+    }
+
+    h3 {
+      font-size: 1.75em;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+    }
+
+    h4 {
+      font-size: 1.3125em;
+    }
+
+    h5 {
+      font-size: 0.75em;
+      font-weight: 500;
+      line-height: 1em;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .MuiSvgIcon-root {
+      font-size: 1.5rem;
+    }
+
+    input {
+      font-family: inherit;
+    }
+
+    mark {
+      background-color: var(--highlight-color);
+      border-radius: 0.25rem;
+      color: #000;
+    }
+
+    kbd {
+      text-transform: uppercase;
+      font-family: inherit;
+      font-size: 0.85em;
+      letter-spacing: 0.05em;
+      font-weight: 600;
+      display: inline-flex;
+      background: var(--body-text-color---opacity-lower);
+      border-radius: 0.25rem;
+      padding: 0.25rem 0.5rem;
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    :focus {
+      outline-width: none;
+    }
+    :focus-visible {
+      outline-width: 1px;
+    }
+  }
+
+  body {
+    overflow: hidden;
+    height: 100vh;
+    width: 100vw;
   }
 
   * {

--- a/src/js/components/utils/style/style.ts
+++ b/src/js/components/utils/style/style.ts
@@ -2,83 +2,83 @@ import { createGlobalStyle } from 'styled-components';
 import { transparentize, readableColor } from 'polished';
 
 export const permuteColorOpacities = (theme) =>
-    Object.keys(theme).map((color) => {
-        return (
-            `--${color}: ${theme[color]};` +
-            `--${color}---contrast: ${readableColor(theme[color])};` +
-            Object.keys(opacities)
-                .map((opacity) => {
-                    return `--${color}---${opacity}: ${transparentize(
-                        1 - opacities[opacity],
-                        theme[color]
-                    )};`;
-                })
-                .join("")
-        );
-    });
+  Object.keys(theme).map((color) => {
+    return (
+      `--${color}: ${theme[color]};` +
+      `--${color}---contrast: ${readableColor(theme[color])};` +
+      Object.keys(opacities)
+        .map((opacity) => {
+          return `--${color}---${opacity}: ${transparentize(
+            1 - opacities[opacity],
+            theme[color]
+          )};`;
+        })
+        .join("")
+    );
+  });
 
 export const opacityStyles = () => Object.keys(opacities).map(opacity => `--${opacity}: ${opacities[opacity]};`).join("")
 
 const opacities = {
-    "opacity-lower": 0.1,
-    "opacity-low": 0.25,
-    "opacity-med": 0.5,
-    "opacity-high": 0.75,
-    "opacity-higher": 0.85,
-    "opacity-05": 0.05,
-    "opacity-10": 0.10,
-    "opacity-15": 0.15,
-    "opacity-20": 0.20,
-    "opacity-25": 0.25,
-    "opacity-30": 0.30,
-    "opacity-80": 0.80,
-    "opacity-90": 0.9,
+  "opacity-lower": 0.1,
+  "opacity-low": 0.25,
+  "opacity-med": 0.5,
+  "opacity-high": 0.75,
+  "opacity-higher": 0.85,
+  "opacity-05": 0.05,
+  "opacity-10": 0.10,
+  "opacity-15": 0.15,
+  "opacity-20": 0.20,
+  "opacity-25": 0.25,
+  "opacity-30": 0.30,
+  "opacity-80": 0.80,
+  "opacity-90": 0.9,
 };
 
 export const themeLight = {
-    "link-color": "#0071DB",
-    "highlight-color": "#F9A132",
-    "text-highlight-color": "#ffdb8a",
-    "warning-color": "#D20000",
-    "confirmation-color": "#009E23",
-    "header-text-color": "#322F38",
-    "body-text-color": "#433F38",
-    "border-color": "hsla(32, 81%, 10%, 0.08)",
-    "background-plus-2": "#fff",
-    "background-plus-1": "#fbfbfb",
-    "background-color": "#F6F6F6",
-    "background-minus-1": "#FAF8F6",
-    "background-minus-2": "#EFEDEB",
-    "graph-control-bg": "#f9f9f9",
-    "graph-control-color": "black",
-    "graph-node-normal": "#909090",
-    "graph-node-hlt": "#0075E1",
-    "graph-link-normal": "#cfcfcf",
-    "error-color": "#fd5243", // Deprecate. Replace with "danger-color"
-    "shadow-color": "#000"
+  "link-color": "#0071DB",
+  "highlight-color": "#F9A132",
+  "text-highlight-color": "#ffdb8a",
+  "warning-color": "#D20000",
+  "confirmation-color": "#009E23",
+  "header-text-color": "#322F38",
+  "body-text-color": "#433F38",
+  "border-color": "hsla(32, 81%, 10%, 0.08)",
+  "background-plus-2": "#fff",
+  "background-plus-1": "#fbfbfb",
+  "background-color": "#F6F6F6",
+  "background-minus-1": "#FAF8F6",
+  "background-minus-2": "#EFEDEB",
+  "graph-control-bg": "#f9f9f9",
+  "graph-control-color": "black",
+  "graph-node-normal": "#909090",
+  "graph-node-hlt": "#0075E1",
+  "graph-link-normal": "#cfcfcf",
+  "error-color": "#fd5243", // Deprecate. Replace with "danger-color"
+  "shadow-color": "#000"
 }
 
 export const themeDark = {
-    "link-color": "#0071DB",
-    "highlight-color": "#FBBE63",
-    "text-highlight-color": "#FBBE63",
-    "warning-color": "#DE3C21",
-    "confirmation-color": "#189E36",
-    "header-text-color": "#BABABA",
-    "body-text-color": "#AAA",
-    "border-color": "hsla(32, 81%, 90%, 0.08)",
-    "background-minus-1": "#151515",
-    "background-minus-2": "#111",
-    "background-color": "#1A1A1A",
-    "background-plus-1": "#222",
-    "background-plus-2": "#333",
-    "graph-control-bg": "#272727",
-    "graph-control-color": "white",
-    "graph-node-normal": "#909090",
-    "graph-node-hlt": "#FBBE63",
-    "graph-link-normal": "#323232",
-    "error-color": "#fd5243", // Deprecate. Replace with "danger-color"
-    "shadow-color": "#000"
+  "link-color": "#0071DB",
+  "highlight-color": "#FBBE63",
+  "text-highlight-color": "#FBBE63",
+  "warning-color": "#DE3C21",
+  "confirmation-color": "#189E36",
+  "header-text-color": "#BABABA",
+  "body-text-color": "#AAA",
+  "border-color": "hsla(32, 81%, 90%, 0.08)",
+  "background-minus-1": "#151515",
+  "background-minus-2": "#111",
+  "background-color": "#1A1A1A",
+  "background-plus-1": "#222",
+  "background-plus-2": "#333",
+  "graph-control-bg": "#272727",
+  "graph-control-color": "white",
+  "graph-node-normal": "#909090",
+  "graph-node-hlt": "#FBBE63",
+  "graph-link-normal": "#323232",
+  "error-color": "#fd5243", // Deprecate. Replace with "danger-color"
+  "shadow-color": "#000"
 }
 
 const lightThemeColors = permuteColorOpacities(themeLight);

--- a/src/js/components/utils/style/style.ts
+++ b/src/js/components/utils/style/style.ts
@@ -179,10 +179,6 @@ export const GlobalStyles = createGlobalStyle`
       text-transform: uppercase;
     }
 
-    .MuiSvgIcon-root {
-      font-size: 1.5rem;
-    }
-
     input {
       font-family: inherit;
     }
@@ -226,5 +222,9 @@ export const GlobalStyles = createGlobalStyle`
 
   * {
     box-sizing: border-box;
+  }
+
+  .MuiSvgIcon-root {
+    font-size: 1.5rem;
   }
 `;

--- a/src/js/components/utils/style/style.ts
+++ b/src/js/components/utils/style/style.ts
@@ -111,7 +111,6 @@ export const GlobalStyles = createGlobalStyle`
     --font-size--text-2xl: 1.5rem;
 
     ${opacityStyles}
-    ${lightThemeColors}
 
     .is-theme-light {
       ${lightThemeColors}


### PR DESCRIPTION
Replaces the core styles with the new one from the TS library. Not a complete changeover yet but a unit of work.

Should appear exactly the same, except in the Presence menu where this change fixes some visual bugs.

- Removes cljs base style inclusions (style variables, html and body styles, etc.), replacing them with TS equivalents.
- Slightly changes the way the theme colors are applied to the DOM, mostly moving it into a classname applied near the root.
  - app-toolbar still subscribes to the theme, because it’s using an older form of styling that isn't able to respond to classes on higher components. Everything else just inherits the current theme from the DOM.

Considerations for later:
- Refactor out the `color` function to eliminate the code duplication between the remaining CLJ styles and TS styles, or only do that once we've replaced all other components?