### PR TITLE
fix: boot sequence and db-dump async flows

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -191,7 +191,8 @@
                                        component/start)))
       (fn []
         (log/warn ":remote/client-connect! health-check failure")
-        (rf/dispatch [:remote/connection-failed])))))
+        (rf/dispatch [:remote/connection-failed])
+        (rf/dispatch [:stage/fail-db-load])))))
 
 
 (rf/reg-fx

--- a/src/cljs/athens/electron/boot.cljs
+++ b/src/cljs/athens/electron/boot.cljs
@@ -72,7 +72,7 @@
 
                                      ;; if nth time, remember dark/light theme
                                      {:when       :seen?
-                                      :events     :reset-conn
+                                      :events     :stage/success-db-load
                                       :dispatch-n [[:fs/update-write-db]
                                                    [:db/sync]
                                                    ;; [:restore-navigation]  ; This functionality is there but unreliable we can use it once we make it reliable
@@ -90,12 +90,12 @@
                                       :dispatch [:sentry/end-tx boot-tx]
                                       :halt?    true}
 
+                                     ;; halt when started connecting to remote
                                      {:when       :seen?
-                                      :events     :remote/connection-failed
-                                      :dispatch-n [[:db-picker/remove-selection]
+                                      :events     [:stage/fail-db-load]
+                                      :dispatch-n [[:posthog/set-super-properties]
+                                                   [:loading/unset]
                                                    [:sentry/end-tx boot-tx]]
-                                      ;; This event ends the async flow unsuccessfully
-                                      ;; and tries to reboot on a different db.
                                       :halt?      true}
 
                                      ;; whether first or nth time, update athens pages

--- a/src/cljs/athens/electron/fs.cljs
+++ b/src/cljs/athens/electron/fs.cljs
@@ -79,7 +79,8 @@
     (let [datoms (-> (.readFileSync (utils/fs) db-path)
                      dt/read-transit-str)]
       {:dispatch-n [[:reset-conn datoms]
-                    [:fs/watch db-path]]})))
+                    [:fs/watch db-path]
+                    [:stage/success-db-load]]})))
 
 
 (rf/reg-event-fx

--- a/src/cljs/athens/electron/fs.cljs
+++ b/src/cljs/athens/electron/fs.cljs
@@ -78,9 +78,14 @@
   (fn [_ [_ {:keys [db-path]}]]
     (let [datoms (-> (.readFileSync (utils/fs) db-path)
                      dt/read-transit-str)]
-      {:dispatch-n [[:reset-conn datoms]
-                    [:fs/watch db-path]
-                    [:stage/success-db-load]]})))
+      {:async-flow {:id             :fs-read-and-watch-async-flow
+                    :db-path        [:async-flow :fs/read-and-watch]
+                    :first-dispatch [:reset-conn datoms]
+                    :rules          [{:when       :seen?
+                                      :events     :success-reset-conn
+                                      :dispatch-n [[:fs/watch db-path]
+                                                   [:stage/success-db-load]]
+                                      :halt?      true}]}})))
 
 
 (rf/reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -45,7 +45,27 @@
     (let [conn (d/create-conn common-db/schema)]
       (doseq [[_id data] athens-datoms/welcome-events]
         (atomic-resolver/resolve-transact! conn data))
-      {:dispatch [:reset-conn @conn]})))
+      {:async-flow {:id             :db-in-mem-load
+                    :db-path        [:async-flow :db/in-mem-load]
+                    :first-dispatch [:reset-conn @conn]
+                    :rules          [{:when     :seen?
+                                      :events   :success-reset-conn
+                                      :dispatch [:stage/success-db-load]
+                                      :halt?    true}]}})))
+
+
+(rf/reg-event-db
+  :stage/success-db-load
+  (fn [db]
+    (js/console.debug ":stage/success-db-load")
+    db))
+
+
+(rf/reg-event-db
+  :stage/fail-db-load
+  (fn [db]
+    (js/console.debug ":stage/fail-db-load")
+    db))
 
 
 (reg-event-db
@@ -611,14 +631,14 @@
 (reg-event-fx
   :transact
   [(interceptors/sentry-span "transact")]
-  (fn [_ [_ tx-data]]
-    (let [synced?   @(subscribe [:db/synced])
-          electron? electron.utils/electron?]
-      (if (and synced? electron?)
-        {:fx [[:transact! tx-data]
-              [:dispatch [:db/not-synced]]
-              [:dispatch [:save]]]}
-        {:fx [[:transact! tx-data]]}))))
+  (fn-traced [_ [_ tx-data]]
+             (let [synced?   @(subscribe [:db/synced])
+                   electron? electron.utils/electron?]
+               (if (and synced? electron?)
+                 {:fx [[:transact! tx-data]
+                       [:dispatch [:db/not-synced]]
+                       [:dispatch [:save]]]}
+                 {:fx [[:transact! tx-data]]}))))
 
 
 (rf/reg-event-fx
@@ -646,13 +666,14 @@
 (reg-event-fx
   :reset-conn
   [(interceptors/sentry-span "reset-conn")]
-  (fn [_ [_ db-with-tx]]
-    {:reset-conn! db-with-tx}))
+  (fn-traced [_ [_ db-with-tx]]
+             {:reset-conn! db-with-tx}))
 
 
 (rf/reg-event-fx
   :success-reset-conn
   (fn [_ _]
+    (js/console.debug ":success-reset-conn")
     {}))
 
 
