### PR TITLE
feat(presence): ui support for multiple presence

### DIFF
--- a/src/cljs/athens/self_hosted/presence/views.cljs
+++ b/src/cljs/athens/self_hosted/presence/views.cljs
@@ -1,56 +1,16 @@
 (ns athens.self-hosted.presence.views
   (:require
+    ["/components/Avatar/Avatar" :refer [Avatar]]
     ["/components/PresenceDetails/PresenceDetails" :refer [PresenceDetails]]
     [athens.self-hosted.presence.events]
     [athens.self-hosted.presence.fx]
     [athens.self-hosted.presence.subs]
     [re-frame.core :as rf]
-    [reagent.core :as r]
-    [stylefy.core :as stylefy :refer [use-style]]))
+    [reagent.core :as r]))
 
 
 ;; Avatar
 
-
-(defn- avatar-svg
-  [props & children]
-  [:svg (merge (use-style {:height          "1.5em"
-                           :width           "1.5em"
-                           :overflow        "hidden"
-                           :border-radius   "1000em"}
-                          {:class "user-avatar"})
-               props)
-   children])
-
-
-(defn- avatar-el
-  "Takes a member map for the user data.
-  Optionally takes some props for things like fill."
-  ([member]
-   [avatar-el member {:filled true}])
-  ([{:keys [username color]} {:keys [filled]}]
-   (let [initials (if (string? username)
-                    (subs username 0 2)
-                    "")]
-     [avatar-svg {:viewBox "0 0 24 24"
-                  :vectorEffect "non-scaling-stroke"}
-      [:circle {:cx          12
-                :cy          12
-                :r           12
-                :fill        color
-                :stroke      color
-                :fillOpacity (when-not filled 0.1)
-                :strokeWidth (if filled 0 "3px")
-                :key "circle"}]
-      [:text {:width      24
-              :x          12
-              :y          16.5
-              :font-size  14
-              :font-weight 600
-              :fill       (if filled "#fff" color)
-              :textAnchor "middle"
-              :key "text"}
-       initials]])))
 
 
 (defn user->person
@@ -133,4 +93,13 @@
   [uid]
   (let [inline-present? (rf/subscribe [:presence/has-presence uid])]
     (when @inline-present?
-      [avatar-el @inline-present?])))
+    [:> (.-Stack Avatar)
+     {:size "1.25rem"
+      :maskSize "1px"
+      :stackOrder "from-left"
+      :limit 3
+      :style {:transform "translateX(calc(-100% + 1rem)) translateY(0.35rem)"
+              :padding "0.125rem"
+              :background "var(--background-color)"}}
+     [:> Avatar (merge {:showTooltip false} @inline-present?)]])))
+

--- a/src/cljs/athens/self_hosted/presence/views.cljs
+++ b/src/cljs/athens/self_hosted/presence/views.cljs
@@ -93,13 +93,13 @@
   [uid]
   (let [inline-present? (rf/subscribe [:presence/has-presence uid])]
     (when @inline-present?
-    [:> (.-Stack Avatar)
-     {:size "1.25rem"
-      :maskSize "1px"
-      :stackOrder "from-left"
-      :limit 3
-      :style {:transform "translateX(calc(-100% + 1rem)) translateY(0.35rem)"
-              :padding "0.125rem"
-              :background "var(--background-color)"}}
-     [:> Avatar (merge {:showTooltip false} @inline-present?)]])))
+      [:> (.-Stack Avatar)
+       {:size "1.25rem"
+        :maskSize "1px"
+        :stackOrder "from-left"
+        :limit 3
+        :style {:transform "translateX(calc(-100% + 1rem)) translateY(0.35rem)"
+                :padding "0.125rem"
+                :background "var(--background-color)"}}
+       [:> Avatar (merge {:showTooltip false} @inline-present?)]])))
 

--- a/src/cljs/athens/views/blocks/content.cljs
+++ b/src/cljs/athens/views/blocks/content.cljs
@@ -55,7 +55,6 @@
                                  :opacity "0"
                                  :font-family "inherit"}]
                      [:&:hover [:textarea [(selectors/& (selectors/not :.is-editing)) {:line-height 2}]]]
