### PR TITLE
undo page merge

### DIFF
--- a/doc/adr/0021-undo-redo.md
+++ b/doc/adr/0021-undo-redo.md
@@ -134,6 +134,17 @@ We can address that issue by creating all blocks before adding their content.
 - how do we present scenarios that won't allow undo to the user?
 - what are the invariants we need to check on op and undo op resolution?
 - repeating undo/redo over an operation results in an ever increasing operation due to nested composites
+- clients with partial state, derived from partial loads, cannot compute the full undo operation since it doesn't have all the data. 
+  In that case it can compute a partial undo, and ask the server to compute the full version.
+  Another strategy is to have the partial load client pull all the data necessary for the operation.
+- When can optimize the operations in undo by flattening the list and analysing it for redundancy (e.g. block/save followed by block/delete).
+  This can help save IO, and we already know that our performance due to IO is suffering.
+  This analysis would need to fully understand the causality chain between operations in order to not introduce bugs over valid composites.
+  A better place to effect this optimization is in the transaction resolver itself, as an execution planner.
+  This would also reduce, or even eliminate, the need for iterative resolution.
+- It's not actually mandatory to update the saved db state on client optimistic rollbacks. 
+  The difference here is a semantic one: if we update we say undos show use the most up to date data, if we don't we say they should use the original data.
+
 
 ## Decision
 

--- a/doc/adr/0021-undo-redo.md
+++ b/doc/adr/0021-undo-redo.md
@@ -144,7 +144,12 @@ We can address that issue by creating all blocks before adding their content.
   This would also reduce, or even eliminate, the need for iterative resolution.
 - It's not actually mandatory to update the saved db state on client optimistic rollbacks. 
   The difference here is a semantic one: if we update we say undos show use the most up to date data, if we don't we say they should use the original data.
-
+- Contiguous moves are problematic to undo, because of how they implicitely have a grouping together with how they resolve back their previous position.
+  We currently have a "forward" bias, where we prefer the :first position if available, followed by :after.
+  But while undoing contiguous moves this fails, because undoing reverts the order of operations, and resolves each position relative to the previous block, which is not yet moved, and results in all blocks but the first staying in place.
+  There's a range of approaches to this issue: static analysis, changing the bias, encoding contiguous ranges, failing the undo.
+  For now we chose to restore the relative order of contiguous moves, after reversing all operations.
+  This is not correct for the general case, but it might be sufficient for all the cases we care about, especially since we have decided that undo is not time travel.
 
 ## Decision
 

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -191,6 +191,20 @@
           eid))
 
 
