### PR TITLE
embed presence

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -177,7 +177,7 @@
     (if (schema/valid-event? event)
       ;; valid event let's send it
       (do
-        (log/info "Sending event:" (pr-str event))
+        (log/debug "Sending event:" (pr-str event))
         (client/send! event))
       (let [explanation (-> schema/event
                             (m/explain event)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -322,7 +322,7 @@
       {:db            (assoc db :editing/uid uid)
        :editing/focus [uid index]
        :dispatch-n    [(when (and uid remote?)
-                         [:presence/send-update {:block-uid uid}])]})))
+                         [:presence/send-update {:block-uid (util/embed-uid->original-uid uid)}])]})))
 
 
 (reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -327,11 +327,11 @@
 
 (reg-event-fx
   :editing/target
-  (fn [{:keys [db]} [_ target]]
+  (fn [_ [_ target]]
     (let [uid (-> (.. target -id)
                   (string/split "editable-uid-")
                   second)]
-      {:db (assoc db :editing/uid uid)})))
+      {:dispatch [:editing/uid uid]})))
 
 
 (reg-event-fx

--- a/src/cljs/athens/self_hosted/client.cljs
+++ b/src/cljs/athens/self_hosted/client.cljs
@@ -193,8 +193,8 @@
 
 (defn- awaited-response-handler
   [{:event/keys [id status] :as packet}]
-  (log/info "event-id:" (pr-str id)
-            "WSClient: response status:" (pr-str status))
+  (log/debug "event-id:" (pr-str id)
+             "WSClient: response status:" (pr-str status))
   ;; is it hello confirmation?
   (if (= @await-open-event-id id)
     (finished-open-handler packet)
@@ -206,7 +206,7 @@
         (condp = status
           :accepted
           (let [{:accepted/keys [tx-id]} packet]
-            (log/info "event-id:" (pr-str id) "accepted in tx" tx-id))
+            (log/debug "event-id:" (pr-str id) "accepted in tx" tx-id))
           :rejected
           (let [{:reject/keys [reason data]} packet]
             (log/warn "event-id:" (pr-str id)
@@ -269,7 +269,7 @@
 
 (defn- forwarded-event-handler
   [args]
-  (log/info "Forwarded event:" (pr-str args))
+  (log/debug "Forwarded event:" (pr-str args))
   (rf/dispatch [:remote/apply-forwarded-event args]))
 
 

--- a/src/cljs/athens/self_hosted/presence/views.cljs
+++ b/src/cljs/athens/self_hosted/presence/views.cljs
@@ -5,6 +5,7 @@
     [athens.self-hosted.presence.events]
     [athens.self-hosted.presence.fx]
     [athens.self-hosted.presence.subs]
+    [athens.util :as util]
     [re-frame.core :as rf]
     [reagent.core :as r]))
 
@@ -83,7 +84,7 @@
 
 (defn inline-presence-el
   [uid]
-  (let [users (rf/subscribe [:presence/has-presence uid])]
+  (let [users (rf/subscribe [:presence/has-presence (util/embed-uid->original-uid uid)])]
     (when (seq @users)
       (into
         [:> (.-Stack Avatar)

--- a/src/cljs/athens/util.cljs
+++ b/src/cljs/athens/util.cljs
@@ -24,6 +24,15 @@
 (declare specter-recursive-path)
 
 
+(defn embed-uid->original-uid
+  "Return the original-uid for uid if it is embed, otherwise returns uid.
+   Embeds have a modified and local uid to make them unique for selection and focus.
+   But for presence, the original uid is used instead because the embed uid
+   is not present in other clients."
+  [uid]
+  (-> uid (string/split #"-embed-") first))
+
+
 (defn recursively-modify-block-for-embed
   "Modify the block and all the block children to have same embed-id for
    referencing the embed block rather than block in original page"


### PR DESCRIPTION
- rfct: reduce log noise on non-verbose settings
- fix: editing/target should delegate to editing/uid
- fix: embeds show presence as well as the original block
