### PR TITLE
Default server config

### DIFF
--- a/dev/clj/config.edn
+++ b/dev/clj/config.edn
@@ -1,4 +1,5 @@
 ;; TODO: load default configs and merge into real ones
 {;; :password   "SuchWow"
  ;; :in-memory? true
+ :fluree     {:servers ["http://localhost:8090"]}
  :nrepl      {:port 8877}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,13 @@ services:
       fluree:
         condition: service_healthy
     ports:
-      - 3010:3010 # Change this according to config.edn
+      - 3010:3010 # Change this according to CONFIG_EDN.
     volumes:
       - ./athens-data/logs:/srv/athens/logs
     environment:
-      # Use system env vars for settings if available.
-      # config_edn is deep merged with the whole config file
-      - CONFIG_EDN=${CONFIG_EDN:-{:fluree {:servers ["http://fluree:8090"]}}}
+      # Uses system env vars for settings if available.
+      # CONFIG_EDN is deep merged with the default config file.
+      - CONFIG_EDN=${CONFIG_EDN:-{}}
     healthcheck:
       test: curl -f localhost:3010/health-check
       interval: 15s

--- a/src/clj/athens/self_hosted/components/web.clj
+++ b/src/clj/athens/self_hosted/components/web.clj
@@ -144,7 +144,9 @@
              server-password :password
              in-memory?      :in-memory?}
             (:config config)]
-        (log/info "Starting WebServer with config:" http-conf ", in-memory?" in-memory?)
+        (log/info "Starting WebServer with config:" http-conf
+                  "in-memory?" in-memory?
+                  "password?" (boolean server-password))
         (assoc component :httpkit
                (http/run-server (make-handler datascript fluree in-memory? server-password) http-conf)))))
 

--- a/src/clj/config.default.edn
+++ b/src/clj/config.default.edn
@@ -1,5 +1,6 @@
 {:http       {:port 3010}
- :fluree     {:servers ["http://localhost:8090"]}
+ ;; Default fluree address on Docker Compose setup.
+ :fluree     {:servers ["http://fluree:8090"]}
  :in-memory? false
  ;; :password   "SuchWow"
  ;; :nrepl      {:port 8877}


### PR DESCRIPTION
- fix: use right key for block/uid on initial presence
- build: user docker compose server settings as default
