### PR TITLE
undo block remove

### DIFF
--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -476,7 +476,11 @@
 (defn compat-position
   "Build a position by coercing incompatible arguments into compatible ones.
   uid to a page will instead use that page's title.
-  Integer relation will be converted to :first if 0, or :after (with matching uid) if not."
+  Integer relation will be converted to :first if 0, or :after (with matching uid) if not.
+  Accepts the `{:block/uid <parent-uid> :relation <integer>}` old format based on order number.
+  Output position will be athens.common-events.graph.schema/child-position for the first block,
+  and athens.common-events.graph.schema/sibling-position for others.
+  It's safe to use a position that does not need coercing of any arguments, like the output formats."
   [db {:keys [relation block/uid page/title] :as pos}]
   (let [[coerced-ref-uid
          coerced-relation] (when (integer? relation)

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -445,8 +445,8 @@
   (let [rename-ks            {:block/open :block/open?
                               :node/title :page/title}
         remove-ks-on-match [[:block/order (constantly true)]
-                            [:block/open? #(:block/open? %)]
-                            [:block/uid #(:page/title %)]]]
+                            [:block/open? :block/open?]
+                            [:block/uid   :page/title]]]
     (->> (d/pull db block-document-pull-vector-for-copy eid)
          sort-block-children
          (walk/postwalk-replace rename-ks)

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -505,6 +505,19 @@
     (or new-pos pos)))
 
 
+(defn get-position
+  "Get the position for block-uid in db.
+  Position will be athens.common-events.graph.schema/child-position for the first block,
+  and athens.common-events.graph.schema/sibling-position for others."
+  [db block-uid]
+  (let [{:block/keys [order]
+         :db/keys    [id]} (get-block db [:block/uid block-uid])
+        parent-uid         (->> id (get-parent db) :block/uid)
+        position           (compat-position db {:block/uid parent-uid
+                                                :relation  order})]
+    position))
+
+
 (defn validate-position
   [db {:keys [block/uid page/title] :as position}]
   (let [title->uid (get-page-uid db title)

--- a/src/cljc/athens/common_events/bfs.cljc
+++ b/src/cljc/athens/common_events/bfs.cljc
@@ -67,9 +67,12 @@
                                       parent-uid   {:block/uid parent-uid     :relation :last}
                                       ;; There's a default place where we can drop blocks, use it.
                                       default-position default-position
-                                      :else (throw (ex-info "Cannot determine position for enhanced internal representation" eir)))]
-      (cond-> [(atomic/make-block-new-op uid position)
-               (graph-ops/build-block-save-op db uid string)]
+                                      :else (throw (ex-info "Cannot determine position for enhanced internal representation" eir)))
+          save-op                   (graph-ops/build-block-save-op db uid string)
+          atomic-save-ops           (if (graph-ops/atomic-composite? save-op)
+                                      (graph-ops/extract-atomics save-op)
+                                      [save-op])]
+      (cond-> (into [(atomic/make-block-new-op uid position)] atomic-save-ops)
         (= open? false) (conj (atomic/make-block-open-op uid false))))))
 
 

--- a/src/cljc/athens/common_events/bfs.cljc
+++ b/src/cljc/athens/common_events/bfs.cljc
@@ -76,14 +76,23 @@
         (= open? false) (conj (atomic/make-block-open-op uid false))))))
 
 
