### PR TITLE
rfct: remove old-string from :block/save event

### DIFF
--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -303,6 +303,13 @@
       :node/title))
 
 
+(defn get-block-string
+  [db uid]
+  (-> db
+      (d/entity [:block/uid uid])
+      :block/string))
+
+
 (defn deepest-child-block
   [db id]
   (let [document (->> (d/pull db '[:block/order :block/uid {:block/children ...}] id)

--- a/src/cljc/athens/common_events/bfs.cljc
+++ b/src/cljc/athens/common_events/bfs.cljc
@@ -69,7 +69,7 @@
                                       default-position default-position
                                       :else (throw (ex-info "Cannot determine position for enhanced internal representation" eir)))]
       [(atomic/make-block-new-op uid position)
-       (graph-ops/build-block-save-op db uid "" string)])))
+       (graph-ops/build-block-save-op db uid string)])))
 
 
 (defn internal-representation->atomic-ops

--- a/src/cljc/athens/common_events/graph/atomic.cljc
+++ b/src/cljc/athens/common_events/graph/atomic.cljc
@@ -25,14 +25,12 @@
 (defn make-block-save-op
   "Creates `:block/save` atomic op.
    - `block-uid` - `:block/uid` of block to be saved
-   - `old-string` - old value of `:block/string`
-   - `new-string` - new value of `:block/string` to be saved"
-  [block-uid old-string new-string]
+   - `string` - new value of `:block/string` to be saved"
+  [block-uid new-string]
   {:op/type    :block/save
    :op/atomic? true
-   :op/args    {:block-uid  block-uid
-                :old-string old-string
-                :new-string new-string}})
+   :op/args    {:block-uid block-uid
+                :string    new-string}})
 
 
 (defn make-block-open-op

--- a/src/cljc/athens/common_events/graph/schema.cljc
+++ b/src/cljc/athens/common_events/graph/schema.cljc
@@ -69,8 +69,7 @@
    [:op/args
     [:map
      [:block-uid string?]
-     [:new-string string?]
-     [:old-string string?]]]])
+     [:string string?]]]])
 
 
 (def op-block-remove

--- a/src/cljc/athens/common_events/resolver/atomic.cljc
+++ b/src/cljc/athens/common_events/resolver/atomic.cljc
@@ -68,22 +68,11 @@
 
 ;; This is Atomic Graph Op, there is also composite version of it
 (defmethod resolve-atomic-op-to-tx :block/save
-  [db {:op/keys [args]}]
-  (let [{:keys [block-uid
-                new-string
-                old-string]} args
-        stored-old-string    (if-let [block-eid (common-db/e-by-av db :block/uid block-uid)]
-                               (common-db/v-by-ea db block-eid :block/string)
-                               "")]
-    (when-not (= stored-old-string old-string)
-      (print (ex-info ":block/save operation started from a stale state."
-                      {:op/args           args
-                       :actual-old-string stored-old-string})))
-    (let [now           (utils/now-ts)
-          updated-block {:block/uid    block-uid
-                         :block/string new-string
-                         :edit/time    now}]
-      [updated-block])))
+  [_db {:op/keys [args]}]
+  (let [{:keys [block-uid string]} args]
+    [{:block/uid    block-uid
+      :block/string string
+      :edit/time    (utils/now-ts)}]))
 
 
 (defmethod resolve-atomic-op-to-tx :block/move

--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -15,14 +15,13 @@
 (defn todo-on-click
   [uid from-str to-str]
   (let [current-block-content (:block/string (db/get-block [:block/uid uid]))
-        new-block-content (clojure.string/replace current-block-content
-                                                  from-str
-                                                  to-str)]
-    (dispatch [:block/save {:uid        uid
-                            :old-string current-block-content
-                            :new-string new-block-content
-                            :callback   #()
-                            :add-time?  true}])))
+        new-block-content     (clojure.string/replace current-block-content
+                                                      from-str
+                                                      to-str)]
+    (dispatch [:block/save {:uid       uid
+                            :string    new-block-content
+                            :callback  #()
+                            :add-time? true}])))
 
 
 (defn span-click-stop

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -654,10 +654,8 @@
   "uid -> Current block
    state -> Look at state atom in block-el"
   [uid state]
-  (let [{:string/keys [local
-                       previous]} @state
-        callback                  #(swap! state assoc :string/previous local)]
-    (dispatch [:block/save {:uid        uid
-                            :old-string previous
-                            :new-string local
-                            :callback   callback}])))
+  (let [{:string/keys [local]} @state
+        callback               #(swap! state assoc :string/previous local)]
+    (dispatch [:block/save {:uid      uid
+                            :string   local
+                            :callback callback}])))

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -63,13 +63,10 @@
   "A helper fn that takes `state` containing textarea changes and when user has made a text change dispatches `transact-string`.
    Used in `block-page-el` function to log when there is a diff and `on-blur`"
   [state block-uid]
-  (let [old-string  (:string/previous state)
-        new-string  (:string/local state)]
-    (dispatch [:block/save {:uid        block-uid
-                            :old-string old-string
-                            :new-string new-string
-                            :callback   #()
-                            :add-time?  true}])))
+  (dispatch [:block/save {:uid       block-uid
+                          :string    (:string/local state)
+                          :callback  #()
+                          :add-time? true}]))
 
 
 ;; Components

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -182,11 +182,9 @@
         block-page            (.. e -target (closest ".block-page"))
         [uid embed-id]        (common-db/uid-and-embed-id uid)
         new-uid               (utils/gen-block-uid)
