### PR TITLE
fix(block-references) #1680 block reference counter not opening

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -625,6 +625,8 @@
        (mapv :db/id)
        merge-parents-and-block
        group-by-parent
+       (sort-by #(-> % first second))
+       (map #(vector (ffirst %) (second %)))
        vec))
 
 


### PR DESCRIPTION
In addition to fixing the error, it also sorts the references by date added. This is the same behavior as with linked references.  
Close #1680 