+(defn move-save-ops-to-end
+  [coll]
+  (let [{save true
+         not-save false} (group-by #(= (:op/type %) :block/save) coll)]
+    (concat [] not-save save)))
+
+
 (defn internal-representation->atomic-ops
-  "Convert internal representation to the set of atomic operations that would create it."
+  "Convert internal representation to the vector of atomic operations that would create it.
+  :block/save operations are grouped at the end so that any ref'd entities are already created."
   [db internal-representation default-position]
   (->> internal-representation
        enhance-internal-representation
        (mapcat (partial tree-seq :block/children :block/children))
        (map (partial enhanced-internal-representation->atomic-ops db default-position))
        flatten
+       move-save-ops-to-end
        vec))
 
 

--- a/src/cljc/athens/common_events/resolver/undo.cljc
+++ b/src/cljc/athens/common_events/resolver/undo.cljc
@@ -28,14 +28,15 @@
 (defmethod resolve-atomic-op-to-undo-ops :block/remove
   [_db evt-db {:op/keys [args]}]
   (let [{:block/keys [uid]} args
-        {:block/keys [order _refs]
+        {backrefs    :block/_refs
+         :block/keys [order]
          :db/keys    [id]}  (common-db/get-block evt-db [:block/uid uid])
         parent-uid          (->> id (common-db/get-parent evt-db) :block/uid)
         position            (common-db/compat-position evt-db {:block/uid parent-uid
                                                                :relation  order})
         repr                [(common-db/get-internal-representation evt-db [:block/uid uid])]
         repr-ops            (bfs/internal-representation->atomic-ops evt-db repr position)
-        save-ops            (->> _refs
+        save-ops            (->> backrefs
                                  (map :db/id)
                                  (map (partial common-db/get-block evt-db))
                                  (map (fn [{:block/keys [uid string]}]

--- a/test/athens/bfs_test.cljc
+++ b/test/athens/bfs_test.cljc
@@ -35,18 +35,18 @@
     (is (= [#:op{:type :page/new, :atomic? true, :args {:page/title "Welcome"}}
             #:op{:type :block/new, :atomic? true, :args {:block/uid "block-1", :block/position {:page/title "Welcome", :relation :last}}}
             #:op{:type :page/new, :atomic? true, :args {:page/title "Welcome"}}
-            #:op{:type :block/save, :atomic? true, :args {:block/uid "block-1", :block/string "block with link to [[Welcome]]"}}
-            #:op{:type :block/open :atomic? true :args {:block/uid "block-1" :block/open? false}}]
+            #:op{:type :block/open :atomic? true :args {:block/uid "block-1" :block/open? false}}
+            #:op{:type :block/save, :atomic? true, :args {:block/uid "block-1", :block/string "block with link to [[Welcome]]"}}]
            (bfs/internal-representation->atomic-ops db tree-with-page nil)))
 
     (is (= [#:op{:type :block/new, :atomic? true, :args {:block/uid "eaa4c9435", :block/position {:page/title "title", :relation :first}}}
-            #:op{:type :block/save, :atomic? true, :args {:block/uid "eaa4c9435", :block/string "block 1"}}
             #:op{:type :block/new, :atomic? true, :args {:block/uid "88c9ff662", :block/position {:block/uid "eaa4c9435", :relation :last}}}
-            #:op{:type :block/save, :atomic? true, :args {:block/uid "88c9ff662", :block/string "B1 C1"}}
             #:op{:type :block/new, :atomic? true, :args {:block/uid "7d11d532f", :block/position {:block/uid "88c9ff662", :relation :after}}}
-            #:op{:type :block/save, :atomic? true, :args {:block/uid "7d11d532f", :block/string "B1 C2"}}
             #:op{:type :block/open :atomic? true :args {:block/uid "7d11d532f" :block/open? false}}
             #:op{:type :block/new, :atomic? true, :args {:block/uid "db5fa9a43", :block/position {:block/uid "7d11d532f", :relation :last}}}
+            #:op{:type :block/save, :atomic? true, :args {:block/uid "eaa4c9435", :block/string "block 1"}}
+            #:op{:type :block/save, :atomic? true, :args {:block/uid "88c9ff662", :block/string "B1 C1"}}
+            #:op{:type :block/save, :atomic? true, :args {:block/uid "7d11d532f", :block/string "B1 C2"}}
             #:op{:type :block/save, :atomic? true, :args {:block/uid "db5fa9a43", :block/string "B1 C2 C1"}}]
            (bfs/internal-representation->atomic-ops db tree-without-page {:page/title "title" :relation :first})))))
 

--- a/test/athens/bfs_test.cljc
+++ b/test/athens/bfs_test.cljc
@@ -34,12 +34,8 @@
   (let [db (d/empty-db common-db/schema)]
     (is (= [#:op{:type :page/new, :atomic? true, :args {:page/title "Welcome"}}
             #:op{:type :block/new, :atomic? true, :args {:block/uid "block-1", :block/position {:page/title "Welcome", :relation :last}}}
-            #:op{:type :composite/consequence,
-                 :atomic? false,
-                 :trigger #:op{:type :block/save},
-                 :consequences
-                 [#:op{:type :page/new, :atomic? true, :args {:page/title "Welcome"}}
-                  #:op{:type :block/save, :atomic? true, :args {:block/uid "block-1", :block/string "block with link to [[Welcome]]"}}]}
+            #:op{:type :page/new, :atomic? true, :args {:page/title "Welcome"}}
+            #:op{:type :block/save, :atomic? true, :args {:block/uid "block-1", :block/string "block with link to [[Welcome]]"}}
             #:op{:type :block/open :atomic? true :args {:block/uid "block-1" :block/open? false}}]
            (bfs/internal-representation->atomic-ops db tree-with-page nil)))
 

--- a/test/athens/bfs_test.cljc
+++ b/test/athens/bfs_test.cljc
@@ -16,18 +16,15 @@
 (def tree-without-page
   [{:block/uid    "eaa4c9435"
     :block/string "block 1"
-    :block/open?  true
     :block/children
     [{:block/uid    "88c9ff662"
-      :block/string "B1 C1"
-      :block/open?  true}
+      :block/string "B1 C1"}
      {:block/uid    "7d11d532f"
       :block/string "B1 C2"
       :block/open?  false
       :block/children
       [{:block/uid    "db5fa9a43"
-        :block/string "B1 C2 C1"
-        :block/open?  true}]}]}])
+        :block/string "B1 C2 C1"}]}]}])
 
 
 (deftest get-individual-blocks-from-tree-test

--- a/test/athens/common_db_test.cljc
+++ b/test/athens/common_db_test.cljc
@@ -74,3 +74,40 @@
                                                 :relation  1})
                  {:block/uid "2-1"
                   :relation  :after}))))))