-        string                (:block/string (db/get-block [:block/uid uid]))
         {:keys [start value]} (textarea-keydown/destruct-key-down e)]
     (cond
       block-page (dispatch [:enter/split-block {:uid        uid
-                                                :old-string string
                                                 :value      value
                                                 :index      start
                                                 :new-uid    new-uid

--- a/test/athens/bfs_test.cljc
+++ b/test/athens/bfs_test.cljc
@@ -41,17 +41,17 @@
                  :trigger #:op{:type :block/save},
                  :consequences
                  [#:op{:type :page/new, :atomic? true, :args {:title "Welcome"}}
-                  #:op{:type :block/save, :atomic? true, :args {:block-uid "block-1", :old-string "", :new-string "block with link to [[Welcome]]"}}]}]
+                  #:op{:type :block/save, :atomic? true, :args {:block-uid "block-1", :string "block with link to [[Welcome]]"}}]}]
            (bfs/internal-representation->atomic-ops db tree-with-pages nil)))
 
     (is (= [#:op{:type :block/new, :atomic? true, :args {:block-uid "eaa4c9435", :position {:ref-title "title", :relation :first}}}
-            #:op{:type :block/save, :atomic? true, :args {:block-uid "eaa4c9435", :old-string "", :new-string "block 1"}}
+            #:op{:type :block/save, :atomic? true, :args {:block-uid "eaa4c9435", :string "block 1"}}
             #:op{:type :block/new, :atomic? true, :args {:block-uid "88c9ff662", :position {:ref-uid "eaa4c9435", :relation :last}}}
-            #:op{:type :block/save, :atomic? true, :args {:block-uid "88c9ff662", :old-string "", :new-string "B1 C1"}}
+            #:op{:type :block/save, :atomic? true, :args {:block-uid "88c9ff662", :string "B1 C1"}}
             #:op{:type :block/new, :atomic? true, :args {:block-uid "7d11d532f", :position {:ref-uid "88c9ff662", :relation :after}}}
-            #:op{:type :block/save, :atomic? true, :args {:block-uid "7d11d532f", :old-string "", :new-string "B1 C2"}}
+            #:op{:type :block/save, :atomic? true, :args {:block-uid "7d11d532f", :string "B1 C2"}}
             #:op{:type :block/new, :atomic? true, :args {:block-uid "db5fa9a43", :position {:ref-uid "7d11d532f", :relation :last}}}
-            #:op{:type :block/save, :atomic? true, :args {:block-uid "db5fa9a43", :old-string "", :new-string "B1 C2 C1"}}]
+            #:op{:type :block/save, :atomic? true, :args {:block-uid "db5fa9a43", :string "B1 C2 C1"}}]
            (bfs/internal-representation->atomic-ops db tree-without-page {:ref-title "title" :relation :first})))))
 
 

--- a/test/athens/common_events/atomic_ops/block_save_test.cljc
+++ b/test/athens/common_events/atomic_ops/block_save_test.cljc
@@ -15,29 +15,24 @@
 
   (t/testing "Simple `:block/save` cases, just saving string."
     (let [block-uid     "block-uid-1"
-          empty-str     ""
           new-str       "new-string"
           block-save-op (graph-ops/build-block-save-op @@fixture/connection
                                                        block-uid
-                                                       empty-str
                                                        new-str)]
       (t/is (= #:op{:type    :block/save,
                     :atomic? true,
-                    :args    {:block-uid  block-uid
-                              :old-string empty-str
-                              :new-string new-str}}
+                    :args    {:block-uid block-uid
+                              :string    new-str}}
                block-save-op))))
 
   (t/testing "Requires `:page/new`, getting interesting"
     (let [block-uid         "block-uid-2"
-          empty-str         ""
           new-str           "[[new-page]]"
           {:op/keys [consequences
                      atomic?
                      trigger
                      type]} (graph-ops/build-block-save-op @@fixture/connection
                                                            block-uid
-                                                           empty-str
                                                            new-str)]
 
       (t/is (= :composite/consequence type))
@@ -48,9 +43,8 @@
       (t/is (= #:op{:type    :block/save,
                     :atomic? true,
                     :args
-                    {:block-uid  "block-uid-2",
-                     :old-string "",
-                     :new-string "[[new-page]]"}}
+                    {:block-uid "block-uid-2",
+                     :string    "[[new-page]]"}}
                (-> consequences second))))))
 
 
