### PR TITLE
fix(data-loss): Quitting athens while editing a block displays no warning and causes data loss. 

### DIFF
--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -220,11 +220,11 @@
     EventType.BEFOREUNLOAD
     (fn [e]
       (let [synced? @(subscribe [:db/synced])
-            idEditing? @(subscribe [:editing/uid])
+            isEditing? @(subscribe [:editing/uid])
             remote? (electron-utils/remote-db? @(subscribe [:db-picker/selected-db]))]
         (cond
           (and (or (not synced?)
-                   (not (= nil idEditing?)))
+                   (not (= nil isEditing?)))
                (not @force-leave))
           (do
             ;; The browser blocks the confirm window during beforeunload, so

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -220,9 +220,11 @@
     EventType.BEFOREUNLOAD
     (fn [e]
       (let [synced? @(subscribe [:db/synced])
+            idEditing? @(subscribe [:editing/uid])
             remote? (electron-utils/remote-db? @(subscribe [:db-picker/selected-db]))]
         (cond
-          (and (not synced?)
+          (and (or (not synced?)
+                   (not (= nil idEditing?)))
                (not @force-leave))
           (do
             ;; The browser blocks the confirm window during beforeunload, so
@@ -230,7 +232,7 @@
             ;; that allows closing the window.
             (dispatch [:confirm/js
                        (str "Athens hasn't finished saving yet. Athens is finished saving when the sync dot is green. "
-                            "Try refreshing or quitting again once the sync is complete. "
+                            "Try refreshing or quitting again once the sync is complete. Make sure you exit out of any block you may be editing"
                             "Press OK to wait, or Cancel to leave without saving (will cause data loss!).")
                        #()
                        (fn []

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -220,11 +220,11 @@
     EventType.BEFOREUNLOAD
     (fn [e]
       (let [synced? @(subscribe [:db/synced])
-            isEditing? @(subscribe [:editing/uid])
+            editing? @(subscribe [:editing/uid])
             remote? (electron-utils/remote-db? @(subscribe [:db-picker/selected-db]))]
         (cond
           (and (or (not synced?)
-                   (not (= nil isEditing?)))
+                   (not (= nil editing?)))
                (not @force-leave))
           (do
             ;; The browser blocks the confirm window during beforeunload, so


### PR DESCRIPTION
Brings up a popup window warning user that edits may not have been saved if user is currently editing a block. 

Discussed in the data loss channel on discord. 

this will close #1898 