-                     [:&.is-locked {:opacity "0.5"}]
                      [:.is-editing {:z-index 3
                                     :line-height "inherit"
                                     :opacity "1"}]
@@ -369,7 +368,7 @@
   The CSS class is-editing is used for many things, such as block selection.
   Opacity is 0 when block is selected, so that the block is entirely blue, rather than darkened like normal editing.
   is-editing can be used for shift up/down, so it is used in both editing and selection."
-  [block state is-presence]
+  [block state]
   (let [{:block/keys [uid original-uid header]} block
         editing? (rf/subscribe [:editing/is-editing uid])
         selected-items (rf/subscribe [::select-subs/items])]
@@ -379,8 +378,7 @@
                         2 "1.7em"
                         3 "1.3em"
                         "1em")]
-        [:div {:class ["block-content"
-                       (when is-presence "is-locked")]
+        [:div {:class ["block-content"]
                :style {:font-size font-size}}
          ;; NOTE: komponentit forces reflow, likely a performance bottle neck
          ;; When block is in editing mode or the editing DOM elements are rendered

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -1,6 +1,5 @@
 (ns athens.views.blocks.core
   (:require
-    ["/components/Avatar/Avatar" :refer [Avatar]]
     ["/components/Button/Button" :refer [Button]]
     [athens.db                               :as db]
     [athens.electron.images                  :as images]

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -1,5 +1,6 @@
 (ns athens.views.blocks.core
   (:require
+    ["/components/Avatar/Avatar" :refer [Avatar]]
     ["/components/Button/Button" :refer [Button]]
     [athens.db                               :as db]
     [athens.electron.images                  :as images]
@@ -45,7 +46,6 @@
                                                      :transform  "translateX(50%)"
                                                      :transition "background-color 0.2s ease-in-out"
                                                      :background (style/color :border-color)}]
-                     ["&.is-presence.show-tree-indicator:before" {:background [["var(--user-color)"]]}]
                      [:&:after {:content        "''"
                                 :z-index        -1
                                 :position       "absolute"
@@ -60,7 +60,6 @@
                                 :background     (style/color :link-color :opacity-lower)}]
                      [:&.is-selected:after {:opacity 1}]
                      [:.user-avatar {:position "absolute"
-                                     :transition "transform 0.3s ease"
                                      :left "4px"
                                      :top "4px"}]
                      [:.block-body {:display               "grid"
@@ -85,8 +84,7 @@
                                                   :bottom     0
                                                   :left       0}]]
                      [:.block-content {:grid-area  "content"
-                                       :min-height "1.5em"}
-                      [:&:hover [:+ [:.user-avatar {:transform "translateX(-2em)"}]]]]
+                                       :min-height "1.5em"}]
                      [:&.is-linked-ref {:background-color (style/color :background-plus-2)}]
                      ;; Inset child blocks
                      [:.block-container {:margin-left "2rem"

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -347,7 +347,6 @@
                                (when (and (seq children) open) "show-tree-indicator")
                                (when (and (false? initial-open) (= uid linked-ref-uid)) "is-linked-ref")
                                (when is-presence "is-presence")]
-           :style             {"--user-color" (if is-presence (:color present-user) nil)}
            :data-uid          uid
            ;; need to know children for selection resolution
            :data-childrenuids children-uids

--- a/src/js/components/Avatar/Avatar.tsx
+++ b/src/js/components/Avatar/Avatar.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import styled from 'styled-components';
-import { Fade, Popper, PopperPlacementType } from '@material-ui/core';
-import { readableColor } from 'polished';
+import React from "react";
+import styled, { css } from "styled-components";
+import { Fade, Popper, PopperPlacementType } from "@material-ui/core";
+import { readableColor } from "polished";
 
-import { DOMRoot } from '@/utils/config';
+import { DOMRoot } from "@/utils/config";
+import { Stack } from "./Avatar.stories";
 
 const Wrapper = styled.svg`
   overflow: visible;
@@ -34,8 +35,8 @@ const FullName = styled.span`
 
 export interface AvatarProps extends React.SVGProps<SVGSVGElement>, Person {
   /**
-  * The primary color of the icon
-  */
+   * The primary color of the icon
+   */
   color: string;
   /**
    * The full username of the person
@@ -52,27 +53,29 @@ export interface AvatarProps extends React.SVGProps<SVGSVGElement>, Person {
   /**
    * Whether to show the user's full name. Set to 'hover' to show it when interacting with the icon.
    */
-  showTooltip?: boolean | 'hover';
+  showTooltip?: boolean | "hover";
   /**
    * Where the tooltip should appear relative to the icon.
    */
-  tooltipPlacement?: PopperPlacementType
+  tooltipPlacement?: PopperPlacementType;
 }
 
 /**
  * Visual representation of a human user
-*/
+ */
 export const Avatar = ({
   username,
   color,
-  showTooltip = 'hover',
-  tooltipPlacement = 'right',
+  showTooltip = "hover",
+  tooltipPlacement = "right",
   isMuted = false,
   size,
   ...props
 }: AvatarProps) => {
   const [avatarEl, setAvatarEl] = React.useState();
-  const [isShowingTooltip, setIsShowingTooltip] = React.useState(showTooltip === 'hover' ? false : showTooltip);
+  const [isShowingTooltip, setIsShowingTooltip] = React.useState(
+    showTooltip === "hover" ? false : showTooltip
+  );
 
   const avatarColors = {
     "--avatar-background-opacity": isMuted ? 0.2 : 1,
@@ -80,11 +83,16 @@ export const Avatar = ({
     "--avatar-text-color": isMuted ? color : readableColor(color),
     "--tooltip-text-color": readableColor(color),
     "--tooltip-background-color": color,
-  }
+  };
 
   let initials;
   if (username) {
-    initials = username.split(' ').map(word => word[0]).join('').slice(0, 2).toUpperCase();
+    initials = username
+      .split(" ")
+      .map((word) => word[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
   }
 
   return (
@@ -92,8 +100,12 @@ export const Avatar = ({
       <Wrapper
         viewBox="0 0 24 24"
         ref={setAvatarEl}
-        onMouseOver={() => { if (showTooltip === 'hover') setIsShowingTooltip(true) }}
-        onMouseLeave={() => { if (showTooltip === 'hover') setIsShowingTooltip(false) }}
+        onMouseOver={() => {
+          if (showTooltip === "hover") setIsShowingTooltip(true);
+        }}
+        onMouseLeave={() => {
+          if (showTooltip === "hover") setIsShowingTooltip(false);
+        }}
         {...props}
         style={{ ...avatarColors, "--size": size, ...props.style }}
       >
@@ -131,7 +143,9 @@ export const Avatar = ({
             <FullName
               className={"tooltip-" + tooltipPlacement}
               style={avatarColors}
-            >{username}</FullName>
+            >
+              {username}
+            </FullName>
           </Fade>
         )}
       </Popper>
@@ -139,41 +153,115 @@ export const Avatar = ({
   );
 };
 
-
-/* 
-* Wraps a horizontal series of avatars and causes them to overlap each other.
-*/
+/*
+ * Wraps a horizontal series of avatars and causes them to overlap each other.
+ */
 interface AvatarStackProps {
+  children: React.ReactChild[];
   /**
    * The width of the mask added to overlapping Avatars.
    */
-  maskSize?: string,
+  limit?: number;
+  /**
+   * The width of the mask added to overlapping Avatars.
+   */
+  maskSize?: string;
   /**
    * The size of Avatars. Can be overridden by the same property on child Avatars.
    */
-  size?: string,
+  stackOrder?: "from-left" | "from-right";
   /**
    * How much Avatars should overlap. 0.5 is 50% overlap.
    */
-  overlap?: number
+  size?: string;
+  /**
+   * How much Avatars should overlap. 0.5 is 50% overlap.
+   */
+  overlap?: number;
 }
 
-Avatar.Stack = styled.div<AvatarStackProps>`
-  --mask-size: ${props => props.maskSize || '3px'};
-  --size: ${props => props.size || undefined};
-  --stack-overlap: ${props => props.overlap || '0.5'};
+const StackWrapper = styled.div<AvatarStackProps>`
+  --mask-size: ${(props) => props.maskSize || "3px"};
+  --size: ${(props) => props.size || undefined};
+  --stack-overlap: ${(props) => props.overlap || "0.5"};
   display: inline-flex;
+  align-items: center;
+  width: max-content;
+  height: max-content;
+  border-radius: 100em;
 
   ${Wrapper} {
-    &:not(:first-of-type) {
-      margin-inline-start: calc(var(--size, 1.5em) * (var(--stack-overlap) * -1));
-      mask-image: radial-gradient(
-        calc(var(--size, 1.5em) + var(--mask-size)) calc((var(--size, 1.5em) * (2 / 3)) + var(--mask-size)) at calc(-100% + (100% * (var(--stack-overlap)))) 50%,
-        transparent 99%,
-        #000 100%);
-    }
+    ${(props) =>
+    props.stackOrder === `from-left`
+      ? css`
+            &:not(:last-of-type) {
+              margin-inline-end: calc(
+                var(--size, 1.5em) * (var(--stack-overlap) * -1)
+              );
+              mask-image: radial-gradient(
+                calc(var(--size, 1.5em) + var(--mask-size))
+                  calc((var(--size, 1.5em) * (2 / 3)) + var(--mask-size)) at
+                  calc(100% + (100% * (var(--stack-overlap)))) 50%,
+                transparent 99%,
+                #000 100%
+              );
+            }
+          `
+      : css`
+            &:not(:first-of-type) {
+              margin-inline-start: calc(
+                var(--size, 1.5em) * (var(--stack-overlap) * -1)
+              );
+              mask-image: radial-gradient(
+                calc(var(--size, 1.5em) + var(--mask-size))
+                  calc((var(--size, 1.5em) * (2 / 3)) + var(--mask-size)) at
+                  calc(-100% + (100% * (var(--stack-overlap)))) 50%,
+                transparent 99%,
+                #000 100%
+              );
+            }
+          `}
   }
 `;
+
+Avatar.Stack = React.forwardRef((props: AvatarStackProps, ref) => {
+  const {
+    children,
+    limit = Infinity,
+    size,
+    maskSize = "3px",
+    overlap = 0.5,
+    stackOrder = "from-right",
+    ...rest
+  } = props;
+
+  let Children = React.Children.toArray(children);
+  let overflow = Children.length - limit;
+
+  return (
+    <StackWrapper
+      ref={ref}
+      stackOrder={stackOrder}
+      style={{
+        "--size": size,
+        "--mask-size": maskSize,
+        "--stack-overlap": overlap,
+      }}
+      {...rest}
+    >
+      {Children.map((avatar) => React.cloneElement(avatar, { size }))}
+      {overflow > 0 && (
+        <Avatar
+          personId="overflow"
+          showTooltip={false}
+          username={`+ ${overflow}`}
+          color="#888"
+          size={size}
+        />
+      )}
+    </StackWrapper>
+  );
+});
 
 Avatar.Wrapper = Wrapper;
 Avatar.Fullname = FullName;

--- a/src/js/components/PresenceDetails/PresenceDetails.tsx
+++ b/src/js/components/PresenceDetails/PresenceDetails.tsx
@@ -192,7 +192,7 @@ export const PresenceDetails = ({
             <Avatar.Stack
               size="1em"
               maskSize="1.5px"
-              overlap="0.2"
+              overlap={0.2}
             >
               {showablePersons && showablePersons.slice(0, maxToDisplay).map((member, index) => {
                 if (index < maxToDisplay) {


### PR DESCRIPTION
Goal
- Multiple avatars per block
- Removes 'locked' properties from block elements

Changes
- Avatar stacks can limit the number of avatars they show, with the overflow displayed as (+N) avatar
- Avatar stacks can reverse the direction of avatar overlap
- Avatars on blocks wrapped in stack
- Block elements no longer change color based on current presence