### PR TITLE
enhance(presence): move inline avatars to the right

### DIFF
--- a/src/cljs/athens/self_hosted/presence/views.cljs
+++ b/src/cljs/athens/self_hosted/presence/views.cljs
@@ -98,12 +98,7 @@
                   :top "0.25rem"
                   :padding "0.125rem"
                   :background "var(--background-color)"}}]
-        (->>
-          @users
-          ;;   (concat @users @users)
-          ;;   (concat @users @users @users)
-          ;;   (concat @users @users @users @users)
-
+        (->> @users
              (map user->person)
              (remove nil?)
              (map (fn [{:keys [personId] :as person}]

--- a/src/cljs/athens/self_hosted/presence/views.cljs
+++ b/src/cljs/athens/self_hosted/presence/views.cljs
@@ -94,11 +94,16 @@
           :limit 3
           :style {:zIndex 100
                   :position "absolute"
-                  :right "1.5rem"
+                  :right "-1.5rem"
                   :top "0.25rem"
                   :padding "0.125rem"
                   :background "var(--background-color)"}}]
-        (->> @users
+        (->>
+          @users
+          ;;   (concat @users @users)
+          ;;   (concat @users @users @users)
+          ;;   (concat @users @users @users @users)
+
              (map user->person)
              (remove nil?)
              (map (fn [{:keys [personId] :as person}]


### PR DESCRIPTION
https://www.loom.com/share/7c8c1dc2320e44b38fa14b016789a969

No overlap when 1 or 2 avatars. Some overlap when 3 or 4+. (i.e. not @shanberg level design, feel free fix later)

The main problem is the 1 avatar case, i.e. when your own avatar is covering the block you are writing in. If you have 3 or 4 people knowingly in the same block at the same time, you have bigger problems to worry about.