### PR TITLE
fix: initialize reactive watchers on startup

### DIFF
--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -36,6 +36,8 @@
 (rf/reg-fx
   :reset-conn!
   (fn [[new-db skip-health-check?]]
+    ;; Remove the reactive watchers will resetting the conn to prevent
+    ;; the watchers from processing a massive tx-report.
     (reactive/unwatch!)
     (wrap-span "ds/reset-conn"
                (d/reset-conn! db/dsdb new-db))

--- a/src/cljs/athens/reactive.cljs
+++ b/src/cljs/athens/reactive.cljs
@@ -14,32 +14,45 @@
 
 
 (defn unwatch!
-  "Unwatch the global datascript database."
+  "Unwatch the global datascript database.
+  While unwatched, all get-reactive-* fns will return non-reactive pulls and queries."
   []
   ;; Watching a new conn will remove all old watchers.
-  ;; You can verify this by calling print-posh-state.
+  ;; You can verify this by printing watch-state.
   (p/posh! (d/create-conn)))
+
+
+(defn init!
+  "Initialize the reactive watchers.
+  Must be called before watch-state or any of the get-reactive-* fns, or these will throw."
+  []
+  ;; Add a remove the watcher to the global datascript db once.
+  ;; This will leave the posh datom connected to it, even after unwatch.
+  (watch!)
+  (unwatch!))
 
 
 (defn watch-state
   []
-  (try
-    (-> (p/get-posh-atom db/dsdb)
-        deref
-        ;; all keys
-        ;; (:schema :filters :return :retrieve :txs :cache :dbs
-        ;; :schemas :ratoms :changed :graph :dcfg :reactions :conns)
+  (-> (p/get-posh-atom db/dsdb)
+      deref
+      ;; all keys
+      ;; (:schema :filters :return :retrieve :txs :cache :dbs
+      ;; :schemas :ratoms :changed :graph :dcfg :reactions :conns)
 
-        ;; These keys don't matter much.
-        (dissoc :schema :filters :dbs :conns :schemas :dcfg))
-    ;; get-posh-atom will throw if not watching.
-    (catch :default _)))
+      ;; These keys don't matter much.
+      (dissoc :schema :filters :dbs :conns :schemas :dcfg)))
 
 
 (defn ratoms
   "Returns current reactive atoms."
   []
   (-> (watch-state) :ratoms))
+
+
+;; Initialization
+
+(init!)
 
 
 ;; Ratoms


### PR DESCRIPTION
Prevents them from throwing and crashing the app on unexpected boot flows.
