### PR TITLE
fix(presence): presence menu appears over toolbar

### DIFF
--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -25,6 +25,8 @@
 
 (def app-wrapper-style
   {:display "grid"
+   :position "relative"
+   :z-index "1"
    :grid-template-areas
    "'app-header app-header app-header'
     'left-sidebar main-content secondary-content'

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -25,8 +25,6 @@
 
 (def app-wrapper-style
   {:display "grid"
-   :position "relative"
-   :z-index "1"
    :grid-template-areas
    "'app-header app-header app-header'
     'left-sidebar main-content secondary-content'

--- a/src/js/components/AppToolbar/AppToolbar.tsx
+++ b/src/js/components/AppToolbar/AppToolbar.tsx
@@ -19,7 +19,7 @@ const AppToolbarWrapper = styled.header`
   padding-left: 10px;
   grid-template-columns: auto 1fr auto;
   transition: border-color 1s ease;
-  z-index: 1070;
+  z-index: var(--zindex-sticky);
   grid-auto-flow: column;
   -webkit-app-region: drag;
 

--- a/src/js/components/utils/style/style.ts
+++ b/src/js/components/utils/style/style.ts
@@ -139,6 +139,7 @@ export const GlobalStyles = createGlobalStyle`
     color: var(--body-text-color);
     font-size: 16px;
     line-height: 1.5;
+    position: relative;
 
     a {
       color: var(--link-color);


### PR DESCRIPTION
- Ensures the app toolbar doesn't break out of base layout containment

To test:
- Open presence menu, see that it isn't clipped by the apptoolbar
- Open a dialog (like merge from roam) and see the dimming backdrop properly covers the whole screen, including the app toolbar