### PR TITLE
fix: this docker images was to skinny

### DIFF
--- a/athens.dockerfile
+++ b/athens.dockerfile
@@ -1,5 +1,5 @@
 # A base, just JVM
-FROM openjdk:16-slim
+FROM openjdk:16
 
 RUN mkdir -p /srv/athens/db
 


### PR DESCRIPTION
It didn't have `curl` anymore,
and we need it for health-check.