### PR TITLE
merge main help

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ Please see our [Open Collective](https://opencollective.com/athens) for more det
 
 To learn more about this project, please read:
 
-- [Athens' $1.9M Seed Round, led by Caffeinated Capital](https://athens-research.ghost.io/athens-1-9m-seed-round-led-by-caffeinated-capital/)
-- [Athens Joins Y Combinator](https://athens-research.ghost.io/athens-joins-y-combinator/)
-- [MVP Update, Funding, and Why I Started Athens](https://athens-research.ghost.io/mvp-update-funding-and-why-i-started-athens/)
-- [Why you should learn Clojure - my first month as a Clojurian](https://athens-research.ghost.io/why-you-should-learn-clojure-my-first-month-as-a-clojurian/)
+- [Athens' $1.9M Seed Round, led by Caffeinated Capital](https://athensresearch.ghost.io/athens-1-9m-seed-round-led-by-caffeinated-capital/)
+- [Athens Joins Y Combinator](https://athensresearch.ghost.io/athens-joins-y-combinator/)
+- [MVP Update, Funding, and Why I Started Athens](https://athensresearch.ghost.io/mvp-update-funding-and-why-i-started-athens/)
+- [Why you should learn Clojure - my first month as a Clojurian](https://athensresearch.ghost.io/why-you-should-learn-clojure-my-first-month-as-a-clojurian/)
 
 # Thank You
 
 Athens is here today because of our Sponsors and Contributors. Thank you.
 
-[![Sponsors](https://athens-research.ghost.io/content/images/size/w1140/2021/04/spnosors.png)](https://opencollective.com/athens)
+[![Sponsors](https://athensresearch.ghost.io/content/images/size/w1140/2021/04/spnosors.png)](https://opencollective.com/athens)
 
 ![Contributors](https://user-images.githubusercontent.com/8952138/111184984-c1d83180-856e-11eb-9b7f-136de40d8252.png)

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -126,7 +126,7 @@
                :mouse-down          false
                :daily-notes/items   []
                :selection           {:items []}
-               :theme/dark          false
+               :help/open?          false
                :zoom-level          0
                :fs/watcher          nil
                :presence            {}

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -192,6 +192,12 @@
 
 
 (reg-event-db
+  :help/toggle
+  (fn [db _]
+    (update db :help/open? not)))
+
+
+(reg-event-db
   :left-sidebar/toggle
   (fn [db _]
     (update db :left-sidebar/open not)))

--- a/src/cljs/athens/subs.cljs
+++ b/src/cljs/athens/subs.cljs
@@ -143,3 +143,10 @@
   :connection-status
   (fn [db _]
     (:connection-status db)))
+
+
+(rf/reg-sub
+  :help/open?
+  (fn [db _]
+    (:help/open? db)))
+

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -262,6 +262,11 @@
       (re-find #"Mac" os) :mac)))
 
 
+(defn is-mac?
+  []
+  (= (get-os) :mac))
+
+
 (defn app-classes
   ([{:keys [os electron? theme-dark? win-focused? win-fullscreen? win-maximized?]}]
    [(case os

--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -12,6 +12,7 @@
     [athens.views.app-toolbar :as app-toolbar]
     [athens.views.athena :refer [athena-component]]
     [athens.views.devtool :refer [devtool-component]]
+    [athens.views.help :refer [help-popup]]
     [athens.views.left-sidebar :as left-sidebar]
     [athens.views.pages.core :as pages]
     [athens.views.right-sidebar :as right-sidebar]
@@ -74,6 +75,7 @@
        [:div (merge {:style {:display "contents"}}
                     (zoom))
         [:> GlobalStyles]
+        [help-popup]
         [alert]
         (let [{:keys [msg type]} @(rf/subscribe [:db/snack-msg])]
           [m-snackbar

--- a/src/cljs/athens/views/app_toolbar.cljs
+++ b/src/cljs/athens/views/app_toolbar.cljs
@@ -44,6 +44,7 @@
                        :isWinFullscreen @win-fullscreen?
                        :isWinMaximized @win-maximized?
                        :isWinFocused @win-focused?
+                       :isHelpOpen @(subscribe [:help/open?])
                        :isThemeDark @theme-dark
                        :isLeftSidebarOpen @left-open?
                        :isRightSidebarOpen @right-open?
@@ -55,6 +56,7 @@
                        :onPressAllPages #(router/navigate :pages)
                        :onPressGraph #(router/navigate :graph)
                        :onPressCommandBar #(dispatch [:athena/toggle])
+                       :onPressHelp #(dispatch [:help/toggle])
                        :onPressThemeToggle #(dispatch [:theme/toggle])
                        :onPressSettings #(router/navigate :settings)
                        :onPressMerge #(swap! merge-open? not)

--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -1,0 +1,375 @@
+(ns athens.views.help
+  (:require
+    ["@material-ui/core/Modal" :default Modal]
+    [athens.style :refer [color]]
+    [athens.util :as util]
+    [clojure.string :as str]
+    [re-frame.core :refer [dispatch subscribe]]
+    [reagent.core :as r]
+    [stylefy.core :as stylefy :refer [use-style]])
+  (:import
+    (goog.events
+      KeyCodes)))
+
+
+;; Helpers to create the help content
+;; ==========================
+(defn opaque-text
+  [text]
+  [:span (use-style {:color (color :body-text-color :opacity-med) :font-weight "normal"}) text])
+
+
+(defn space
+  []
+  [:i (use-style {:width         "0.25em"
+                  :display       "inline-block"
+                  :margin-inline "0.25em"
+                  :height        "0.125em"
+                  :border        (str "1px solid " (color :body-text-color :opacity-low))
+                  :border-top    0})])
+
+
+(defn example
+  [template & args]
+  (let [opaque-texts (map #(conj [opaque-text] %) args)
+        insert-spaces (fn [str-or-vec]
+                        (if (and (string? str-or-vec)
+                                 (str/includes? str-or-vec "$space"))
+                          (-> str-or-vec
+                              (str/split #"\$space")
+                              (interleave (repeat [space])))
+                          str-or-vec))]
+    [:span (use-style
+             {:font-size   "85%"
+              :font-weight "bold"
+              :user-select "all"
+              :word-break  "break-word"})
+     (as-> template t
+           (str/split t #"\$text")
+           (interleave t (concat opaque-texts [nil]))
+           (map insert-spaces t))]))
+
+
+;; Help content
+;; The examples use a small template language to insert the text (opaque) in the examples.
+;; $text -> placeholder that will be replaced with opaque text, there can be many. The args passed
+;;          passed after the template will replace the $text placeholders in order
+;; $space -> small utility to render a space symbol.
+;; ==========================
+(def syntax-groups
+  [{:name  "Links"
+    :items [{:description "Link (or Create New Page)"
+             :example     [example "[[$text]]" "Athens"]}
+            {:description "Links to Block"
+             :example     [example "(($text))" "Block ID"]}
+            {:description "Labeled Link"
+             :example     [example "[$text]($text)" "Athens" "http://athensresearch.org/"]}
+            {:description "Link"
+             :example     [example "<$text>" "http://athensresearch.org/"]}
+            {:description "Tag"
+             :example     [example "#$text" "Athens"]}
+            {:description "Tagged Link"
+             :example     [example "#[[$text]]" "Athens"]}]}
+   {:name  "Embeds"
+    :items [{:description "Block"
+             :example     [example "{{[[embed]]:(($text))}}" "reference to a block on a page"]}
+            {:description "Image by URL"
+             :example     [example "![$text]($text)" "Athens Logo" "https://avatars.githubusercontent.com/u/8952138"]}
+            {:description "Youtube  Video"
+             :example     [example "{{[[youtube]]:$text]]}}" "https://youtube.com/..."]}
+            {:description "Web Page"
+             :example     [example "{{iframe:<iframe src=\"$text\"></iframe>}}" "https://github.com/athensresearch/"]}]}
+   {:name  "Formatting"
+    :items [{:description "LaTeX"
+             :example     [example "$$$text$$" "Your equation or mathematical symbol"]}
+            {:description "Checkbox"
+             :example     [example "{{[[TODO]]}}$space$text" "Label"]}
+            {:description "Inline code"
+             :example     [example "`$text`" "Code"]}
+            {:description "Highlight"
+             :example     [example "^^$text^^" "Athens"]}
+            {:description "Italicize"
+             :example     [example "__$text__" "Athens"]}
+            {:description "Bold"
+             :example     [example "**$text**" "Athens"]}
+            {:description "Underline"
+             :example     [example "--$text--" "Athens"]}
+            {:description "Strikethrough"
+             :example     [example "~~$text~~" "Athens"]}
+            {:description "Heading level 1"
+             :example     [example "#$space$text" "Athens"]}
+            {:description "Heading level 2"
+             :example     [example "##$space$text" "Athens"]}
+            {:description "Heading level 3"
+             :example     [example "###$space$text" "Athens"]}
+            {:description "Heading level 4"
+             :example     [example "####$space$text" "Athens"]}
+            {:description "Heading level 5"
+             :example     [example "#####$space$text" "Athens"]}
+            {:description "Heading level 6"
+             :example     [example "######$space$text" "Athens"]}]}])
+
+
+(def shortcut-groups
+  [{:name  "App"
+    :items [{:description "Toggle Athena"
+             :shortcut    "mod+k"}
+            {:description "Toggle Left Sidebar"
+             :shortcut    "mod+\\"}
+            {:description "Toggle Right Sidebar"
+             :shortcut    "mod+shift+\\"}
+            {:description "Increase Text Size"
+             :shortcut    "mod+plus"}
+            {:description "Decrease Text Size"
+             :shortcut    "mod+minus"}
+            {:description "Reset Text Size"
+             :shortcut    "mod+0"}]}
+   {:name  "Input"
+    :items [{:description "Autocomplete Menu"
+             :shortcut    "/"}
+            {:description "Indent selected block"
+             :shortcut    "tab"}
+            {:description "Unindent selected block"
+             :shortcut    "shift+tab"}
+            {:description "Undo"
+             :shortcut    "mod+z"}
+            {:description "Redo"
+             :shortcut    "mod+shift+z"}
+            {:description "Copy"
+             :shortcut    "mod+c"}
+            {:description "Paste"
+             :shortcut    "mod+v"}
+            {:description "Paste without formatting"
+             :shortcut    "mod+shift+v"}
+            {:description "Convert to checkbox"
+             :shortcut    "mod+enter"}]}
+   {:name  "Selection"
+    :items [{:description "Select previous block"
+             :shortcut    "shift+up"}
+            {:description "Select next block"
+             :shortcut    "shift+down"}
+            {:description "Select all blocks"
+             :shortcut    "mod+a"}]}
+   {:name  "Formatting"
+    :items [{:description "Bold"
+             :example     [:strong "Athens"]
+             :shortcut    "mod+b"}
+            {:description "Italics"
+             :example     [:i "Athens"]
+             :shortcut    "mod+i"}
+            ;; Underline is currently not working. Uncomment when it does.
+            ;; {:description "Underline"
+            ;; :example     [:span (use-style {:text-decoration "underline"}) "Athens"]
+            ;; :shortcut    "mod+u"}
+            {:description "Strikethrough"
+             :example     [:span (use-style {:text-decoration "line-through"}) "Athens"]
+             :shortcut    "mod+y"}
+            {:description "Highlight"
+             :example     [:span (use-style {:background    (color :highlight-color)
+                                             :color         (color :background-color)
+                                             :border-radius "0.1rem"
+                                             :padding       "0 0.125em"}) "Athens"]
+             :shortcut    "mod+h"}]}
+   {:name  "Graph"
+    :items [{:description "Open Node in Sidebar"
+             :shortcut    "shift+click"}
+            {:description "Move Node"
+             :shortcut    "click+drag"}
+            {:description "Zoom in/out"
+             :shortcut    "scroll up/down"}]}])
+
+
+(def content
+  [{:name   "Syntax",
+    :groups syntax-groups}
+   {:name   "Keyboard Shortcuts"
+    :groups shortcut-groups}])
+
+
+;; Components to render content
+;; =============================
+(def mod-key
+  (if (util/is-mac?) "⌘" "CTRL"))
+
+
+(def alt-key
+  (if (util/is-mac?) "⌥" "Alt"))
+
+
+(defn shortcut
+  [shortcut-str]
+  [:div (use-style {:display     "flex"
+                    :align-items "center"
+                    :gap         "0.3rem"})
+   (let [key-to-display (fn [key]
+                          (-> key
+                              (str/replace #"mod" mod-key)
+                              (str/replace #"alt" alt-key)
+                              (str/replace #"shift" "⇧")
+                              (str/replace #"minus" "-")
+                              (str/replace #"plus" "+")))
+         keys (as-> shortcut-str s
+                    (str/split s #"\+")
+                    (map key-to-display s))]
+
+
+     (for [key keys]
+       ^{:key key} [:span (use-style {:font-family    "inherit"
+                                      :display        "inline-flex"
+                                      :gap            "0.3em"
+                                      :text-transform "uppercase"
+                                      :font-size      "0.8em"
+                                      :padding-inline "0.35em"
+                                      :background     (color :background-plus-2)
+                                      :border-radius  "0.25rem"
+                                      :font-weight    600})
+                    key]))])
+
+
+(def modal-body-styles
+  {:width         "max-content"
+   :margin        "2rem auto"
+   :max-width     "calc(100% - 1rem)"
+   :border        (str "1px solid " (color :border-color))
+   :border-radius "1rem"
+   :box-shadow    (str "0 0.25rem 0.5rem -0.25rem " (color :shadow-color))
+   :display       "flex"})
+
+
+(def help-styles
+  {:background-color (color :background-color)
+   :border-radius    "1rem"
+   :display          "flex"
+   :flex-direction   "column"
+   :min-width        "500px"})
+
+
+(def help-header-styles
+  {:display         "flex"
+   :justify-content "space-between"
+   :margin          0
+   :align-items     "center"
+   :border-bottom   [["1px solid" (color :border-color)]]})
+
+
+(def help-title
+  {:padding   "1rem 1.5rem"
+   :margin    "0"
+   :font-size "2rem"
+   :color     (color :header-text-color)})
+
+
+(defn help-section
+  [title & children]
+  [:section
+   [:h2 (use-style
+          {:color          (color :body-text-color :opacity-med)
+           :text-transform "uppercase"
+           :letter-spacing "0.06rem"
+           :margin         0
+           :font-weight    600
+           :font-size      "100%"
+           :padding        "1rem 1.5rem"})
+    title]
+   children])
+
+
+(defn help-section-group
+  [title & children]
+  [:section (use-style
+              {:display               "grid"
+               :padding               "1.5rem"
+               :grid-template-columns "12rem 1fr"
+               :column-gap            "1rem"
+               :border-top            [["1px solid" (color :border-color)]]})
+   [:h3 (use-style {:font-size   "1.5em"
+                    :margin      0
+                    :font-weight "bold"})
+    title]
+   [:div children]])
+
+
+(defn help-item
+  [item]
+  [:div (use-style
+          {:border-radius         "0.5rem"
+           :align-items           "center"
+           :display               "grid"
+           :gap                   "1rem"
+           :grid-template-columns "12rem 1fr"
+           :padding               "0.25rem 0.5rem"
+           ::stylefy/manual       [["&:nth-child(odd)"
+                                    {:background (color :background-plus-2 :opacity-low)}]]})
+
+
+   [:span (use-style
+            {:display         "flex"
+             :justify-content "space-between"})
+    ;; Position of the example changes if there is a shortcut or not.
+    (:description item)
+    (when (contains? item :shortcut)
+      (:example item))]
+   (when (not (contains? item :shortcut))
+     (:example item))
+   (when (contains? item :shortcut)
+     [shortcut (:shortcut item)])])
+
+
+(defn modal-body
+  [& children]
+  [:div (use-style modal-body-styles) children])
+
+
+;; Help popup UI
+;; Why the escape handler?
+;; Because when disabled the modal autofocus (which moves the modal to the top when
+;; opened and causes other issues like moving into the top the modal when clicking outside
+;; of it from the top), the escape handler from the modal itself doesn't work.
+;; Because of that, our own escape handler is added.
+(defn help-popup
+  []
+  (r/with-let
+    [open? (subscribe [:help/open?])
+     close #(dispatch [:help/toggle])
+     escape-handler (fn [event]
+                      (when
+                        (and @open? (= (.. event -keyCode) KeyCodes.ESC))
+                        (close)))
+     _ (js/addEventListener "keydown" escape-handler)]
+    [:> Modal {:open             @open?
+               :style            {:overflow-y "auto"}
+               :disableAutoFocus true
+               :onClose          close}
+     [modal-body
+      [:div (use-style help-styles)
+       [:header (use-style help-header-styles)
+        [:h1 (use-style help-title)
+         "Help"]
+        [:nav
+         (use-style
+           {:display "flex"
+            :gap     "1rem"
+            :padding "1rem"})]]
+       ;; Links at the top of the help. Uncomment when the correct links are obtained.
+       ;; [help-link
+       ;; [:> LiveHelp]
+       ;; "Get Help on Discord"]
+       ;; [help-link
+       ;; [:> Error]
+       ;; "Get Help on Discord"]
+       ;; [help-link
+       ;; [:> AddToPhotos]
+       ;; "Get Help on Discord"]]]
+       [:div (use-style {:overflow-y "auto"})
+        (for [section content]
+          ^{:key section}
+          [help-section (:name section)
+           (for [group (:groups section)]
+             ^{:key group}
+             [help-section-group (:name group)
+              (for [item (:items group)]
+                ^{:key item}
+                [help-item item])])])]]]]
+    (finally js/removeEventListener "keydown" escape-handler)))
+
+

--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -30,11 +30,14 @@
                   :border        (str "1px solid " (color :body-text-color :opacity-low))
                   :border-top    0})])
 
-(defn- add-keys [sequence]
+
+(defn- add-keys
+  [sequence]
   (doall
-   (for [el sequence]
-     ^{:keys (hash el)}
-     el)))
+    (for [el sequence]
+      ^{:keys (hash el)}
+      el)))
+
 
 (defn example
   [template & args]
@@ -50,10 +53,10 @@
                                       add-keys))
                             str-or-vec))]
     [:span (use-style
-            {:font-size   "85%"
-             :font-weight "bold"
-             :user-select "all"
-             :word-break  "break-word"})
+             {:font-size   "85%"
+              :font-weight "bold"
+              :user-select "all"
+              :word-break  "break-word"})
      (as-> template t
            (str/split t #"\$text")
            (interleave t (concat opaque-texts [nil]))
@@ -218,25 +221,25 @@
                              (str/replace #"minus" "-")
                              (str/replace #"plus" "+")))
         keys           (as-> shortcut-str s
-                         (str/split s #"\+")
-                         (map key-to-display s))]
+                             (str/split s #"\+")
+                             (map key-to-display s))]
     [:div (use-style {:display     "flex"
                       :align-items "center"
                       :gap         "0.3rem"})
 
      (doall
-      (for [key keys]
-        ^{:key key}
-        [:span (use-style {:font-family    "inherit"
-                           :display        "inline-flex"
-                           :gap            "0.3em"
-                           :text-transform "uppercase"
-                           :font-size      "0.8em"
-                           :padding-inline "0.35em"
-                           :background     (color :background-plus-2)
-                           :border-radius  "0.25rem"
-                           :font-weight    600})
-         key]))]))
+       (for [key keys]
+         ^{:key key}
+         [:span (use-style {:font-family    "inherit"
+                            :display        "inline-flex"
+                            :gap            "0.3em"
+                            :text-transform "uppercase"
+                            :font-size      "0.8em"
+                            :padding-inline "0.35em"
+                            :background     (color :background-plus-2)
+                            :border-radius  "0.25rem"
+                            :font-weight    600})
+          key]))]))
 
 
 (def modal-body-styles
@@ -285,9 +288,9 @@
            :padding        "1rem 1.5rem"})
     title]
    (doall
-    (for [child children]
-      ^{:key (hash child)}
-      child))])
+     (for [child children]
+       ^{:key (hash child)}
+       child))])
 
 
 (defn help-section-group
@@ -304,25 +307,25 @@
     title]
    [:div
     (doall
-     (for [child children]
-       ^{:key (hash child)}
-       child))]])
+      (for [child children]
+        ^{:key (hash child)}
+        child))]])
 
 
 (defn help-item
   [item]
   [:div (use-style
-         {:border-radius         "0.5rem"
-          :align-items           "center"
-          :display               "grid"
-          :gap                   "1rem"
-          :grid-template-columns "12rem 1fr"
-          :padding               "0.25rem 0.5rem"
-          ::stylefy/manual       ["&:nth-child(odd)"
-                                  {:background (color :background-plus-2 :opacity-low)}]})
+          {:border-radius         "0.5rem"
+           :align-items           "center"
+           :display               "grid"
+           :gap                   "1rem"
+           :grid-template-columns "12rem 1fr"
+           :padding               "0.25rem 0.5rem"
+           ::stylefy/manual       ["&:nth-child(odd)"
+                                   {:background (color :background-plus-2 :opacity-low)}]})
    [:span (use-style
-           {:display         "flex"
-            :justify-content "space-between"})
+            {:display         "flex"
+             :justify-content "space-between"})
     ;; Position of the example changes if there is a shortcut or not.
     (:description item)
     (when (contains? item :shortcut)
@@ -345,44 +348,44 @@
                close #(dispatch [:help/toggle])
                escape-handler (fn [event]
                                 (when
-                                    (and @open? (= (.. event -keyCode) KeyCodes.ESC))
+                                  (and @open? (= (.. event -keyCode) KeyCodes.ESC))
                                   (close)))
                _ (js/addEventListener "keydown" escape-handler)]
-    [:> Modal {:open             @open?
-               :style            {:overflow-y "auto"}
-               :disableAutoFocus true
-               :onClose          close}
-     [:div (use-style modal-body-styles)
-      [:div (use-style help-styles)
-       [:header (use-style help-header-styles)
-        [:h1 (use-style help-title)
-         "Help"]
-        [:nav (use-style {:display "flex"
-                          :gap     "1rem"
-                          :padding "1rem"})]]
-       ;; Links at the top of the help. Uncomment when the correct links are obtained.
-       ;; [help-link
-       ;; [:> LiveHelp]
-       ;; "Get Help on Discord"]
-       ;; [help-link
-       ;; [:> Error]
-       ;; "Get Help on Discord"]
-       ;; [help-link
-       ;; [:> AddToPhotos]
-       ;; "Get Help on Discord"]]]
-       [:div (use-style {:overflow-y "auto"})
-        (doall
-         (for [section content]
-           ^{:key section}
-           [help-section (:name section)
-            (doall
-             (for [group (:groups section)]
-               ^{:key group}
-               [help-section-group (:name group)
-                (doall
-                 (for [item (:items group)]
-                   ^{:key item}
-                   [help-item item]))]))]))]]]]
-    (finally js/removeEventListener "keydown" escape-handler)))
+              [:> Modal {:open             @open?
+                         :style            {:overflow-y "auto"}
+                         :disableAutoFocus true
+                         :onClose          close}
+               [:div (use-style modal-body-styles)
+                [:div (use-style help-styles)
+                 [:header (use-style help-header-styles)
+                  [:h1 (use-style help-title)
+                   "Help"]
+                  [:nav (use-style {:display "flex"
+                                    :gap     "1rem"
+                                    :padding "1rem"})]]
+                 ;; Links at the top of the help. Uncomment when the correct links are obtained.
+                 ;; [help-link
+                 ;; [:> LiveHelp]
+                 ;; "Get Help on Discord"]
+                 ;; [help-link
+                 ;; [:> Error]
+                 ;; "Get Help on Discord"]
+                 ;; [help-link
+                 ;; [:> AddToPhotos]
+                 ;; "Get Help on Discord"]]]
+                 [:div (use-style {:overflow-y "auto"})
+                  (doall
+                    (for [section content]
+                      ^{:key section}
+                      [help-section (:name section)
+                       (doall
+                         (for [group (:groups section)]
+                           ^{:key group}
+                           [help-section-group (:name group)
+                            (doall
+                              (for [item (:items group)]
+                                ^{:key item}
+                                [help-item item]))]))]))]]]]
+              (finally js/removeEventListener "keydown" escape-handler)))
 
 