@@ -663,35 +684,35 @@
 
 (rf/reg-event-fx
   :db-dump-handler
-  (fn [{:keys [db]} [_ datoms]]
-    (let [existing-tx     (sentry/transaction-get-current)
-          sentry-tx       (if existing-tx
-                            existing-tx
-                            (sentry/transaction-start "db-dump-handler"))
-          conversion-span (sentry/span-start sentry-tx "convert-datoms")
-          tx-data         (into [] (map datom->tx-entry) datoms)]
-      (sentry/span-finish conversion-span)
-      {:db         db
-       :async-flow {:id             :db-dump-handler-async-flow ; NOTE do not ever use id that is defined event
-                    :db-path        [:async-flow :db-dump-handler]
-                    :first-dispatch [:reset-conn (d/empty-db common-db/schema)]
-                    :rules          [{:when     :seen?
-                                      :events   :success-reset-conn
-                                      :dispatch [:transact tx-data]}
-                                     {:when       :seen?
-                                      :events     :success-transact
-                                      :dispatch-n [[:remote/start-event-sync]
-                                                   [:db/sync]
-                                                   [:remote/connected]]}
-                                     (merge {:when     :seen-all-of?
-                                             :events   [:success-reset-conn
-                                                        :success-transact
-                                                        :remote/start-event-sync
-                                                        :db/sync
-                                                        :remote/connected]
-                                             :halt?    true}
-                                            (when-not existing-tx
-                                              {:dispatch [:sentry/end-tx sentry-tx]}))]}})))
+  (fn-traced [{:keys [db]} [_ datoms]]
+             (let [existing-tx     (sentry/transaction-get-current)
+                   sentry-tx       (if existing-tx
+                                     existing-tx
+                                     (sentry/transaction-start "db-dump-handler"))
+                   conversion-span (sentry/span-start sentry-tx "convert-datoms")
+                   tx-data         (into [] (map datom->tx-entry) datoms)]
+               (sentry/span-finish conversion-span)
+               {:db         db
+                :async-flow {:id             :db-dump-handler-async-flow ; NOTE do not ever use id that is defined event
+                             :db-path        [:async-flow :db-dump-handler]
+                             :first-dispatch [:reset-conn (d/empty-db common-db/schema)]
+                             :rules          [{:when     :seen?
+                                               :events   :success-reset-conn
+                                               :dispatch [:transact tx-data]}
+                                              {:when       :seen?
+                                               :events     :success-transact
+                                               :dispatch-n [[:remote/start-event-sync]
+                                                            [:db/sync]
+                                                            [:remote/connected]]}
+                                              {:when       :seen-all-of?
+                                               :events     [:success-reset-conn
+                                                            :success-transact
+                                                            :remote/start-event-sync
+                                                            :db/sync
+                                                            :remote/connected]
+                                               :dispatch-n (cond-> [[:stage/success-db-load]]
+                                                             (not existing-tx) (conj [:sentry/end-tx sentry-tx]))
+                                               :halt?      true}]}})))
 
 
 (reg-event-fx


### PR DESCRIPTION
Added `:stage/success-db-load` and `:stage/fail-db-load`,
those are used in boot flow.