### PR TITLE
feat: don't warn on exit while editing

### DIFF
--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -223,13 +223,11 @@
     EventType.BEFOREUNLOAD
     (fn [e]
       (let [synced? @(subscribe [:db/synced])
-            editing? @(subscribe [:editing/uid])
             ;; See test/e2e/electron-test.ts for details about this flag.
             e2e-ignore-save? (= (js/localStorage.getItem "E2E_IGNORE_SAVE") "true")
             remote? (electron.utils/remote-db? @(subscribe [:db-picker/selected-db]))]
         (cond
-          (and (or (not synced?)
-                   (not (= nil editing?)))
+          (and (not synced?)
                (not @force-leave)
                (not e2e-ignore-save?))
           (do
@@ -238,7 +236,7 @@
             ;; that allows closing the window.
             (dispatch [:confirm/js
                        (str "Athens hasn't finished saving yet. Athens is finished saving when the sync dot is green. "
-                            "Try refreshing or quitting again once the sync is complete. Make sure you exit out of any block you may be editing. "
+                            "Try refreshing or quitting again once the sync is complete. "
                             "Press Cancel to wait, or OK to leave without saving (will cause data loss!).")
                        (fn []
                          (reset! force-leave true)


### PR DESCRIPTION
This change was first introduced in
https://github.com/athensresearch/athens/pull/1899.

It made a lot of sense at the time because it was so easy to lose
content that was being edited.
But now we auto-save after 2s of inactivity in a block, so I don't think
it's as big of a problem anymore.

I do get the warning popup very often so I think now it's doing more
harm than good.
