### PR TITLE
fix: small paste bugs

### DIFF
--- a/src/cljc/athens/common_events/bfs.cljc
+++ b/src/cljc/athens/common_events/bfs.cljc
@@ -135,7 +135,6 @@
                                     empty-block? current-block-parent-uid
                                     current-block-parent? uid
                                     :else current-block-parent-uid)
-         ;; do we need compat position? the 3 cases are X, :first, and :after. I'm not sure about the case of empty-block?
          default-position         (common-db/compat-position db {:block/uid block-position
                                                                  :relation  new-block-order})
          ir-ops                   (internal-representation->atomic-ops db internal-representation default-position)

--- a/src/cljc/athens/common_events/bfs.cljc
+++ b/src/cljc/athens/common_events/bfs.cljc
@@ -127,7 +127,9 @@
                                                 empty-block?          order
                                                 current-block-parent? 0
                                                 :else                 (inc order))
-         default-position                     (common-db/compat-position db {:block/uid current-block-parent-uid
+         default-position                     (common-db/compat-position db {:block/uid (if empty-block?
+                                                                                          current-block-parent-uid
+                                                                                          uid)
                                                                              :relation  new-block-order})
          extra-ops                            (if empty-block? [(graph-ops/build-block-remove-op db uid)] [])]
      (composite/make-consequence-op {:op/type :block/paste}

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1337,10 +1337,11 @@
 
 (reg-event-fx
   :paste-internal
-  (fn [_ [_ uid internal-representation]]
+  (fn [_ [_ uid local-str internal-representation]]
     (let [[uid]  (db/uid-and-embed-id uid)
           op     (bfs/build-paste-op @db/dsdb
                                      uid
+                                     local-str
                                      internal-representation)
           event  (common-events/build-atomic-event op)]
       (log/debug "paste internal event is" (pr-str event))

--- a/src/cljs/athens/views/blocks/content.cljs
+++ b/src/cljs/athens/views/blocks/content.cljs
@@ -306,7 +306,7 @@
       internal?
       (do
         (.. e preventDefault)
-        (rf/dispatch [:paste-internal uid repr-with-new-uids]))
+        (rf/dispatch [:paste-internal uid (:string/local @state) repr-with-new-uids]))
 
       ;; For images
       (seq (filter (fn [item]
@@ -320,7 +320,7 @@
       (and line-breaks no-shift)
       (do
         (.. e preventDefault)
-        (rf/dispatch [:paste-internal uid text-to-inter]))
+        (rf/dispatch [:paste-internal uid (:string/local @state) text-to-inter]))
 
       (not no-shift)
       (do

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -297,7 +297,7 @@
        (do
          (set-selection target (- start-idx 2) start)
          (replace-selection-with "")
-         (dispatch [:paste-internal uid target-ir])
+         (dispatch [:paste-internal uid (:string/local @state) target-ir])
          (swap! state assoc :search/type nil))))))
 
 

--- a/test/athens/copy_paste_test.cljs
+++ b/test/athens/copy_paste_test.cljs
@@ -66,113 +66,101 @@
 (t/use-fixtures :each (partial fixture/integration-test-fixture []))
 
 
-(deftest paste-internal-event)
+(deftest paste-internal-event
+  (let [block-1-uid         "test-block-1-uid"
+        block-2-uid         "test-block-2-uid"
+        block-1-str         "block 1 string"
+        paste-uid           "test-block-uid"
+        paste-string        "Paste me"
+        page-title          "test page"
+        setup-repr          [{:page/title     page-title
+                              :block/children [#:block {:uid    block-1-uid
+                                                        :string block-1-str}
+                                               #:block {:uid    block-2-uid
+                                                        :string ""}]}]
+        exp-repr            [{:page/title     page-title
+                              :block/children [#:block {:uid    block-1-uid
+                                                        :string block-1-str}
+                                               #:block {:uid    paste-uid
+                                                        :string paste-string}
+                                               #:block {:uid    block-2-uid
+                                                        :string ""}]}]
+        paste-internal-repr [{:block/uid    paste-uid,
+                              :block/string paste-string,
+                              :block/open   true,
+                              :block/order  5}]
+        run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str paste-internal-repr)
+                                  fixture/op-resolve-transact!)]
+    (fixture/setup! setup-repr)
+    (is (= setup-repr
+           [(fixture/get-repr [:node/title page-title])]))
+    (run!)
+    (is (= exp-repr
+           [(fixture/get-repr [:node/title page-title])]))))
 
 
-(fixture/integration-test-fixture
-  (fn []
-    (let [block-1-uid         "test-block-1-uid"
-          block-2-uid         "test-block-2-uid"
-          block-1-str         "block 1 string"
-          paste-uid           "test-block-uid"
-          paste-string        "Paste me"
-          page-title          "test page"
-          setup-repr          [{:page/title     page-title
-                                :block/children [#:block {:uid    block-1-uid
-                                                          :string block-1-str}
-                                                 #:block {:uid    block-2-uid
-                                                          :string ""}]}]
-          exp-repr            [{:page/title     page-title
-                                :block/children [#:block {:uid    block-1-uid
-                                                          :string block-1-str}
-                                                 #:block {:uid    paste-uid
-                                                          :string paste-string}
-                                                 #:block {:uid    block-2-uid
-                                                          :string ""}]}]
-          paste-internal-repr [{:block/uid    paste-uid,
-                                :block/string paste-string,
-                                :block/open   true,
-                                :block/order  5}]
-          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str paste-internal-repr)
-                                    fixture/op-resolve-transact!)]
-      (fixture/setup! setup-repr)
-      (is (= setup-repr
-             [(fixture/get-repr [:node/title page-title])]))
-      (run!)
-      (is (= exp-repr
-             [(fixture/get-repr [:node/title page-title])])))))
+(deftest paste-with-open-block-children-test
+  (let [page-title          "test page"
+        block-1-uid         "test-block-1-uid"
+        block-1-str         "block 1 string"
+        block-2-uid         "test-block-2-uid"
+        paste-uid           "paste-uid"
+        paste-string        "Paste me"
+        setup-repr          [{:page/title     page-title
+                              :block/children [#:block {:uid      block-1-uid
+                                                        :string   block-1-str
+                                                        :children [#:block {:uid    block-2-uid
+                                                                            :string ""}]}]}]
+        exp-repr            [{:page/title     page-title
+                              :block/children [#:block {:uid      block-1-uid
+                                                        :string   block-1-str
+                                                        :children [#:block {:uid    paste-uid
+                                                                            :string paste-string}
+                                                                   #:block {:uid    block-2-uid
+                                                                            :string ""}]}]}]
+        paste-internal-repr [{:block/uid    paste-uid,
+                              :block/string paste-string,
+                              :block/open   true,
+                              :block/order  5}]
+        run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str paste-internal-repr)
+                                  fixture/op-resolve-transact!)]
+    (fixture/setup! setup-repr)
+    (is (= setup-repr
+           [(fixture/get-repr [:node/title page-title])]))
+    (run!)
+    (is (= exp-repr
+           [(fixture/get-repr [:node/title page-title])]))))
 
 
-(deftest paste-with-open-block-children-test)
-
-
-(fixture/integration-test-fixture
-  (fn []
-    (let [page-title          "test page"
-          block-1-uid         "test-block-1-uid"
-          block-1-str         "block 1 string"
-          block-2-uid         "test-block-2-uid"
-          paste-uid           "paste-uid"
-          paste-string        "Paste me"
-          setup-repr          [{:page/title     page-title
-                                :block/children [#:block {:uid      block-1-uid
-                                                          :string   block-1-str
-                                                          :children [#:block {:uid    block-2-uid
-                                                                              :string ""}]}]}]
-          exp-repr            [{:page/title     page-title
-                                :block/children [#:block {:uid      block-1-uid
-                                                          :string   block-1-str
-                                                          :children [#:block {:uid    paste-uid
-                                                                              :string paste-string}
-                                                                     #:block {:uid    block-2-uid
-                                                                              :string ""}]}]}]
-          paste-internal-repr [{:block/uid    paste-uid,
-                                :block/string paste-string,
-                                :block/open   true,
-                                :block/order  5}]
-          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str paste-internal-repr)
-                                    fixture/op-resolve-transact!)]
-      (fixture/setup! setup-repr)
-      (is (= setup-repr
-             [(fixture/get-repr [:node/title page-title])]))
-      (run!)
-      (is (= exp-repr
-             [(fixture/get-repr [:node/title page-title])])))))
-
-
-(deftest paste-with-temporary-string-event)
-
-
-(fixture/integration-test-fixture
-  (fn []
-    (let [block-1-uid         "test-block-1-uid"
-          block-2-uid         "test-block-2-uid"
-          block-1-str-start   "block 1 string"
-          block-1-str-end     (str block-1-str-start " and more text")
-          paste-uid           "test-block-uid"
-          paste-string        "Paste me"
-          page-title          "test page"
-          setup-repr          [{:page/title     page-title
-                                :block/children [#:block {:uid    block-1-uid
-                                                          :string block-1-str-start}
-                                                 #:block {:uid    block-2-uid
-                                                          :string ""}]}]
-          exp-repr            [{:page/title     page-title
-                                :block/children [#:block {:uid    block-1-uid
-                                                          :string block-1-str-end}
-                                                 #:block {:uid    paste-uid
-                                                          :string paste-string}
-                                                 #:block {:uid    block-2-uid
-                                                          :string ""}]}]
-          paste-internal-repr [{:block/uid    paste-uid,
-                                :block/string paste-string,
-                                :block/open   true,
-                                :block/order  5}]
-          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str-end paste-internal-repr)
-                                    fixture/op-resolve-transact!)]
-      (fixture/setup! setup-repr)
-      (is (= setup-repr
-             [(fixture/get-repr [:node/title page-title])]))
-      (run!)
-      (is (= exp-repr
-             [(fixture/get-repr [:node/title page-title])])))))
+(deftest paste-with-temporary-string-event
+  (let [block-1-uid         "test-block-1-uid"
+        block-2-uid         "test-block-2-uid"
+        block-1-str-start   "block 1 string"
+        block-1-str-end     (str block-1-str-start " and more text")
+        paste-uid           "test-block-uid"
+        paste-string        "Paste me"
+        page-title          "test page"
+        setup-repr          [{:page/title     page-title
+                              :block/children [#:block {:uid    block-1-uid
+                                                        :string block-1-str-start}
+                                               #:block {:uid    block-2-uid
+                                                        :string ""}]}]
+        exp-repr            [{:page/title     page-title
+                              :block/children [#:block {:uid    block-1-uid
+                                                        :string block-1-str-end}
+                                               #:block {:uid    paste-uid
+                                                        :string paste-string}
+                                               #:block {:uid    block-2-uid
+                                                        :string ""}]}]
+        paste-internal-repr [{:block/uid    paste-uid,
+                              :block/string paste-string,
+                              :block/open   true,
+                              :block/order  5}]
+        run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str-end paste-internal-repr)
+                                  fixture/op-resolve-transact!)]
+    (fixture/setup! setup-repr)
+    (is (= setup-repr
+           [(fixture/get-repr [:node/title page-title])]))
+    (run!)
+    (is (= exp-repr
+           [(fixture/get-repr [:node/title page-title])]))))

