### PR TITLE
feat: speedy window re-open on macOS

### DIFF
--- a/src/cljs/athens/main/core.cljs
+++ b/src/cljs/athens/main/core.cljs
@@ -108,6 +108,10 @@
     ;; Path is relative to the compiled js file (main.js in our case)
     (.loadURL ^js @main-window (str "file://" js/__dirname "/public/index.html"))
     (.on ^js @main-window "closed" #(reset! main-window nil))
+    (.on ^js @main-window "close" (fn [e]
+                                    (when (= js/process.platform "darwin")
+                                      (. e preventDefault)
+                                      (. @main-window hide))))
     (.. ^js @main-window -webContents (on "new-window" (fn [e url]
                                                          (.. e preventDefault)
                                                          (.. shell (openExternal url)))))))


### PR DESCRIPTION
Normal mac behavior on clicking the red x is to hide the window so it can be opened instantly from the dock and not have to got through the whole initial boot cycle.

You might want to now move the (prevent-save) function onto this close listener so that on macos it can keep syncing in the background since the window is now hidden but not destroyed.

I'd move (prevent-save) to the window "close" event myself but I have no experience using clojure.