### PR TITLE
Fix for issue 2017 hardcoded http backend

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -9,6 +9,7 @@
     [cljs-http.client            :as http]
     [cljs.core.async             :refer [go <!]]
     [cljs.core.async.interop     :refer [<p!]]
+    [clojure.string              :as str]
     [com.stuartsierra.component  :as component]
     [datascript.core             :as d]
     [day8.re-frame.async-flow-fx]
@@ -152,10 +153,16 @@
 ;; TODO: temporary, and limits to one client opened.
 (def self-hosted-client (atom nil))
 
+(defn resolve-url
+  [url]
+  (if (or (str/starts-with? url "http://") (str/starts-with? url "https://"))
+    url
+    (str/join ["http://" url])))
+
 
 (defn self-hosted-health-check
   [url success-cb failure-cb]
-  (go (let [ch  (go (<p! (.. (js/fetch (str "http://" url "/health-check"))
+  (go (let [ch  (go (<p! (.. (js/fetch (str (resolve-url url) "/health-check"))
                              (then (fn [response]
                                      (if (.-ok response)
                                        :success

--- a/src/cljs/athens/electron/utils.cljc
+++ b/src/cljs/athens/electron/utils.cljc
@@ -1,4 +1,6 @@
-(ns athens.electron.utils)
+(ns athens.electron.utils
+  (:require
+    [clojure.string :as str]))
 
 
 ;; Electron node libs
@@ -87,6 +89,11 @@
   (when (not (.existsSync (fs) dir))
     (.mkdirSync (fs) dir)))
 
+(defn resolve-ws-url
+  [url]
+  (if (str/starts-with? url "http://") (str "ws://" (last (str/split url #"http://")) "/ws")
+    (if (str/starts-with? url "https://") (str "wss://" (last (str/split url #"https://")) "/ws")
+      (str "ws://" url "/ws"))))
 
 (defn self-hosted-db
   "Returns a map representing a self-hosted db.
@@ -97,7 +104,7 @@
    :id       url
    :url      url
    :password password
-   :ws-url   (str "ws://" url "/ws")})
+   :ws-url   (resolve-ws-url url )})
 
 
 (defn local-db?


### PR DESCRIPTION
* Added function to resolve URL to perform the healthcheck
* Added function resolve the websockets URL
* Validated fix manually

This is my first foray into Clojure so I apologize for any newbie errors.
I have two big concerns for this change as is:
1. There are no tests. I would be happy to add some but I might need a bit of help.
2. The two new functions `resolve-url` and `resolve-ws-url` are homed right next to where they are used; should these be added to a "URL utils" type file?