+
+
+(t/deftest get-position
+  (let [tx-data [{:node/title     "a page"
+                  :block/uid      "page-uid"
+                  :block/children [{:block/uid   "1"
+                                    :block/order 0}
+                                   {:block/uid      "2"
+                                    :block/order    1
+                                    :block/children [{:block/uid   "2-1"
+                                                      :block/order 0}
+                                                     {:block/uid   "2-2"
+                                                      :block/order 1}]}]}]
+        db      (-> (d/empty-db common-db/schema)
+                    (d/db-with tx-data))]
+
+    (t/testing "page parent"
+      (t/testing "first block"
+        (t/is (= (common-db/get-position db "1")
+                 {:page/title "a page"
+                  :relation   :first})))
+
+      (t/testing "non-first block"
+        (t/is (= (common-db/get-position db "2")
+                 {:block/uid "1"
+                  :relation  :after}))))
+
+    (t/testing "block parent"
+      (t/testing "first block"
+        (t/is (= (common-db/get-position db "2-1")
+                 {:block/uid "2"
+                  :relation  :first})))
+
+      (t/testing "non-first block"
+        (t/is (= (common-db/get-position db "2-2")
+                 {:block/uid "2-1"
+                  :relation  :after}))))))

--- a/test/athens/common_db_test.cljc
+++ b/test/athens/common_db_test.cljc
@@ -1,0 +1,42 @@
+(ns athens.common-db-test
+  (:require
+    [athens.common-db :as common-db]
+    [clojure.test     :as t]
+    [datascript.core  :as d]))
+
+
+(t/deftest get-internal-representation
+  (let [gir (fn [tx-data eid]
+              (-> (d/empty-db common-db/schema)
+                  (d/db-with tx-data)
+                  (common-db/get-internal-representation eid)))]
+
+    (t/testing "rename :node/title to :page/title"
+      (t/is (= (gir [{:node/title "a page"}]
+                    [:node/title "a page"])
+               {:page/title "a page"})))
+
+    (t/testing "rename :block/open to :block/open?"
+      (t/is (= (gir [{:block/uid  "1"
+                      :block/open false}]
+                    [:block/uid "1"])
+               {:block/uid   "1"
+                :block/open? false})))
+
+    (t/testing "remove :block/order"
+      (t/is (= (gir [{:block/uid   "1"
+                      :block/order 0}]
+                    [:block/uid "1"])
+               {:block/uid "1"})))
+
+    (t/testing "remove :block/open? if true"
+      (t/is (= (gir [{:block/uid  "1"
+                      :block/open true}]
+                    [:block/uid "1"])
+               {:block/uid "1"})))
+
+    (t/testing "remove :block/uid if map has :page/title"
+      (t/is (= (gir [{:node/title "a page"
+                      :block/uid  "1"}]
+                    [:node/title "a page"])
+               {:page/title "a page"})))))

--- a/test/athens/common_events/atomic_ops/block_remove_test.clj
+++ b/test/athens/common_events/atomic_ops/block_remove_test.clj
@@ -4,6 +4,7 @@
     [athens.common-events                 :as common-events]
     [athens.common-events.bfs             :as bfs]
     [athens.common-events.fixture         :as fixture]