--- a/test/athens/copy_paste_test.cljs
+++ b/test/athens/copy_paste_test.cljs
@@ -25,14 +25,14 @@
 
 
 (def blocks-for-testing
-  [{:block/uid "df27e0c38",
+  [{:block/uid    "df27e0c38",
     :block/string "((df27e0c38))"
-    :block/open true,
-    :block/order 0}
-   {:block/uid "b6c3d65a7",
+    :block/open   true,
+    :block/order  0}
+   {:block/uid    "b6c3d65a7",
     :block/string "((b6c3d65a7))",,
-    :block/open true,
-    :block/order 1}])
+    :block/open   true,
+    :block/order  1}])
 
 
 (def replace-uids-for-testing
@@ -66,38 +66,72 @@
 (t/use-fixtures :each (partial fixture/integration-test-fixture []))
 
 
-(deftest paste-internal-event
-  (let [block-1-uid "test-block-1-uid"
-        block-2-uid "test-block-2-uid"
-        test-block-uid "test-block-uid"
-        setup-tx    [{:node/title     "test page"
-                      :block/uid      "page-uid"
-                      :block/children [{:block/uid      block-1-uid
-                                        :block/string   "A block with text"
-                                        :block/order    0
-                                        :block/children []}
-                                       {:block/uid      block-2-uid
-                                        :block/string   ""
-                                        :block/order    1
-                                        :block/children []}]}]]
-    (fixture/transact-with-middleware setup-tx)
-    (let [internal-representation  [{:block/uid test-block-uid,
-                                     :block/string "Copy-Paste test block",
-                                     :block/open true,
-                                     :block/order 5}]
-          op                       (bfs/build-paste-op @@fixture/connection
-                                                       block-1-uid
-                                                       internal-representation)
-          block-paste-atomics      (graph-ops/extract-atomics op)]
-      (doseq [atomic-op block-paste-atomics
-              :let      [atomic-txs (atomic-resolver/resolve-atomic-op-to-tx @@fixture/connection atomic-op)]]
-        (fixture/transact-with-middleware atomic-txs)))
-    (let [pasted-block    (common-db/get-block @@fixture/connection [:block/uid test-block-uid])
-          reindexed-block (common-db/get-block @@fixture/connection [:block/uid block-2-uid])]
+(deftest paste-internal-event)
+(fixture/integration-test-fixture
+  (fn []
+    (let [block-1-uid         "test-block-1-uid"
+          block-2-uid         "test-block-2-uid"
+          paste-uid           "test-block-uid"
+          paste-string        "Paste me"
+          page-title          "test page"
+          setup-repr          [{:page/title     page-title
+                                :block/children [#:block {:uid    block-1-uid
+                                                          :string "A block with text"}
+                                                 #:block {:uid    block-2-uid
+                                                          :string ""}]}]
+          exp-repr            [{:page/title     page-title
+                                :block/children [#:block {:uid    block-1-uid
+                                                          :string "A block with text"}
+                                                 #:block {:uid    paste-uid
+                                                          :string paste-string}
+                                                 #:block {:uid    block-2-uid
+                                                          :string ""}]}]
+          paste-internal-repr [{:block/uid    paste-uid,
+                                :block/string paste-string,
+                                :block/open   true,
+                                :block/order  5}]
+          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid paste-internal-repr)
+                                    fixture/op-resolve-transact!)]
+      (fixture/setup! setup-repr)
+      (is (= setup-repr
+             [(fixture/get-repr [:node/title page-title])]))
+      (run!)
+      (is (= exp-repr
+             [(fixture/get-repr [:node/title page-title])])))))
 