@@ -70,10 +64,7 @@
       (d/transact! @fixture/connection setup-txs)
       (let [child-1-eid    (common-db/e-by-av @@fixture/connection
                                               :block/uid child-1-uid)
-            block-save-op  (graph-ops/build-block-save-op @@fixture/connection
-                                                          child-1-uid
-                                                          empty-str
-                                                          new-str)
+            block-save-op  (graph-ops/build-block-save-op @@fixture/connection child-1-uid new-str)
             block-save-txs (atomic-resolver/resolve-atomic-op-to-tx @@fixture/connection
                                                                     block-save-op)]
         (t/is (= empty-str (common-db/v-by-ea @@fixture/connection
@@ -97,10 +88,7 @@
       (d/transact! @fixture/connection setup-txs)
       (let [child-1-eid        (common-db/e-by-av @@fixture/connection
                                                   :block/uid child-1-uid)
-            block-save-op      (graph-ops/build-block-save-op @@fixture/connection
-                                                              child-1-uid
-                                                              empty-str
-                                                              new-str)
+            block-save-op      (graph-ops/build-block-save-op @@fixture/connection child-1-uid new-str)
             block-save-atomics (graph-ops/extract-atomics block-save-op)]
         (t/is (nil? (common-db/e-by-av @@fixture/connection
                                        :node/title page-title)))

--- a/test/athens/common_events/atomic_ops/block_split_test.cljc
+++ b/test/athens/common_events/atomic_ops/block_split_test.cljc
@@ -37,8 +37,7 @@
       (let [block-split-op      (graph-ops/build-block-split-op @@fixture/connection
                                                                 {:old-block-uid child-1-uid
                                                                  :new-block-uid child-2-uid
-                                                                 :old-string    start-str
-                                                                 :new-string    new-tmp-string
+                                                                 :string        new-tmp-string
                                                                  :index         2
                                                                  :relation      :after})
             block-split-atomics (graph-ops/extract-atomics block-split-op)]
@@ -90,8 +89,7 @@
         (let [block-split-op      (graph-ops/build-block-split-op @@fixture/connection
                                                                   {:old-block-uid child-1-uid
                                                                    :new-block-uid child-3-uid
-                                                                   :old-string    start-str
-                                                                   :new-string    start-str
+                                                                   :string        start-str
                                                                    :index         2
                                                                    :relation      :after})
               block-split-atomics (graph-ops/extract-atomics block-split-op)]
@@ -145,8 +143,7 @@
         (let [block-split-op      (graph-ops/build-block-split-op @@fixture/connection
                                                                   {:old-block-uid child-1-uid
                                                                    :new-block-uid child-3-uid
-                                                                   :old-string    start-str
-                                                                   :new-string    start-str
+                                                                   :string        start-str
                                                                    :index         2
                                                                    :relation      :first})
               block-split-atomics (graph-ops/extract-atomics block-split-op)]


### PR DESCRIPTION
This breaks existing events.