--- a/src/js/components/AppToolbar/AppToolbar.tsx
+++ b/src/js/components/AppToolbar/AppToolbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { BubbleChart, ChevronLeft, ChevronRight, FileCopy, Menu as MenuIcon, MergeType, Search, Settings, Storage, Today, ToggleOff, ToggleOn, VerticalSplit } from '@material-ui/icons';
+import { BubbleChart, ChevronLeft, ChevronRight, FileCopy, Help, Menu as MenuIcon, MergeType, Search, Settings, Storage, Today, ToggleOff, ToggleOn, VerticalSplit } from '@material-ui/icons';
 
 import { Button } from '@/Button';
 import { WindowButtons } from './components/WindowButtons';
@@ -122,6 +122,10 @@ export interface AppToolbarProps extends React.HTMLAttributes<HTMLDivElement>, D
   */
   isDatabaseDialogOpen: boolean;
   /**
+  * Whether the help dialog is open
+  */
+  isHelpOpen: boolean;
+  /**
   * Whether the theme is set to dark mode
   */
   isThemeDark: boolean;
@@ -137,6 +141,7 @@ export interface AppToolbarProps extends React.HTMLAttributes<HTMLDivElement>, D
   onPressDailyNotes(): void;
   onPressAllPages(): void;
   onPressGraph(): void;