-      (is (= 1
-             (:block/order pasted-block)))
-      (is (= 2
-             (:block/order reindexed-block)))
-      (is (= "Copy-Paste test block"
-             (:block/string pasted-block))))))
+
+
+
+
+(deftest paste-with-temporary-string-event)
+(fixture/integration-test-fixture
+  (fn []
+    (let [block-1-uid         "test-block-1-uid"
+          block-2-uid         "test-block-2-uid"
+          paste-uid           "test-block-uid"
+          paste-string        "Paste me"
+          page-title          "test page"
+          setup-repr          [{:page/title     page-title
+                                :block/children [#:block {:uid    block-1-uid
+                                                          :string "A block with text"}
+                                                 #:block {:uid    block-2-uid
+                                                          :string ""}]}]
+          exp-repr            [{:page/title     page-title
+                                :block/children [#:block {:uid    block-1-uid
+                                                          :string "A block with text"}
+                                                 #:block {:uid    paste-uid
+                                                          :string paste-string}
+                                                 #:block {:uid    block-2-uid
+                                                          :string ""}]}]
+          paste-internal-repr [{:block/uid    paste-uid,
+                                :block/string paste-string,
+                                :block/open   true,
+                                :block/order  5}]
+          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid paste-internal-repr)
+                                    fixture/op-resolve-transact!)]
+      (fixture/setup! setup-repr)
+      (is (= setup-repr
+             [(fixture/get-repr [:node/title page-title])]))
+      (run!)
+      (is (= exp-repr
+             [(fixture/get-repr [:node/title page-title])])))))

