### PR TITLE
fix: `:page/merge` throwing exceptions in `orderkeeper` no more.

### DIFF
--- a/src/clj/athens/self_hosted/web/datascript.clj
+++ b/src/clj/athens/self_hosted/web/datascript.clj
@@ -32,6 +32,7 @@
     :block/remove
     :block/move
     :page/new
+    :page/rename
     :composite/consequence})
 
 

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -34,9 +34,7 @@
 
 (defn v-by-ea
   [db e a]
-  (-> (d/datoms db :eavt e a)
-      first
-      :v))
+  (get (d/entity db e) a))
 
 
 (def rules
@@ -656,6 +654,7 @@
         old-parents    (when db-before
                          (->> mod-eids
                               (map #(get-parent-eid db-before %))
+                              (remove #(string/blank? (v-by-ea db-after % :block/uid)))
                               set))
         new-parents    (->> mod-eids
                             (map #(get-parent-eid db-after %))

--- a/src/cljc/athens/common_events/resolver/atomic.cljc
+++ b/src/cljc/athens/common_events/resolver/atomic.cljc
@@ -359,7 +359,7 @@
         new-datoms                      (concat [delete-page]
                                                 new-linked-refs
                                                 reindex)]
-    (log/debug "type:" type ", args:" (pr-str args) ", resolved-tx:" (pr-str new-datoms))
+    (log/debug ":page/merge args:" (pr-str args) ", resolved-tx:" (pr-str new-datoms))
     new-datoms))
 
 

--- a/test/athens/common_events/atomic_ops/page_merge_test.cljc
+++ b/test/athens/common_events/atomic_ops/page_merge_test.cljc
@@ -44,10 +44,7 @@
         (t/is (= test-page-from-uid uid-by-title))
         (d/transact! @fixture/connection merge-page-txs)
         (let [{kids :block/children} (common-db/get-page-document @@fixture/connection [:node/title test-title-to])]
-          (t/is (thrown-with-msg? #?(:cljs js/Error
-                                     :clj ExceptionInfo)
-                                  #"Nothing found for entity id"
-                  (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
+          (t/is (nil? (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
           (t/is (= 2 (count kids)))
           (t/is (= test-page-from-uid uid-by-title))))))
 
@@ -83,10 +80,7 @@
               block-string           (common-db/v-by-ea @@fixture/connection [:block/uid test-block-1-uid] :block/string)
               block-1                (common-db/get-block @@fixture/connection [:block/uid test-block-1-uid])
               block-2                (common-db/get-block @@fixture/connection [:block/uid test-block-2-uid])]
-          (t/is (thrown-with-msg? #?(:cljs js/Error
-                                     :clj ExceptionInfo)
-                                  #"Nothing found for entity id"
-                  (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
+          (t/is (nil? (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
           (t/is (= 2 (count kids)))
           (t/is (= test-page-to-uid uid-by-title))
           (t/is (= test-string-to block-string))
@@ -137,10 +131,7 @@
               block-2                (common-db/get-block @@fixture/connection [:block/uid test-block-2-uid])
               block-3                (common-db/get-block @@fixture/connection [:block/uid test-block-3-uid])
               block-4                (common-db/get-block @@fixture/connection [:block/uid test-block-4-uid])]
-          (t/is (thrown-with-msg? #?(:cljs js/Error
-                                     :clj ExceptionInfo)
-                                  #"Nothing found for entity id"
-                  (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
+          (t/is (nil? (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
           (t/is (= 4 (count kids)))
           (t/is (= test-page-to-uid uid-by-title))
           (t/is (= test-string-to block-string))

--- a/test/athens/common_events/atomic_ops/page_merge_test.cljc
+++ b/test/athens/common_events/atomic_ops/page_merge_test.cljc
@@ -80,11 +80,71 @@
         (d/transact! @fixture/connection merge-page-txs)
         (let [{kids :block/children} (common-db/get-page-document @@fixture/connection [:node/title test-title-to])
               uid-by-title           (common-db/v-by-ea @@fixture/connection [:node/title test-title-to] :block/uid)
-              block-string           (common-db/v-by-ea @@fixture/connection [:block/uid test-block-1-uid] :block/string)]
+              block-string           (common-db/v-by-ea @@fixture/connection [:block/uid test-block-1-uid] :block/string)
+              block-1                (common-db/get-block @@fixture/connection [:block/uid test-block-1-uid])
+              block-2                (common-db/get-block @@fixture/connection [:block/uid test-block-2-uid])]
           (t/is (thrown-with-msg? #?(:cljs js/Error
                                      :clj ExceptionInfo)
                                   #"Nothing found for entity id"
                   (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
           (t/is (= 2 (count kids)))
           (t/is (= test-page-to-uid uid-by-title))
-          (t/is (= test-string-to block-string)))))))
+          (t/is (= test-string-to block-string))
+          (t/is (= 0 (:block/order block-2)))
+          (t/is (= 1 (:block/order block-1)))))))
+
+  (t/testing "simple case, where we don't need to update string representations but there is a bit more then 1 block per page"
+    (let [test-page-from-uid "test-page-3-1-uid"
+          test-title-from    "test page 3 title from"
+          test-page-to-uid   "test-page-3-2-uid"
+          test-title-to      "test page 3 title to"
+          test-block-1-uid   "test-block-3-1-uid"
+          test-block-2-uid   "test-block-3-2-uid"
+          test-block-3-uid   "test-block-3-3-uid"
+          test-block-4-uid   "test-block-3-4-uid"
+          test-string-from   (str "[[" test-title-from "]]")
+          test-string-to     (str "[[" test-title-to "]]")
+          setup-txs          [{:node/title     test-title-from
+                               :block/uid      test-page-from-uid
+                               :block/children [{:block/uid      test-block-1-uid
+                                                 :block/string   test-string-from
+                                                 :block/order    0
+                                                 :block/children []}
+                                                {:block/uid      test-block-2-uid
+                                                 :block/string   test-string-from
+                                                 :block/order    1
+                                                 :block/children []}]}
+                              {:node/title     test-title-to
+                               :block/uid      test-page-to-uid
+                               :block/children [{:block/uid      test-block-3-uid
+                                                 :block/string   test-string-from
+                                                 :block/order    0
+                                                 :block/children []}
+                                                {:block/uid      test-block-4-uid
+                                                 :block/string   test-string-from
+                                                 :block/order    1
+                                                 :block/children []}]}]]
+      (fixture/transact-with-middleware setup-txs)
+      (let [uid-by-title   (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)
+            merge-page-txs (atomic-resolver/resolve-to-tx @@fixture/connection
+                                                          (atomic-graph-ops/make-page-merge-op test-title-from test-title-to))]
+        (t/is (= test-page-from-uid uid-by-title))
+        (d/transact! @fixture/connection merge-page-txs)
+        (let [{kids :block/children} (common-db/get-page-document @@fixture/connection [:node/title test-title-to])
+              uid-by-title           (common-db/v-by-ea @@fixture/connection [:node/title test-title-to] :block/uid)
+              block-string           (common-db/v-by-ea @@fixture/connection [:block/uid test-block-1-uid] :block/string)
+              block-1                (common-db/get-block @@fixture/connection [:block/uid test-block-1-uid])
+              block-2                (common-db/get-block @@fixture/connection [:block/uid test-block-2-uid])
+              block-3                (common-db/get-block @@fixture/connection [:block/uid test-block-3-uid])
+              block-4                (common-db/get-block @@fixture/connection [:block/uid test-block-4-uid])]
+          (t/is (thrown-with-msg? #?(:cljs js/Error
+                                     :clj ExceptionInfo)
+                                  #"Nothing found for entity id"
+                  (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
+          (t/is (= 4 (count kids)))
+          (t/is (= test-page-to-uid uid-by-title))
+          (t/is (= test-string-to block-string))
+          (t/is (= 0 (:block/order block-3)))
+          (t/is (= 1 (:block/order block-4)))
+          (t/is (= 2 (:block/order block-1)))
+          (t/is (= 3 (:block/order block-2))))))))

--- a/test/athens/common_events/atomic_ops/page_rename_test.cljc
+++ b/test/athens/common_events/atomic_ops/page_rename_test.cljc
@@ -63,9 +63,6 @@
         (d/transact! @fixture/connection rename-page-txs)
         (let [uid-by-title (common-db/v-by-ea @@fixture/connection [:node/title test-title-to] :block/uid)
               block-string (common-db/v-by-ea @@fixture/connection [:block/uid test-block-uid] :block/string)]
-          (t/is (thrown-with-msg? #?(:cljs js/Error
-                                     :clj ExceptionInfo)
-                                  #"Nothing found for entity id"
-                  (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
+          (t/is (nil? (common-db/v-by-ea @@fixture/connection [:node/title test-title-from] :block/uid)))
           (t/is (= test-page-uid uid-by-title))
           (t/is (= test-string-to block-string)))))))


### PR DESCRIPTION
![order restored](https://media.giphy.com/media/3o6ozqTvP4AIu6eaje/giphy.gif)