### PR TITLE
Postgres support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,6 +41,7 @@
                  ;;   TODO: monitor https://github.com/replikativ/datahike/issues/364 and
                  ;;   and uncomment tests that refer to this issue when it is fixed.
                  [io.replikativ/datahike "0.3.7-SNAPSHOT"]
+                 [io.replikativ/datahike-postgres "0.1.0"]
                  ;;   web server
                  [http-kit/http-kit "2.5.3"]
                  [compojure/compojure "1.6.2"]


### PR DESCRIPTION
adds https://github.com/replikativ/datahike-postgres to the project dependecies