--- a/test/athens/copy_paste_test.cljs
+++ b/test/athens/copy_paste_test.cljs
@@ -67,6 +67,8 @@
 
 
 (deftest paste-internal-event)
+
+
 (fixture/integration-test-fixture
   (fn []
     (let [block-1-uid         "test-block-1-uid"
@@ -102,6 +104,8 @@
 
 
 (deftest paste-with-open-block-children-test)
+
+
 (fixture/integration-test-fixture
   (fn []
     (let [page-title          "test page"
@@ -136,9 +140,9 @@
              [(fixture/get-repr [:node/title page-title])])))))
 
 
-
-
 (deftest paste-with-temporary-string-event)
+
+
 (fixture/integration-test-fixture
   (fn []
     (let [block-1-uid         "test-block-1-uid"

--- a/test/athens/copy_paste_test.cljs
+++ b/test/athens/copy_paste_test.cljs
@@ -71,17 +71,18 @@
   (fn []
     (let [block-1-uid         "test-block-1-uid"
           block-2-uid         "test-block-2-uid"
+          block-1-str         "block 1 string"
           paste-uid           "test-block-uid"
           paste-string        "Paste me"
           page-title          "test page"
           setup-repr          [{:page/title     page-title
                                 :block/children [#:block {:uid    block-1-uid
-                                                          :string "A block with text"}
+                                                          :string block-1-str}
                                                  #:block {:uid    block-2-uid
                                                           :string ""}]}]
           exp-repr            [{:page/title     page-title
                                 :block/children [#:block {:uid    block-1-uid
-                                                          :string "A block with text"}
+                                                          :string block-1-str}
                                                  #:block {:uid    paste-uid
                                                           :string paste-string}
                                                  #:block {:uid    block-2-uid
@@ -90,7 +91,7 @@
                                 :block/string paste-string,
                                 :block/open   true,
                                 :block/order  5}]
-          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid paste-internal-repr)
+          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str paste-internal-repr)
                                     fixture/op-resolve-transact!)]
       (fixture/setup! setup-repr)
       (is (= setup-repr
@@ -105,17 +106,18 @@
   (fn []
     (let [page-title          "test page"
           block-1-uid         "test-block-1-uid"
+          block-1-str         "block 1 string"
           block-2-uid         "test-block-2-uid"
           paste-uid           "paste-uid"
           paste-string        "Paste me"
           setup-repr          [{:page/title     page-title
                                 :block/children [#:block {:uid      block-1-uid
-                                                          :string   "A block with text"
+                                                          :string   block-1-str
                                                           :children [#:block {:uid    block-2-uid
                                                                               :string ""}]}]}]
           exp-repr            [{:page/title     page-title
                                 :block/children [#:block {:uid      block-1-uid
-                                                          :string   "A block with text"
+                                                          :string   block-1-str
                                                           :children [#:block {:uid    paste-uid
                                                                               :string paste-string}
                                                                      #:block {:uid    block-2-uid
@@ -124,7 +126,7 @@
                                 :block/string paste-string,
                                 :block/open   true,
                                 :block/order  5}]
-          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid paste-internal-repr)
+          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str paste-internal-repr)
                                     fixture/op-resolve-transact!)]
       (fixture/setup! setup-repr)
       (is (= setup-repr
@@ -141,17 +143,19 @@
   (fn []
     (let [block-1-uid         "test-block-1-uid"
           block-2-uid         "test-block-2-uid"
+          block-1-str-start   "block 1 string"
+          block-1-str-end     (str block-1-str-start " and more text")
           paste-uid           "test-block-uid"
           paste-string        "Paste me"
           page-title          "test page"
           setup-repr          [{:page/title     page-title
                                 :block/children [#:block {:uid    block-1-uid
-                                                          :string "A block with text"}
+                                                          :string block-1-str-start}
                                                  #:block {:uid    block-2-uid
                                                           :string ""}]}]
           exp-repr            [{:page/title     page-title
                                 :block/children [#:block {:uid    block-1-uid
-                                                          :string "A block with text"}
+                                                          :string block-1-str-end}
                                                  #:block {:uid    paste-uid
                                                           :string paste-string}
                                                  #:block {:uid    block-2-uid
@@ -160,7 +164,7 @@
                                 :block/string paste-string,
                                 :block/open   true,
                                 :block/order  5}]
-          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid paste-internal-repr)
+          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid block-1-str-end paste-internal-repr)
                                     fixture/op-resolve-transact!)]
       (fixture/setup! setup-repr)
       (is (= setup-repr

--- a/test/athens/copy_paste_test.cljs
+++ b/test/athens/copy_paste_test.cljs
@@ -100,6 +100,39 @@
              [(fixture/get-repr [:node/title page-title])])))))
 
 
