### PR TITLE
feat: `:page/new` can be composite op.

### DIFF
--- a/src/cljc/athens/common_events/graph/atomic.cljc
+++ b/src/cljc/athens/common_events/graph/atomic.cljc
@@ -76,14 +76,12 @@
 (defn make-page-new-op
   "Creates `:page/new` atomic op.
    - `title` - Page title page to be created
-   - `page-uid` - `:block/uid` of page to be created
-   - `block-uid` - `:block/uid` of 1st block to be created in page to be created"
-  [title page-uid block-uid]
+   - `page-uid` - `:block/uid` of page to be created"
+  [title page-uid]
   {:op/type    :page/new
    :op/atomic? true
-   :op/args    {:title     title
-                :page-uid  page-uid
-                :block-uid block-uid}})
+   :op/args    {:title    title
+                :page-uid page-uid}})
 
 
 (defn make-page-rename-op

--- a/src/cljc/athens/common_events/graph/schema.cljc
+++ b/src/cljc/athens/common_events/graph/schema.cljc
@@ -50,8 +50,7 @@
    [:op/args
     [:map
      [:title string?]
-     [:page-uid string?]
-     [:block-uid string?]]]])
+     [:page-uid string?]]]])
 
 
 (def atomic-op

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -592,9 +592,10 @@
   (fn [{:keys [db]} [_ {:keys [title page-uid block-uid shift?] :or {shift? false} :as args}]]
     (log/debug ":page/create args" (pr-str args))
     (let [event (common-events/build-atomic-event (:remote/last-seen-tx db)
-                                                  (atomic-graph-ops/make-page-new-op title
-                                                                                     page-uid
-                                                                                     block-uid))]
+                                                  (graph-ops/build-page-new-op @db/dsdb
+                                                                               title
+                                                                               page-uid
+                                                                               block-uid))]
       {:fx [[:dispatch-n [[:resolve-transact-forward event]
                           (cond
                             shift?
@@ -851,9 +852,10 @@
   :page/new
   (fn [{:keys [db]} [_ {:keys [title page-uid block-uid] :as args}]]
     (log/debug ":page/new args" (pr-str args))
-    (let [op    (atomic-graph-ops/make-page-new-op title
-                                                   page-uid
-                                                   block-uid)
+    (let [op    (graph-ops/build-page-new-op @db/dsdb
+                                             title
+                                             page-uid
+                                             block-uid)
           event (common-events/build-atomic-event (:remote/last-seen-tx db) op)]
       {:fx [[:dispatch-n [[:resolve-transact-forward event]
                           [:editing/uid block-uid]]]]})))

--- a/src/cljs/athens/self_hosted/client.cljs
+++ b/src/cljs/athens/self_hosted/client.cljs
@@ -487,7 +487,6 @@
   (send! (common-events/build-atomic-event
           1
           (atomic-graph-ops/make-page-new-op "test title"
-                                             "abc123"
-                                             "abc1234"))))
+                                             "page-uid-1"))))
 
 

--- a/test/athens/common_events/atomic_ops/block_new_test.clj
+++ b/test/athens/common_events/atomic_ops/block_new_test.clj
@@ -44,7 +44,7 @@
           (t/is (seq children))
           (t/is (= #{[child-2-eid]} children))))))
 
-  (t/testing "Create new block in page"
+  (t/testing "Create new block between 2 blocks"
     (let [page-1-uid  "page-2-uid"
           child-1-uid "child-2-1-uid"
           child-2-uid "child-2-2-uid"

--- a/test/athens/common_events/atomic_ops/block_save_test.clj
+++ b/test/athens/common_events/atomic_ops/block_save_test.clj
@@ -43,7 +43,11 @@
       (t/is (false? atomic?))
       (t/is (= :block/save (:op/type trigger)))
       (t/is (= 2 (count consequences)))
-      (t/is (= :page/new (-> consequences first :op/type)))
+      (t/is (= :composite/consequence (-> consequences first :op/type)))
+      (t/is (= 2 (-> consequences
+                     first
+                     :op/consequences
+                     count)))
       (t/is (= #:op{:type    :block/save,
                     :atomic? true,
                     :args

--- a/test/athens/common_events/atomic_ops/page_new_test.clj
+++ b/test/athens/common_events/atomic_ops/page_new_test.clj
@@ -1,33 +1,42 @@
 (ns athens.common-events.atomic-ops.page-new-test
   (:require
+    [athens.common-db                     :as common-db]
     [athens.common-events.fixture         :as fixture]
     [athens.common-events.graph.atomic    :as atomic-graph-ops]
+    [athens.common-events.graph.ops       :as graph-ops]
     [athens.common-events.resolver.atomic :as atomic-resolver]
     [clojure.test                         :as t]
     [datahike.api                         :as d]))
 
 
-(t/use-fixtures :each fixture/integration-test-fixture)
+(t/use-fixtures :each (partial fixture/integration-test-fixture []))
 
 
-(t/deftest page-new-test
-  (t/testing "Page new test"
-    (let [test-title        "test page title"
-          test-page-uid     "test-page-uid-1"
-          test-block-uid    "test-block-uid-1"
-          page-new-event   (atomic-graph-ops/make-page-new-op test-title
-                                                              test-page-uid
-                                                              test-block-uid)
-          page-new-txs     (atomic-resolver/resolve-atomic-op-to-tx @@fixture/connection
-                                                                    page-new-event)]
+(t/deftest page-new-atomic-test
+  (t/testing "page/new when page didn't exist yet"
+    (let [test-title     "test page title"
+          test-page-uid  "test-page-uid-1"
+          page-new-event (atomic-graph-ops/make-page-new-op test-title
+                                                            test-page-uid)
+          page-new-txs   (atomic-resolver/resolve-atomic-op-to-tx @@fixture/connection
+                                                                  page-new-event)]
       (d/transact @fixture/connection page-new-txs)
       (let [e-by-title (d/q '[:find ?e
                               :where [?e :node/title ?title]
                               :in $ ?title]
                             @@fixture/connection test-title)
-            e-by-uid (d/q '[:find ?e
-                            :where [?e :block/uid ?uid]
-                            :in $ ?uid]
-                          @@fixture/connection test-page-uid)]
+            e-by-uid   (d/q '[:find ?e
+                              :where [?e :block/uid ?uid]
+                              :in $ ?uid]
+                            @@fixture/connection test-page-uid)]
         (t/is (seq e-by-title))
         (t/is (= e-by-title e-by-uid))))))
+
+
+(t/deftest page-new-composite-test
+  (t/testing "that `:page/new` generates composite ops when page doesn't exist."
+    (let [page-uid    "page-uid-1"
+          page-title  "page 1 title"
+          block-uid   "block-uid-1-1"
+          page-new-op (graph-ops/build-page-new-op @@fixture/connection page-title page-uid block-uid)]
+      (t/is (= :composite/consequence (:op/type page-new-op))))))


### PR DESCRIPTION
`:page/new` doesn't create a block anymore,
instead it delegates to `:block/new` op.