### PR TITLE
fix: rollback-tx-snapshot atomically

### DIFF
--- a/src/clj/athens/self_hosted/web/datascript.clj
+++ b/src/clj/athens/self_hosted/web/datascript.clj
@@ -6,8 +6,7 @@
     [athens.common-events.resolver.atomic :as atomic-resolver]
     [athens.common.logging                :as log]
     [athens.self-hosted.clients           :as clients]
-    [clojure.pprint                       :as pprint]
-    [datascript.core                      :as d])
+    [clojure.pprint                       :as pprint])
   (:import
     (clojure.lang
       ExceptionInfo)))
@@ -73,11 +72,7 @@
                 txs)]
       (log/debug "transact! event-id:" event-id ", normalized-txs:" (with-out-str
                                                                       (pprint/pprint txs)))
-      (let [processed-tx            (->> txs
-                                         (common-db/block-uid-nil-eater @conn)
-                                         (common-db/linkmaker @conn)
-                                         (common-db/orderkeeper @conn))
-            {:keys [tempids]}       (d/transact! conn processed-tx)
+      (let [{:keys [tempids]}       (common-db/transact-with-middleware! conn txs)
             {:db/keys [current-tx]} tempids]
         (log/debug "transact! event-id:" event-id ", transacted in tx-id:" current-tx)
         (common-events/build-event-accepted event-id current-tx)))

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -768,3 +768,19 @@
      (catch #?(:cljs :default
                :clj Exception) e
        (block-uid-nil-eater-error e input-tx)))))
+
+
+(defn tx-with-middleware
+  [db tx-data]
+  (->> tx-data
+       (block-uid-nil-eater db)
+       (linkmaker db)
+       (orderkeeper db)))
+
+
+(defn transact-with-middleware!
+  "Transact tx-data enriched with middleware txs into conn."
+  [conn tx-data]
+  ;; 🎶 Sia "Cheap Thrills"
+  (d/transact! conn (tx-with-middleware @conn tx-data)))
+

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -19,14 +19,11 @@
 
 ;; Effects
 
+
 (rf/reg-fx
   :transact!
   (fn [tx-data]
-    ;; 🎶 Sia "Cheap Thrills"
-    (d/transact! db/dsdb (->> tx-data
-                              (common-db/block-uid-nil-eater @db/dsdb)
-                              (common-db/linkmaker @db/dsdb)
-                              (common-db/orderkeeper @db/dsdb)))))
+    (common-db/transact-with-middleware! db/dsdb tx-data)))
 
 
 (rf/reg-fx


### PR DESCRIPTION
This should fix a bug where uids wouldn't be resolved on rollback, and the bug
where all clients were marked as unsynced when another client forwarded changes.