+(deftest paste-with-open-block-children-test)
+(fixture/integration-test-fixture
+  (fn []
+    (let [page-title          "test page"
+          block-1-uid         "test-block-1-uid"
+          block-2-uid         "test-block-2-uid"
+          paste-uid           "paste-uid"
+          paste-string        "Paste me"
+          setup-repr          [{:page/title     page-title
+                                :block/children [#:block {:uid      block-1-uid
+                                                          :string   "A block with text"
+                                                          :children [#:block {:uid    block-2-uid
+                                                                              :string ""}]}]}]
+          exp-repr            [{:page/title     page-title
+                                :block/children [#:block {:uid      block-1-uid
+                                                          :string   "A block with text"
+                                                          :children [#:block {:uid    paste-uid
+                                                                              :string paste-string}
+                                                                     #:block {:uid    block-2-uid
+                                                                              :string ""}]}]}]
+          paste-internal-repr [{:block/uid    paste-uid,
+                                :block/string paste-string,
+                                :block/open   true,
+                                :block/order  5}]
+          run!                #(->> (bfs/build-paste-op @@fixture/connection block-1-uid paste-internal-repr)
+                                    fixture/op-resolve-transact!)]
+      (fixture/setup! setup-repr)
+      (is (= setup-repr
+             [(fixture/get-repr [:node/title page-title])]))
+      (run!)
+      (is (= exp-repr
+             [(fixture/get-repr [:node/title page-title])])))))
+
 
 
 


### PR DESCRIPTION
Demos

1a. https://www.loom.com/share/811939853f6646058b481860f0e1d429

1b. https://www.loom.com/share/cd507d3e31a240fa95d5ae65551a03d8

---

1. fixes subtle issues with paste
  a. pasting while there is an unsaved local string overwrote it; now it doesn't
  b. pasting when on a block that is open with children previously added blocks to the top of the page; now it adds them to the top of the children
2. wasn't able to get tests to runs in Cursive in my REPL, so temporarily using the `fixture/integration-test-fixture`. will remove once the general logic for this PR or I can get the tests to compile in my REPL
3. there is a more general problem regarding 1a. oftentimes user will trigger some sort of graph op while they have an unsaved local-string edit, e.g. paste, indent, enter. Seems like there should be a more elegant, generic solution that does better local-string handling.
4. currently no `:editing/uid` is dispatched after paste events, user just says on the same block. `:editing/uid` should be dispatched, but want to wait for a larger refactor here (I think depending on Alex's async-flow-fx)