### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     #   dockerfile: athens.dockerfile
     restart: always
     depends_on:
-      - fluree:
+      - fluree
     ports:
       - 3010:3010 # Change this according to CONFIG_EDN.
     volumes:
@@ -35,7 +35,7 @@ services:
     #  dockerfile: nginx.dockerfile
     restart: always
     depends_on:
-      - athens:
+      - athens
     restart: always
     ports:
       - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+# NB: Always use immutable tags (e.g. not latest etc) on docker refs.
+# Any :latest tags on this file will be replaced with athens release version on release.
+
+version: "3.4"
+services:
+  athens:
+    image: ghcr.io/athensresearch/athens:latest
+    # Uncomment the build sections if you want docker compose to build them locally.
+    # build:
+    #   context: .
+    #   dockerfile: athens.dockerfile
+    restart: always
+    depends_on:
+      - fluree:
+    ports:
+      - 3010:3010 # Change this according to CONFIG_EDN.
+    volumes:
+      - ./athens-data/logs:/srv/athens/logs
+    environment:
+      # Uses system env vars for settings if available.
+      # CONFIG_EDN is deep merged with the default config file.
+      - CONFIG_EDN=${CONFIG_EDN:-{}}
+    healthcheck:
+      test: curl -f localhost:3010/health-check
+      interval: 15s
+      timeout: 60s
+      retries: 10
+      start_period: 15s
+
+
+  nginx:
+    image: ghcr.io/athensresearch/nginx:latest
+    # build:
+    #  context: .
+    #  dockerfile: nginx.dockerfile
+    restart: always
+    depends_on:
+      - athens:
+    restart: always
+    ports:
+      - 80:80
+
+  fluree:
+    # Under default settings maximum recommended event size is 2mb.
+    # Can be increased via fdb-memory-reindex-max to up to 10mb.
+    image: fluree/ledger:1.0
+    restart: always
+    ports:
+      - 8090:8090
+    volumes:
+      - ./athens-data/fluree:/var/lib/fluree
+    healthcheck:
+      test: curl -f localhost:8090/fdb/health
+      interval: 15s
+      timeout: 30s
+      retries: 3
+      start_period: 15s


### PR DESCRIPTION
The docker-compose.yml file has been incorrectly formatted for the version of compose used, for months now. I've fixed it by adding dashes in front of `depends_on` services as well as removing the deprecated `condition` fields within the `depends_on` fields.