+  onPressHelp(): void;
   onPressThemeToggle(): void;
   onPressMerge(): void;
   onPressSettings(): void;
@@ -156,6 +161,7 @@ export const AppToolbar = (props: AppToolbarProps): React.ReactElement => {
     isWinFullscreen,
     isWinFocused,
     isWinMaximized,
+    isHelpOpen,
     isThemeDark,
     isLeftSidebarOpen,
     isRightSidebarOpen,
@@ -165,6 +171,7 @@ export const AppToolbar = (props: AppToolbarProps): React.ReactElement => {
     onPressDailyNotes: handlePressDailyNotes,
     onPressAllPages: handlePressAllPages,
     onPressGraph: handlePressGraph,
+    onPressHelp: handlePressHelp,
     onPressThemeToggle: handlePressThemeToggle,
     onPressMerge: handlePressMerge,
     onPressSettings: handlePressSettings,
@@ -209,6 +216,7 @@ export const AppToolbar = (props: AppToolbarProps): React.ReactElement => {
         onClick={handlePressThemeToggle}>
         {isThemeDark ? <ToggleOff /> : <ToggleOn />}
       </Button>
+      <Button isPressed={isHelpOpen} onClick={handlePressHelp}><Help /></Button>
       <AppToolbar.Separator />
       <Button
         isPressed={isRightSidebarOpen}


### PR DESCRIPTION
- wip: help-popup
- feat(help-popup): Add help popup with content.
- feat(help-popup): Add tooltip to help icon
- feat(help-popup): Fix issue with scroll-bar and move scroll to content of the help.
- feat(help-popup): Remove "code block" from Help.
- feat(help-popup): Comment out help links until we have the correct ones.
- feat(help-popup): Fix border mismatches
- feat(help-popup): Fix spacing
- feat(help-popup): Fix scroll behaviour
- feat(help-popup): Fix a few shortcuts
- feat(help-popup): Fix closing of modal using escape.
- feat(help-popup): Fix copy and remove  a shortcut that doesn't work
- doc: Fix links to Athens Research Blog (#1666)
- rfct: use button tooltip instead
- style: style, lint, carve
