### PR TITLE
build: install dependencies and build on vercel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,27 +255,3 @@ jobs:
            allowUpdates: true
            prerelease: true
            draft: true
-
-
-   release-devtools:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v2
-       - uses: ./.github/custom-actions/clojure-env
-       - uses: ./.github/custom-actions/node-env
-
-       - name: Build static Storybook site
-         run: yarn storybook:static
-
-       - name: Build static Clerk site
-         run: yarn notebooks:static
-
-       - uses: amondnet/vercel-action@v20
-         with:
-           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-           github-token: ${{ secrets.GITHUB_TOKEN }}
-           # deploy files in vercel-static/
-           # prod build for pushes to main
-           vercel-args: vercel-static/ ${{ github.ref != 'refs/heads/main' && '--prod' || '' }}

--- a/deps.edn
+++ b/deps.edn
@@ -28,11 +28,7 @@
   day8.re-frame/re-frame-10x            #:mvn{:version "1.1.13"}
   day8.re-frame/tracing                 #:mvn{:version "0.6.2"}
   org.flatland/ordered                  #:mvn{:version "1.15.10"}
-  ;; See https://github.com/nextjournal/clerk/pull/31 for why the fork.
-  ;; This was necessary for using vercel to deploy the built clerk output.
-  ;; TODO: go back to using the main repo when that issue is resolved.
-  io.github.nextjournal/clerk           {:git/url "https://github.com/filipesilva/clerk"
-                                         :git/sha "94c6ed5563c7cdb8810bc41380f6993c763d7c75"}
+  io.github.nextjournal/clerk           #:git{:sha "d111501576537c402dc8bf65eee30e2cd90d2666"}
   org.clojure/data.json                 #:mvn{:version "2.4.0"}
   ;; backend
   ;;   logging hell

--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,11 @@
   day8.re-frame/re-frame-10x            #:mvn{:version "1.1.13"}
   day8.re-frame/tracing                 #:mvn{:version "0.6.2"}
   org.flatland/ordered                  #:mvn{:version "1.15.10"}
-  io.github.nextjournal/clerk           {:git/sha "64ce88eb80609ab915b61fbabd46f7d9c8ac1375"}
+  ;; See https://github.com/nextjournal/clerk/pull/31 for why the fork.
+  ;; This was necessary for using vercel to deploy the built clerk output.
+  ;; TODO: go back to using the main repo when that issue is resolved.
+  io.github.nextjournal/clerk           {:git/url "https://github.com/filipesilva/clerk"
+                                         :git/sha "94c6ed5563c7cdb8810bc41380f6993c763d7c75"}
   org.clojure/data.json                 #:mvn{:version "2.4.0"}
   ;; backend
   ;;   logging hell

--- a/dev/notebooks/notebooks.clj
+++ b/dev/notebooks/notebooks.clj
@@ -24,9 +24,11 @@
   [& _args]
   (clerk/build-static-app!
     {:out-path "vercel-static/clerk"
+     :browse? false
      :paths (->> "dev/notebooks"
                  io/file
                  file-seq
                  (filter #(.isFile %))
                  (map io/as-relative-path)
-                 (filter #(not= % "dev/notebooks/notebooks.clj")))}))
+                 (remove #{"dev/notebooks/notebooks.clj"
+                           "dev/notebooks/.DS_Store"}))}))

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "clj:outdated": "clojure -M:outdated",
     "notebooks": "clojure -M:notebooks",
     "notebooks:static": "clojure -X:notebooks-static",
+    "vercel:install": "./script/vercel-setup.sh && yarn && clojure -P",
+    "vercel:build": "yarn notebooks:static && yarn storybook:static",
     "//client scripts": "",
     "dev": "yarn components && concurrently \"yarn components:watch\" \"yarn client:watch\"",
     "client:watch": "shadow-cljs watch main renderer app",

--- a/script/vercel-setup.sh
+++ b/script/vercel-setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Fail on all sorts of errors.
+# https://stackoverflow.com/a/2871034/2116927
+set -euxo pipefail
+
+# In Vercel -> Project Settings -> Build & Development Settings:
+# Build command   : yarn vercel:build
+# Output directory: vercel-static
+# Install command : yarn vercel:install
+
+# See https://vercel.com/docs/concepts/deployments/build-step#build-image for custom setup instructions.
+
+# Java 11 is already installed.
+java --version
+
+# Clojure linux installer.
+curl -O https://download.clojure.org/install/linux-install-1.10.3.1040.sh
+chmod +x linux-install-1.10.3.1040.sh
+./linux-install-1.10.3.1040.sh
+clojure --version

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "github": {
-    "enabled": false
-  },
-  "builds": [
-    { "src": "./**", "use": "@now/static" }
-  ]
-}


### PR DESCRIPTION
The secrets necessary for `amondnet/vercel-action` will not be sent for
fork PR builds, so it's not really suitable for usage in our development model.