+    [athens.common-events.graph.atomic    :as atomic-graph-ops]
     [athens.common-events.graph.ops       :as graph-ops]
     [athens.common-events.resolver.atomic :as atomic-resolver]
     [athens.common-events.resolver.undo   :as undo]
@@ -521,7 +522,7 @@
                      :block/children [{:block/uid    "reffer-uid"
                                        :block/string "\"yields falsehood when preceded by its quotation\" yields falsehood when preceded by its quotation."}]}]
         lookup     [:node/title "test-page"]
-        remove!    #(-> (graph-ops/build-block-remove-op @@fixture/connection test-uid)
+        remove!    #(-> (atomic-graph-ops/make-block-remove-op test-uid)
                         fixture/op-resolve-transact!)]
 
     (t/testing "undo"

--- a/test/athens/common_events/atomic_ops/block_remove_test.clj
+++ b/test/athens/common_events/atomic_ops/block_remove_test.clj
@@ -1,9 +1,12 @@
 (ns athens.common-events.atomic-ops.block-remove-test
   (:require
     [athens.common-db                     :as common-db]
+    [athens.common-events                 :as common-events]
+    [athens.common-events.bfs             :as bfs]
     [athens.common-events.fixture         :as fixture]
     [athens.common-events.graph.ops       :as graph-ops]
     [athens.common-events.resolver.atomic :as atomic-resolver]
+    [athens.common-events.resolver.undo   :as undo]
     [athens.common.logging :as log]
     [clojure.pprint :as pp]
     [clojure.test                         :as t]
@@ -494,3 +497,49 @@
           (t/is (= 0 (:block/order child-3)))
           (t/is (= (str child-1-text child-2-text)
                    (:block/string child-1))))))))
+
+
+(t/deftest undo
+  (let [test-uid   "test-uid"
+        setup-repr [{:page/title     "test-page"
+                     :block/children [{:block/uid    "reffer-uid"
+                                       ;; The string displays as:
+                                       ;;   "yields falsehood when preceded by its quotation" yields falsehood when preceded by its quotation.
+                                       ;; This is a quine: https://en.wikipedia.org/wiki/Quine_(computing)
+                                       ;; It's interesting in and of itself but it's also especially relevant
+                                       ;; for this test, as it's an example of a reference in plain text.
+                                       ;; Undoing a remove must restore the referencing string to its previous
+                                       ;; state instead of trying to do clever things with regexes, since there
+                                       ;; isn't enough information in the string after the reference was removed
+                                       ;; to determine what parts need to go back to being a ref.
+                                       :block/string (str "\"((" test-uid "))\" ((" test-uid ")).")}
+                                      {:block/uid      test-uid
+                                       :block/string   "yields falsehood when preceded by its quotation"
+                                       :block/children [{:block/uid    "123-uid"
+                                                         :block/string "123"}]}]}]
+        exp-repr   [{:page/title     "test-page"
+                     :block/children [{:block/uid    "reffer-uid"
+                                       :block/string "\"yields falsehood when preceded by its quotation\" yields falsehood when preceded by its quotation."}]}]
+        lookup     [:node/title "test-page"]
+        remove!    #(-> (graph-ops/build-block-remove-op @@fixture/connection test-uid)
+                        fixture/op-resolve-transact!)]
+
+    (t/testing "undo"
+      (fixture/setup! setup-repr)
+      (let [[evt-db evt] (remove!)]
+        (t/is (= [(fixture/get-repr lookup)] exp-repr)
+              "Removed block and children, and replaced ref with text")
+        (fixture/undo! evt-db evt)
+        (t/is (= setup-repr [(fixture/get-repr [:node/title "test-page"])]) "Undo restored to the original state"))
+      (fixture/teardown! setup-repr))
+
+
+    ;; TODO: re-enable when block/new is supported
+    #_(t/testing "redo"
+      (fixture/setup! setup-repr)
+      (let [[evt-db evt]   (remove!)
+            [evt-db' evt'] (fixture/undo! evt-db evt)]
+        (fixture/undo! evt-db' evt')
+        (t/is (= [(fixture/get-repr lookup)] exp-repr)
+              "Redo removed block and children, and replaced ref with text"))
+      (fixture/teardown! setup-repr))))


### PR DESCRIPTION
- feat: build-paste-op returns a flat list of atomic ops
- feat: group block save at the end of paste-op
- fix: don't return repr with uid for title or open true
- feat: support :block/remove in undo
