### PR TITLE
enhance(help-popup): Use more general term for search shortcut 

### DIFF
--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -131,7 +131,7 @@
 
 (def shortcut-groups
   [{:name  "App"
-    :items [{:description "Toggle Athena"
+    :items [{:description "Toggle Search"
              :shortcut    "mod+k"}
             {:description "Toggle Left Sidebar"
              :shortcut    "mod+\\"}


### PR DESCRIPTION
Changes the instruction in the help popup to show "Toggle Search" instead of "Toggle Athena". 

<img width="532" alt="Screen Shot 2022-01-08 at 4 58 20 PM" src="https://user-images.githubusercontent.com/80150109/148645059-21ffcfff-5380-4824-9e7b-86000d9a3799.png">
 
Believe this to make sense as Athena is not a term that the general end user will likely be familiar with. They will, however, instantly understand if we use the term "Search"