+(defn get-page
+  "Fetches whole page based on `:db/id`."
+  [db eid]
+  (d/pull db '[:db/id
+               :node/title
+               :block/uid
+               :page/sidebar
+               :block/refs
+               :block/_refs
+               {:block/children [:block/uid
+                                 :block/order]}]
+          eid))
+
+
 (defn get-parent-eid
   "Find parent's `:db/id` of given `eid`."
   [db eid]

--- a/test/athens/common_events/atomic_ops/composite_of_composites_undo_test.cljc
+++ b/test/athens/common_events/atomic_ops/composite_of_composites_undo_test.cljc
@@ -11,8 +11,7 @@
 (t/use-fixtures :each (partial fixture/integration-test-fixture []))
 
 
-;; TODO enable this test when we have `:page/new` undo implemented
-#_(t/deftest composite-of-composites-undo
+(t/deftest composite-of-composites-undo
   (let [block-1-uid    "block-1-uid"
         block-2-uid    "block-2-uid"
         start-str      "aa"
@@ -25,18 +24,18 @@
     (fixture/setup! setup-repr)
     (t/is (nil? (get-page new-page-title)))
     (let [block-split-op (graph-ops/build-block-split-op @@fixture/connection {:old-block-uid block-1-uid
-                                                                                    :new-block-uid block-2-uid
-                                                                                    :string        (str start-str " [[" new-page-title "]]")
-                                                                                    :index         (inc (count start-str))
-                                                                                    :relation      :after})
+                                                                               :new-block-uid block-2-uid
+                                                                               :string        (str start-str " [[" new-page-title "]]")
+                                                                               :index         (inc (count start-str))
+                                                                               :relation      :after})
           block-split-atomics (graph-ops/extract-atomics block-split-op)
           [before-split-db split-event] (fixture/op-resolve-transact! block-split-op)]
       (log/info "block-split-op\n"
-                 (with-out-str
-                   (pp/pprint block-split-op))
-                 "\nblock-split-atomics\n"
-                 (with-out-str
-                   (pp/pprint block-split-atomics)))
+                (with-out-str
+                  (pp/pprint block-split-op))
+                "\nblock-split-atomics\n"
+                (with-out-str
+                  (pp/pprint block-split-atomics)))
       (t/is (not (nil? (get-page new-page-title))))
       (let [[_ undo-op] (fixture/undo! before-split-db split-event)]
         (log/info "undo-op\n"

--- a/test/athens/common_events/atomic_ops/composite_of_move_undo_test.cljc
+++ b/test/athens/common_events/atomic_ops/composite_of_move_undo_test.cljc
@@ -1,0 +1,53 @@
+(ns athens.common-events.atomic-ops.composite-of-move-undo-test
+  (:require
+    [athens.common-events.fixture         :as fixture]
+    [athens.common-events.graph.atomic    :as atomic-ops]
+    [athens.common-events.graph.composite :as composite]
+    [clojure.test                         :as t]))
+
+
+(t/use-fixtures :each (partial fixture/integration-test-fixture []))
+
+
+(let [from-title   "from-title"
+      target-title "target-title"
+      setup-repr   [{:page/title     from-title
+                     :block/children [{:block/uid    "one"
+                                       :block/string ""}
+                                      {:block/uid    "two"
+                                       :block/string ""}
+                                      {:block/uid    "three"
+                                       :block/string ""}]}
+                    {:page/title target-title}]
+      exp-repr     [{:page/title     target-title
+                     :block/children [{:block/uid    "one"
+                                       :block/string ""}
+                                      {:block/uid    "two"
+                                       :block/string ""}
+                                      {:block/uid    "three"
+                                       :block/string ""}]}]
+      move!        #(->> [(atomic-ops/make-block-move-op "one" {:relation :last :page/title target-title})
+                          (atomic-ops/make-block-move-op "two" {:relation :last :page/title target-title})
+                          (atomic-ops/make-block-move-op "three" {:relation :last :page/title target-title})]
+                         (composite/make-consequence-op {:op/type :multi-move})
+                         fixture/op-resolve-transact!)]
+
+  (t/deftest undo-move-composite
+    (fixture/setup! setup-repr)
+
+    (let [[evt-db evt] (move!)]
+      (t/is (= [(fixture/get-repr [:node/title target-title])] exp-repr)
+            "Blocks were moved in order")
+      (fixture/undo! evt-db evt)
+      (t/is (= setup-repr [(fixture/get-repr [:node/title from-title])
+                           (fixture/get-repr [:node/title target-title])])
+            "Undo restored to the original state")))
+
+  (t/deftest redo-move-composite
+    (fixture/setup! setup-repr)
+
+    (let [[evt-db evt] (move!)
+          [evt-db' evt'] (fixture/undo! evt-db evt)]
+      (fixture/undo! evt-db' evt')
+      (t/is (= [(fixture/get-repr [:node/title target-title])] exp-repr)
+            "Blocks were moved in order"))))

--- a/test/athens/common_events/atomic_ops/page_merge_test.cljc
+++ b/test/athens/common_events/atomic_ops/page_merge_test.cljc
@@ -170,21 +170,20 @@
       merge!       #(-> (atomic-graph-ops/make-page-merge-op from-title target-title)
                         fixture/op-resolve-transact!)]
 
-  ;; TODO: uncomment short assertions when undo merge supports shortcuts
   (t/deftest undo-merge
     (fixture/setup! setup-repr setup-ops)
 
     (let [[evt-db evt] (merge!)]
       (t/is (= [(fixture/get-repr lookup)] exp-repr)
             "Merged children into target and replaced ref")
-      #_(t/is (= (mapv :node/title (common-db/get-sidebar-elements @@fixture/connection))
+      (t/is (= (common-db/get-sidebar-titles @@fixture/connection)
                ["target-title"])
             "Removed shortcut")
       (fixture/undo! evt-db evt)
       (t/is (= setup-repr [(fixture/get-repr [:node/title from-title])
                            (fixture/get-repr [:node/title target-title])])
             "Undo restored to the original state")
-      #_(t/is (= (mapv :node/title (common-db/get-sidebar-elements @@fixture/connection))
+      (t/is (= (common-db/get-sidebar-titles @@fixture/connection)
                ["from-title" "target-title"])
             "Undo restored shortcuts")))
 
@@ -197,6 +196,6 @@
       (fixture/undo! evt-db' evt')
       (t/is (= [(fixture/get-repr lookup)] exp-repr)
             "Redo merged children into target and replaced ref")
-      #_(t/is (= (mapv :node/title (common-db/get-sidebar-elements @@fixture/connection))
+      (t/is (= (common-db/get-sidebar-titles @@fixture/connection)
                ["target-title"])
             "Redo removed shortcut"))))


### PR DESCRIPTION
- docs: add more undo mvp findings
- feat: add :page/merge undo
- fix: don't fail :block/move if ref-block-order is nil
