### PR TITLE
Fix the issue with merging blocks using the delete key

### DIFF
--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -704,6 +704,9 @@
         next-block-uid            (db/next-block-uid o-uid)]
     (when (and no-selection? end? next-block-uid)
       (let [next-block (db/get-block [:block/uid (-> next-block-uid db/uid-and-embed-id first)])]
+        ;; save the state of this block before merging with the next one
+        ;; (do the same thing as "blur" does)
+        (db/transact-state-for-uid uid state)
         (dispatch [:backspace (cond-> next-block-uid
                                 embed-id (str "-embed-" embed-id))
                    (str (:block/string state) (:block/string next-block))])))))


### PR DESCRIPTION
Fixes https://github.com/athensresearch/athens/issues/560. I've got hit by it, so I'm proposing a fix.

To sum up:

The problem happened when:
1. there are 2 consecutive non-empty blocks
2. user changes the first one (e.g. deletes a character)
3. user moves the cursor to the end of the first block and hits the
   delete key

Instead of merging visible the blocks, the first block gets "reverted"
to the old state (as if the 2nd step didn't happen).

Fixed by transacting the block to the db before merging the blocks.