### PR TITLE
fix: pressing up and the previous block has a closed child

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -386,12 +386,13 @@
 
 (defn deepest-child-block
   [id]
-  (let [document (->> (d/pull @dsdb '[:block/order :block/uid {:block/children ...}] id)
+  (let [document (->> (d/pull @dsdb '[:block/order :block/uid :block/open {:block/children ...}] id)
                       sort-block-children)]
     (loop [block document]
-      (let [{:block/keys [children]} block
+      (let [{:block/keys [children open]} block
             n (count children)]
-        (if (zero? n)
+        (if (or (zero? n)
+                (not open))
           block
           (recur (get children (dec n))))))))
 


### PR DESCRIPTION
https://www.loom.com/share/e231434d9eb44bd8aeb59bc58f1443c6

I think there's another case where something similar happens: backspace and merge when previous block is more indented.

Is this something that needs tests?