### PR TITLE
fix(apptoolbar): unzoom toolbar, correct default zoom

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -128,7 +128,7 @@
                :daily-notes/items   []
                :selection           {:items []}
                :theme/dark          false
-               :zoom-level          1
+               :zoom-level          0
                :fs/watcher          nil
                :presence            {}
                :connection-status   :disconnected})

--- a/src/cljs/athens/style.cljs
+++ b/src/cljs/athens/style.cljs
@@ -144,7 +144,7 @@
 (defn unzoom
   []
   (let [zoom-level (subscribe [:zoom-level])]
-    {:style {:font-size (str "calc(1 / " (get-zoom-pct @zoom-level) " * 100 * 100%)")}}))
+    {:font-size (str "calc(1 / " (get-zoom-pct @zoom-level) " * 100 * 100%)")}))
 
 
 (defn init

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -10,7 +10,6 @@
     [athens.subs]
     [athens.util :as util]
     [re-frame.core :refer [subscribe dispatch]]
-    
     [reagent.core :as r]))
 
 

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -6,9 +6,11 @@
     [athens.electron.utils :as electron.utils]
     [athens.router :as router]
     [athens.self-hosted.presence.views :refer [toolbar-presence-el]]
+    [athens.style :refer [unzoom]]
     [athens.subs]
     [athens.util :as util]
     [re-frame.core :refer [subscribe dispatch]]
+    
     [reagent.core :as r]))
 
 
