### PR TITLE
improvement(blocks): hide block toggle unless interacting

### DIFF
--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -42,9 +42,12 @@
                                                      :left       "calc(1.375em + 1px)"
                                                      :top        "2em"
                                                      :bottom     "0"
+                                                     :opacity    "0"
                                                      :transform  "translateX(50%)"
-                                                     :transition "background-color 0.2s ease-in-out"
+                                                     :transition "background-color 0.2s ease-in-out, opacity 0.2s ease-in-out"
                                                      :background (style/color :border-color)}]
+                     [:&:hover
+                      :&:focus-within [:&.show-tree-indicator:before {:opacity "1"}]]
                      [:&:after {:content        "''"
                                 :z-index        -1
                                 :position       "absolute"
@@ -70,6 +73,8 @@
                                       'below below below below'"
                                     :border-radius         "0.5rem"
                                     :position              "relative"}
+                      [:&:hover
+                       :&:focus-within ["> .block-toggle" {:opacity "1"}]]
                       [:button.block-edit-toggle {:position   "absolute"
                                                   :appearance "none"
                                                   :width      "100%"
@@ -108,8 +113,7 @@
                             :grid-area "refs"
                             :z-index (:zindex-dropdown style/ZINDICES)
                             :visibility (when-not (pos? count) "hidden")})
-   [:> Button {:is-primary true
-               :on-click (fn [e]
+   [:> Button {:on-click (fn [e]
                            (.. e stopPropagation)
                            (rf/dispatch [:right-sidebar/open-item uid]))}
     count]])

--- a/src/cljs/athens/views/blocks/toggle.cljs
+++ b/src/cljs/athens/views/blocks/toggle.cljs
@@ -16,13 +16,14 @@
    :display "flex"
    :background "none"
    :border "none"
-   :transition "color 0.05s ease"
+   :transition "color 0.05s ease, opacity 0.2s ease-in-out"
    :align-items "center"
    :justify-content "center"
    :cursor "pointer"
    :padding "0"
    :-webkit-appearance "none"
    :color (style/color :body-text-color :opacity-med)
+   :opacity "0"
    ::stylefy/manual [[:&:hover {:color (style/color :link-color)}]
                      [:&:before {:content "''"
                                  :inset "0.25rem -0.125rem"
@@ -50,8 +51,8 @@
   [:button (stylefy/use-style block-disclosure-toggle-style
                               {:class    (if (or (and (true? linked-ref) (:linked-ref/open @state))
                                                  (and (false? linked-ref) open))
-                                           "open"
-                                           "closed")
+                                           "block-toggle open"
+                                           "block-toggle closed")
                                :tab-index 0
                                :on-click (fn [e]
                                            (.. e stopPropagation)


### PR DESCRIPTION
- Hides block toggle and tree indicator (line odwn the left side) until hover or focus within a block