### PR TITLE
ci: ping alpha tester on new release (proposal)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
       #       curl \
       #       -H "Content-Type: application/json" \
       #       # how to ping roles manually: https://support.discord.com/hc/en-us/community/posts/360057835772-Role-Pinging-for-Bots
-      #       -d '{"username": "athens", "content": "Hey <@&${{ secrets.discord_alpha_role }}> a new release has been published \n\n[Go check it out!](https://github.com/athensresearch/athens/releases)"}' \
+      #       -d '{"username": "Athens", "avatar_url": "https://github.com/athensresearch/athens-assets/raw/main/athens-512x512.png", "content": "Hey <@&${{ secrets.discord_alpha_role }}> a new release has been published \n\n[Go check it out!](https://github.com/athensresearch/athens/releases)"}' \
       #       ${{ secrets.discord_webhook }}
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,14 @@ jobs:
            API_KEY_ID: ${{ secrets.api_key_id }}
            API_KEY_ISSUER_ID: ${{ secrets.api_key_issuer_id }}
 
+      #  - name: Notify Alpha Testers of new release
+      #    run: |
+      #       curl \
+      #       -H "Content-Type: application/json" \
+      #       # how to ping roles manually: https://support.discord.com/hc/en-us/community/posts/360057835772-Role-Pinging-for-Bots
+      #       -d '{"username": "athens", "content": "Hey <@&${{ secrets.discord_alpha_role }}> a new release has been published \n\n[Go check it out!](https://github.com/athensresearch/athens/releases)"}' \
+      #       ${{ secrets.discord_webhook }}
+
 
    release-server:
      runs-on: ubuntu-latest


### PR DESCRIPTION
The idea was to have a way to automatically ping users with a certain role from the github workflow.

Would need some beforehand setup in discord:
- create webhook url
- invite a reaction roles bot and set it up so users can give themselves different roles, e.g. "alpha tester", "beta tester" ... etc
- make a seperate channel that is only viewable by these roles. That way only those roles see the spam by this new webhook