@@ -36,7 +38,8 @@
       [:<>
        (when @merge-open?
          [db-modal/merge-modal merge-open?])
-       [:> AppToolbar {:os os
+       [:> AppToolbar {:style (unzoom)
+                       :os os
                        :isElectron electron?
                        :route @route-name
                        :isWinFullscreen @win-fullscreen?

--- a/src/js/components/AppToolbar/AppToolbar.tsx
+++ b/src/js/components/AppToolbar/AppToolbar.tsx
@@ -167,13 +167,10 @@ export const AppToolbar = (props: AppToolbarProps): React.ReactElement => {
     onPressClose: handlePressClose,
     databaseMenu,
     presenceDetails,
+    ...rest
   } = props;
 
-  console.log("props");
-  console.log(props);
-  console.log(isElectron, databaseMenu, presenceDetails)
-
-  return (<AppToolbarWrapper>
+  return (<AppToolbarWrapper {...rest}>
     <AppToolbar.MainControls>
       {databaseMenu}
       <Button

--- a/src/js/components/AppToolbar/AppToolbar.tsx
+++ b/src/js/components/AppToolbar/AppToolbar.tsx
@@ -66,6 +66,16 @@ const AppToolbarWrapper = styled.header`
   }
 `;
 
+const AthenaButton = styled(Button)`
+  ${Button.Wrap} {
+    gap: 0;
+    
+    svg {
+      margin-right: 0;
+    }
+  }
+`;
+
 export interface AppToolbarProps extends React.HTMLAttributes<HTMLDivElement>, DatabaseMenuProps, PresenceDetailsProps {
   /**
   * The application's current route
@@ -189,7 +199,7 @@ export const AppToolbar = (props: AppToolbarProps): React.ReactElement => {
       <Button isPressed={route === '/daily-notes'} onClick={handlePressDailyNotes}><Today /></Button>
       <Button isPressed={route === '/all-pages'} onClick={handlePressAllPages}><FileCopy /></Button>
       <Button isPressed={route === '/graph'} onClick={handlePressGraph}><BubbleChart /></Button>
-      <Button isPressed={isCommandBarOpen} onClick={handlePressCommandBar}><Search /> <span>Find or create a page</span></Button>
+      <AthenaButton isPressed={isCommandBarOpen} onClick={handlePressCommandBar}><Search /> <span>Find or create a page</span></AthenaButton>
     </AppToolbar.MainControls>
     <AppToolbar.SecondaryControls>
       {presenceDetails}

--- a/src/js/components/Button/Button.tsx
+++ b/src/js/components/Button/Button.tsx
@@ -18,11 +18,11 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   /**
    * Button shape. Set to 'unset' to manually style padding and radius.
    */
-  shape: 'rect' | 'round' | 'unset';
+  shape?: 'rect' | 'round' | 'unset';
   /**
    * Button shape style. Set to 'unset' to manually style color and interaction styles.
    */
-  variant: 'plain' | 'gray' | 'tinted' | 'filled' | 'unset';
+  variant?: 'plain' | 'gray' | 'tinted' | 'filled' | 'unset';
   /**
    * Styles provided to the button's focus ring.
    */

--- a/src/js/components/Button/Button.tsx
+++ b/src/js/components/Button/Button.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 import { classnames } from '@/utils/classnames';
 import { useFocusRing } from '@react-aria/focus'
+import { useFocusRingEl } from '@/utils/useFocusRingEl';
 import { mergeProps } from '@react-aria/utils';
 import { DOMRoot } from '@/utils/config';
 
@@ -161,40 +162,13 @@ const ButtonWrap = styled.button.attrs<ButtonProps>(props => {
   }
 `;
 
-const FocusRing = styled.div`
-  --inset: -3px;
-  position: absolute;
-  inset: -3px;
-  border: 2px solid var(--link-color);
-  top: calc(var(--top) + var(--inset));
-  left: calc(var(--left) + var(--inset));
-  width: calc(var(--width) - var(--inset) * 2);
-  height: calc(var(--height) - var(--inset) * 2);
-  z-index: 99999;
-
-  &.shape-round {
-    border-radius: 1000em;
-  }
-
-  &.shape-rect {
-    border-radius: calc(0.25rem - var(--inset));
-  }
-`;
-
-const focusRingRectStyle = (rectProps: DOMRect, otherProps) => {
-  return {
-    "--left": rectProps.left + 'px',
-    "--top": rectProps.top + 'px',
-    "--width": rectProps.width + 'px',
-    "--height": rectProps.height + 'px',
-    ...otherProps
-  };
+interface Result extends React.ForwardRefExoticComponent<ButtonProps> {
+  Wrap?: typeof ButtonWrap;
 }
 
-const _Button = React.forwardRef((props: ButtonProps, ref): any => {
-  let { isFocusVisible, focusProps } = useFocusRing();
+const _Button: Result = React.forwardRef((props: ButtonProps, ref): any => {
   ref = ref || React.useRef();
-  let focusRingRect = ref.current?.getBoundingClientRect();
+  let { FocusRing, focusProps } = useFocusRingEl(ref);
 
   return <>
     <ButtonWrap
@@ -205,16 +179,7 @@ const _Button = React.forwardRef((props: ButtonProps, ref): any => {
       )}>
       {props.children}
     </ButtonWrap>
-    {isFocusVisible &&
-      ReactDOM.createPortal(
-        <FocusRing className={classnames(
-          props.shape && 'shape-' + props.shape,
-          props.variant && 'variant-' + props.variant,
-        )}
-          style={focusRingRectStyle(focusRingRect, props.focusRingStyle)}
-        />, DOMRoot()
-      )
-    }
+    {FocusRing}
   </>;
 });
 

--- a/src/js/components/utils/useFocusRingEl.tsx
+++ b/src/js/components/utils/useFocusRingEl.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import styled from "styled-components";
+import { useFocusRing } from "@react-aria/focus";
+import { DOMRoot } from "@/utils/config";
+
+const focusRingRectStyle = (ref): any => {
+  const position = ref?.current?.getBoundingClientRect();
+  const style = getComputedStyle(ref?.current);
+  const borderTopLeftRadius = style.borderTopLeftRadius;
+  const borderTopRightRadius = style.borderTopRightRadius;
+  const borderBottomRightRadius = style.borderBottomRightRadius;
+  const borderBottomLeftRadius = style.borderBottomLeftRadius;
+  let inset = style.getPropertyValue("--focus-ring-inset");
+  if (inset === "") {
+    inset = "-3px";
+  }
+
+  return {
+    "--inset": inset,
+    "--left": position.left + "px",
+    "--top": position.top + "px",
+    "--width": position.width + "px",
+    "--height": position.height + "px",
+    "--border-top-left-radius": borderTopLeftRadius,
+    "--border-top-right-radius": borderTopRightRadius,
+    "--border-bottom-right-radius": borderBottomRightRadius,
+    "--border-bottom-left-radius": borderBottomLeftRadius,
+  };
+};
+
+const FocusRingEl = styled.div<React.HTMLAttributes<HTMLDivElement>>`
+  position: absolute;
+  inset: var(--inset);
+  border: 2px solid var(--link-color);
+  box-shadow: inset 0 0 0 1px var(--background-color);
+  top: calc(var(--top) + var(--inset));
+  left: calc(var(--left) + var(--inset));
+  width: calc(var(--width) - var(--inset) * 2);
+  height: calc(var(--height) - var(--inset) * 2);
+  z-index: 99999;
+  pointer-events: none;
+  border-top-left-radius: calc(var(--border-top-left-radius) - var(--inset));
+  border-top-right-radius: calc(var(--border-top-right-radius) - var(--inset));
+  border-bottom-left-radius: calc(
+    var(--border-bottom-left-radius) - var(--inset)
+  );
+  border-bottom-right-radius: calc(
+    var(--border-bottom-right-radius) - var(--inset)
+  );
+`;
+
+export const useFocusRingEl = (ref) => {
+  const { isFocusVisible, focusProps } = useFocusRing(ref);
+
+  const FocusRing = isFocusVisible ? (
+    ReactDOM.createPortal(
+      <FocusRingEl style={focusRingRectStyle(ref)} />,
+      DOMRoot,
+    )
+  ) : (
+    <></>
+  );
+
+  return {
+    isFocusVisible,
+    focusProps,
+    FocusRing,
+  };
+};


### PR DESCRIPTION
- App toolbar should _not_ zoom when the content zooms
- Default zoom level is 0, not 1. Zooming levels are deltas from the baseline, which is zero
- Removes extra console logs
- Makes unnecessary button props optional

To test:
- Use cmd/ctrl+ to zoom in, cmd/ctrl- to zoom out. Content should change size, but toolbar should not.
- Default zoom level should make things appear smaller than in recent builds