### PR TITLE
undo page/new

### DIFF
--- a/src/cljc/athens/common_events/resolver/undo.cljc
+++ b/src/cljc/athens/common_events/resolver/undo.cljc
@@ -90,10 +90,12 @@
                         (into []))]
     undo-ops))
 
+
 (defmethod resolve-atomic-op-to-undo-ops :page/new
   [_db _evt-db {:op/keys [args]}]
   (let [{:page/keys [title]} args]
     [(atomic-graph-ops/make-page-remove-op title)]))
+
 
 ;; TODO: should there be a distinction between undo and redo?
 (defn build-undo-event

--- a/src/cljc/athens/common_events/resolver/undo.cljc
+++ b/src/cljc/athens/common_events/resolver/undo.cljc
@@ -75,6 +75,10 @@
                         (into []))]
     undo-ops))
 
+(defmethod resolve-atomic-op-to-undo-ops :page/new
+  [_db _evt-db {:op/keys [args]}]
+  (let [{:page/keys [title]} args]
+    [(atomic-graph-ops/make-page-remove-op title)]))
 
 ;; TODO: should there be a distinction between undo and redo?
 (defn build-undo-event

--- a/test/athens/common_events/atomic_ops/page_new_test.cljc
+++ b/test/athens/common_events/atomic_ops/page_new_test.cljc
@@ -51,7 +51,6 @@
         ;; undo (remove page)
         (let [[db' evt'] (fixture/undo! db evt)]
           (t/is (nil? (common-db/get-page-document @@fixture/connection [:node/title test-title])))
-          ;; TODO: uncomment the following tests after undo page/remove is implemented
           (fixture/undo! db' evt')
           (t/is (common-db/get-page-document @@fixture/connection [:node/title test-title])))))))
 
@@ -74,7 +73,6 @@
           (t/is (nil? (common-db/get-page-document @@fixture/connection [:node/title test-title])))
           (t/is (nil? (common-db/get-block @@fixture/connection [:block/uid block-uid])))
           ;; redo
-          ;; TODO: uncomment the following tests after undo page/remove is implemented
           (fixture/undo! db' evt')
           (t/is (common-db/get-page-document @@fixture/connection [:node/title test-title]))
           (t/is (common-db/get-block @@fixture/connection [:block/uid block-uid])))))))


### PR DESCRIPTION
The branch this PR is being pushed from `shortcut-page-new` is misnamed. No shortcuts here! Just page-new.