### PR TITLE
Basic warnings for unsupported browsers

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -10,6 +10,9 @@
       <link rel="stylesheet" href="./css/codemirror.css" type="text/css" />
       <style id="_stylefy-constant-styles_"></style>
       <style id="_stylefy-styles_"></style>
+      <noscript>
+        JavaScript must be enabled in your browser
+      </noscript>
       <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
         posthog.init('qouvHPR2-blOal8-l6CSmFybj8VWojBlv472Ac-ovAI',{api_host:'https://app.posthog.com', persistence:'localStorage'})
@@ -28,19 +31,32 @@
         localStorage.setItem("day8.re-frame-10x.show-panel","\"true\"")
         localStorage.setItem("day8.re-frame-10x.using-trace?","\"true\"")
       }
+      function isBrowserSupported() {
+        return window.chrome !== undefined;
+      }
+      function showUnsupportedBrowserWarning() {
+          let warnDiv = window.document.createElement("div");
+          warnDiv.innerText = "Only browsers based on Chrome/Chromium are supported";
+          window.document.body.appendChild(warnDiv);
+      }
     </script>
     <script>
-      var electron = isElectron()
-      var src = ""
-      if (electron) {
-         src = "js/compiled/renderer.js"
-         show10x() // 10x exists on DOM by default, but athens.style hides via CSS
+      if (!isBrowserSupported()) {
+        showUnsupportedBrowserWarning();
       } else {
-         src = "js/compiled/app.js"
+        var electron = isElectron()
+        var src = ""
+        if (electron) {
+           src = "js/compiled/renderer.js"
+           show10x() // 10x exists on DOM by default, but athens.style hides via CSS
+        } else {
+           src = "js/compiled/app.js"
+        }
+
+        var script = document.createElement("script");
+        script.setAttribute("src", src);
+        document.getElementsByTagName("head")[0].appendChild(script);
       }
-      var script = document.createElement("script");
-      script.setAttribute("src", src);
-      document.getElementsByTagName("head")[0].appendChild(script);
     </script>
   </body>
 </html>


### PR DESCRIPTION
1. Display a warning when JS is disabled in the browser (previously the  browser just displayed a blank page). Tested with the links browser as well with chromium with JS disabled.
2. Display a warning for browsers other than chrome/chromium (previously a JS error popup was displayed). See #1718 and #1705. Tested on Chromium Version 92.0.4515.159 (openSUSE Build), Opera 79.0 (warning not displayed) and Firefox 78.12 (warning displayed).

It's nothing fancy: there is no CSS styling applied to the warnings, but I believe it's still better than the current status.

Firefox:
![ss1](https://user-images.githubusercontent.com/1412268/136698250-bb7819e5-0eef-47a7-adcd-cd06a6bf938f.png)

Chrome w/o JS:
![ss2](https://user-images.githubusercontent.com/1412268/136698270-30ee0726-4884-4325-93fc-65d45c412aac.png)


