### PR TITLE
build: remove marked dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "iconoir-react": "^2.1.0",
     "katex": "^0.12.0",
     "luxon": "^2.0.2",
-    "marked": "^1.0.0",
     "nedb": "^1.8.0",
     "polished": "^4.1.3",
     "react": "17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10248,11 +10248,6 @@ markdown-to-jsx@^7.1.0, markdown-to-jsx@^7.1.3:
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz#f00bae66c0abe7dd2d274123f84cb6bd2a2c7c6a"
   integrity sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==
 
-marked@^1.0.0:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
-
 matcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"


### PR DESCRIPTION
This was only needed due to devcards, and we've since removed devcards.
