### PR TITLE
Sentry txs limit fix

### DIFF
--- a/src/cljc/athens/common/sentry.cljc
+++ b/src/cljc/athens/common/sentry.cljc
@@ -48,8 +48,7 @@
   #?(:clj  nil
      :cljs (let [tx-running?  (sentry/tx-running?)
                  sentry-tx    (if tx-running?
-                                (sentry/transaction-get-current)
-                                (sentry/transaction-start (str _span-name "-defntrace-auto-tx")))
+                                (sentry/transaction-get-current))
                  active-span  (sentry/span-active)
                  current-span (when sentry-tx
                                 (sentry/span-start (or active-span

--- a/src/cljc/athens/common/sentry.cljc
+++ b/src/cljc/athens/common/sentry.cljc
@@ -43,11 +43,12 @@
          (athens.utils.sentry/transaction-finish sentry-tx#)))
      result#))
 
+
 (defn span-start
   [_span-name]
   #?(:clj  nil
      :cljs (let [tx-running?  (sentry/tx-running?)
-                 sentry-tx    (if tx-running?
+                 sentry-tx    (when tx-running?
                                 (sentry/transaction-get-current))
                  active-span  (sentry/span-active)
                  current-span (when sentry-tx

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -889,30 +889,30 @@
   ;; states that need fixing.
   (log/info "Knowledge graph health check...")
   (let [linkmaker-txs       #?(:cljs (wrap-span-no-new-tx "linkmaker"
-                                                (linkmaker @conn))
+                                                          (linkmaker @conn))
                                :clj (linkmaker @conn))
         orderkeeper-txs     #?(:cljs (wrap-span-no-new-tx "orderkeeper"
-                                                (orderkeeper @conn))
+                                                          (orderkeeper @conn))
                                :clj (orderkeeper @conn))
         block-nil-eater-txs #?(:cljs (wrap-span-no-new-tx "nil-eater"
-                                                (block-uid-nil-eater @conn))
+                                                          (block-uid-nil-eater @conn))
                                :clj (block-uid-nil-eater @conn))]
     (when-not (empty? linkmaker-txs)
       (log/warn "linkmaker fixes#:" (count linkmaker-txs))
       (log/info "linkmaker fixes:" (pr-str linkmaker-txs))
       #?(:cljs (wrap-span-no-new-tx "transact linkmaker"
-                          (d/transact! conn linkmaker-txs))
+                                    (d/transact! conn linkmaker-txs))
          :clj (d/transact! conn linkmaker-txs)))
     (when-not (empty? orderkeeper-txs)
       (log/warn "orderkeeper fixes#:" (count orderkeeper-txs))
       (log/info "orderkeeper fixes:" (pr-str orderkeeper-txs))
       #?(:cljs (wrap-span-no-new-tx "transact orderkeeper"
-                          (d/transact! conn orderkeeper-txs))
+                                    (d/transact! conn orderkeeper-txs))
          :clj (d/transact! conn orderkeeper-txs)))
     (when-not (empty? block-nil-eater-txs)
       (log/warn "block-uid-nil-eater fixes#:" (count block-nil-eater-txs))
       (log/info "block-uid-nil-eater fixes:" (pr-str block-nil-eater-txs))
       #?(:cljs (wrap-span-no-new-tx "transact nil-eater"
-                          (d/transact! conn block-nil-eater-txs))
+                                    (d/transact! conn block-nil-eater-txs))
          :clj (d/transact! conn block-nil-eater-txs)))
     (log/info "✅ Knowledge graph health check.")))

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -40,10 +40,10 @@
     ;; the watchers from processing a massive tx-report.
     (reactive/unwatch!)
     (wrap-span-no-new-tx "ds/reset-conn"
-               (d/reset-conn! db/dsdb new-db))
+                         (d/reset-conn! db/dsdb new-db))
     (when-not skip-health-check?
       (wrap-span-no-new-tx "db/health-check"
-                 (common-db/health-check db/dsdb)))
+                           (common-db/health-check db/dsdb)))
     (reactive/watch!)
     (rf/dispatch [:success-reset-conn])))
 

--- a/src/cljs/athens/effects.cljs
+++ b/src/cljs/athens/effects.cljs
@@ -4,7 +4,7 @@
     [athens.common-db            :as common-db]
     [athens.common-events.schema :as schema]
     [athens.common.logging       :as log]
-    [athens.common.sentry        :refer-macros [wrap-span]]
+    [athens.common.sentry        :refer-macros [wrap-span wrap-span-no-new-tx]]
     [athens.db                   :as db]
     [athens.reactive             :as reactive]
     [athens.self-hosted.client   :as client]
@@ -39,10 +39,10 @@
     ;; Remove the reactive watchers will resetting the conn to prevent
     ;; the watchers from processing a massive tx-report.
     (reactive/unwatch!)
-    (wrap-span "ds/reset-conn"
+    (wrap-span-no-new-tx "ds/reset-conn"
                (d/reset-conn! db/dsdb new-db))
     (when-not skip-health-check?
-      (wrap-span "db/health-check"
+      (wrap-span-no-new-tx "db/health-check"
                  (common-db/health-check db/dsdb)))
     (reactive/watch!)
     (rf/dispatch [:success-reset-conn])))

--- a/src/cljs/athens/electron/boot.cljs
+++ b/src/cljs/athens/electron/boot.cljs
@@ -1,6 +1,6 @@
 (ns athens.electron.boot
   (:require
-    [athens.common.sentry      :refer-macros [wrap-span]]
+    [athens.common.sentry      :refer-macros [wrap-span wrap-span-no-new-tx]]
     [athens.db                 :as db]
     [athens.electron.db-picker :as db-picker]
     [athens.electron.utils     :as utils]
@@ -13,7 +13,7 @@
   [(rf/inject-cofx :local-storage :athens/persist)]
   (fn [{:keys [local-storage]} _]
     (let [boot-tx             (sentry/transaction-start "boot-sequence")
-          init-app-db         (wrap-span "db/init-app-db"
+          init-app-db         (wrap-span-no-new-tx"db/init-app-db"
                                          (db/init-app-db local-storage))
           all-dbs             (db-picker/all-dbs init-app-db)
           selected-db         (db-picker/selected-db init-app-db)

--- a/src/cljs/athens/electron/boot.cljs
+++ b/src/cljs/athens/electron/boot.cljs
@@ -1,6 +1,6 @@
 (ns athens.electron.boot
   (:require
-    [athens.common.sentry      :refer-macros [wrap-span wrap-span-no-new-tx]]
+    [athens.common.sentry      :refer-macros [wrap-span-no-new-tx]]
     [athens.db                 :as db]
     [athens.electron.db-picker :as db-picker]
     [athens.electron.utils     :as utils]
@@ -13,8 +13,8 @@
   [(rf/inject-cofx :local-storage :athens/persist)]
   (fn [{:keys [local-storage]} _]
     (let [boot-tx             (sentry/transaction-start "boot-sequence")
-          init-app-db         (wrap-span-no-new-tx"db/init-app-db"
-                                         (db/init-app-db local-storage))
+          init-app-db         (wrap-span-no-new-tx "db/init-app-db"
+                                                   (db/init-app-db local-storage))
           all-dbs             (db-picker/all-dbs init-app-db)
           selected-db         (db-picker/selected-db init-app-db)
           default-db          (utils/get-default-db)

--- a/src/cljs/athens/electron/fs.cljs
+++ b/src/cljs/athens/electron/fs.cljs
@@ -74,7 +74,7 @@
 
 (rf/reg-event-fx
   :fs/read-and-watch
-  [(interceptors/sentry-span "fs/read-and-watch")]
+  [(interceptors/sentry-span-no-new-tx "fs/read-and-watch")]
   (fn [_ [_ {:keys [db-path]}]]
     (let [datoms (-> (.readFileSync (utils/fs) db-path)
                      dt/read-transit-str)]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -70,21 +70,21 @@
 
 (reg-event-db
   :init-rfdb
-  [(interceptors/sentry-span "init-rfdb")]
+  [(interceptors/sentry-span-no-new-tx "init-rfdb")]
   (fn [_ _]
     db/rfdb))
 
 
 (reg-event-db
   :db/sync
-  [(interceptors/sentry-span "db/sync")]
+  [(interceptors/sentry-span-no-new-tx "db/sync")]
   (fn [db [_]]
     (assoc db :db/synced true)))
 
 
 (reg-event-db
   :db/not-synced
-  [(interceptors/sentry-span "db/not-synced")]
+  [(interceptors/sentry-span-no-new-tx "db/not-synced")]
   (fn [db [_]]
     (assoc db :db/synced false)))
 
@@ -200,7 +200,7 @@
 
 (reg-event-fx
   :upload/roam-edn
-  [(interceptors/sentry-span "upload/roam-edn")]
+  [(interceptors/sentry-span-no-new-tx "upload/roam-edn")]
   (fn [_ [_ transformed-dates-roam-db roam-db-filename]]
     (let [shared-pages   (get-shared-pages transformed-dates-roam-db)
           merge-shared   (mapv (fn [x] (merge-shared-page [:node/title x] transformed-dates-roam-db roam-db-filename))
@@ -215,14 +215,14 @@
 
 (reg-event-db
   :athena/toggle
-  [(interceptors/sentry-span "athena/toggle")]
+  [(interceptors/sentry-span-no-new-tx "athena/toggle")]
   (fn [db _]
     (update db :athena/open not)))
 
 
 (reg-event-db
   :athena/update-recent-items
-  [(interceptors/sentry-span "athena/undate-recent-items")]
+  [(interceptors/sentry-span-no-new-tx "athena/undate-recent-items")]
   (fn-traced [db [_ selected-page]]
              (when (nil? ((set (:athena/recent-items db)) selected-page))
                (update db :athena/recent-items conj selected-page))))
@@ -230,28 +230,28 @@
 
 (reg-event-db
   :devtool/toggle
-  [(interceptors/sentry-span "devtool/toggle")]
+  [(interceptors/sentry-span-no-new-tx "devtool/toggle")]
   (fn [db _]
     (update db :devtool/open not)))
 
 
 (reg-event-db
   :help/toggle
-  [(interceptors/sentry-span "help/toggle")]
+  [(interceptors/sentry-span-no-new-tx "help/toggle")]
   (fn [db _]
     (update db :help/open? not)))
 
 
 (reg-event-db
   :left-sidebar/toggle
-  [(interceptors/sentry-span "left-sidebar/toggle")]
+  [(interceptors/sentry-span-no-new-tx "left-sidebar/toggle")]
   (fn [db _]
     (update db :left-sidebar/open not)))
 
 
 (reg-event-fx
   :right-sidebar/toggle
-  [(interceptors/sentry-span "right-sidebar/toggle")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/toggle")]
   (fn [{:keys [db]} _]
     (let [closing? (:right-sidebar/open db)]
       {:db       (update db :right-sidebar/open not)
@@ -260,7 +260,7 @@
 
 (reg-event-fx
   :right-sidebar/toggle-item
-  [(interceptors/sentry-span "right-sidebar/toggle-item")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/toggle-item")]
   (fn [{:keys [db]} [_ item]]
     {:db       (update-in db [:right-sidebar/items item :open] not)
      :dispatch [:posthog/report-feature :right-sidebar true]}))
@@ -268,7 +268,7 @@
 
 (reg-event-db
   :right-sidebar/set-width
-  [(interceptors/sentry-span "right-sidebar/set-width")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/set-width")]
   (fn [db [_ width]]
     (assoc db :right-sidebar/width width)))
 
@@ -297,7 +297,7 @@
 ;; TODO: dec all indices > closed item
 (reg-event-fx
   :right-sidebar/close-item
-  [(interceptors/sentry-span "right-sidebar/close-item")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/close-item")]
   (fn [{:keys [db]} [_ uid]]
     (let [{:right-sidebar/keys
            [items]}  db
@@ -310,7 +310,7 @@
 
 (reg-event-fx
   :right-sidebar/navigate-item
-  [(interceptors/sentry-span "right-sidebar/navigate-item")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/navigate-item")]
   (fn [{:keys [db]} [_ uid breadcrumb-uid]]
     (let [block      (d/pull @db/dsdb '[:node/title :block/string] [:block/uid breadcrumb-uid])
           item-index (get-in db [:right-sidebar/items uid :index])
@@ -324,7 +324,7 @@
 ;; TODO: change right sidebar items from map to datascript
 (reg-event-fx
   :right-sidebar/open-item
-  [(interceptors/sentry-span "right-sidebar/open-item")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/open-item")]
   (fn [{:keys [db]} [_ uid is-graph?]]
     (let [block     (d/pull @db/dsdb '[:node/title :block/string] [:block/uid uid])
           new-item  (merge block {:open true :index -1 :is-graph? is-graph?})
@@ -349,7 +349,7 @@
 
 (reg-event-fx
   :right-sidebar/open-page
-  [(interceptors/sentry-span "right-sidebar/open-page")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/open-page")]
   (fn [{:keys [db]} [_ page-title is-graph?]]
     (let [{:keys [:block/uid]
            :as   block} (d/pull @db/dsdb '[:block/uid :node/title :block/string] [:node/title page-title])
@@ -375,14 +375,14 @@
 
 (reg-event-fx
   :right-sidebar/scroll-top
-  [(interceptors/sentry-span "right-sidebar/scroll-top")]
+  [(interceptors/sentry-span-no-new-tx "right-sidebar/scroll-top")]
   (fn []
     {:right-sidebar/scroll-top nil}))
 
 
 (reg-event-fx
   :editing/uid
-  [(interceptors/sentry-span "editing/uid")]
+  [(interceptors/sentry-span-no-new-tx "editing/uid")]
   (fn [{:keys [db]} [_ uid index]]
     (let [remote? (db-picker/remote-db? db)]
       {:db            (assoc db :editing/uid uid)
@@ -393,7 +393,7 @@
 
 (reg-event-fx
   :editing/target
-  [(interceptors/sentry-span "editing/target")]
+  [(interceptors/sentry-span-no-new-tx "editing/target")]
   (fn [_ [_ target]]
     (let [uid (-> (.. target -id)
                   (string/split "editable-uid-")
@@ -403,7 +403,7 @@
 
 (reg-event-fx
   :editing/first-child
-  [(interceptors/sentry-span "editing/first-child")]
+  [(interceptors/sentry-span-no-new-tx "editing/first-child")]
   (fn [_ [_ uid]]
     (when-let [first-block-uid (db/get-first-child-uid uid @db/dsdb)]
       {:dispatch [:editing/uid first-block-uid]})))
@@ -449,7 +449,7 @@
 
 (reg-event-db
   :selected/up
-  [(interceptors/sentry-span "selected/up")]
+  [(interceptors/sentry-span-no-new-tx "selected/up")]
   (fn [db [_ selected-items]]
     (assoc-in db [:selection :items] (select-up selected-items))))
 
@@ -458,7 +458,7 @@
 ;; this would let us know if the operation is additive or subtractive
 (reg-event-db
   :selected/down
-  [(interceptors/sentry-span "selected/down")]
+  [(interceptors/sentry-span-no-new-tx "selected/down")]
   (fn [db [_ selected-items]]
     (let [last-item         (last selected-items)
           next-block-uid    (db/next-block-uid last-item true)
@@ -610,7 +610,7 @@
 
 (reg-event-fx
   :http-success/get-db
-  [(interceptors/sentry-span "http-success/get-db")]
+  [(interceptors/sentry-span-no-new-tx "http-success/get-db")]
   (fn [_ [_ json-str]]
     (let [datoms (db/str-to-db-tx json-str)
           new-db (d/db-with common-db/empty-db datoms)]
@@ -619,7 +619,7 @@
 
 (reg-event-fx
   :theme/set
-  [(interceptors/sentry-span "theme/set")]
+  [(interceptors/sentry-span-no-new-tx "theme/set")]
   (fn [{:keys [db]} _]
     (util/switch-body-classes (if (-> db :athens/persist :theme/dark)
                                 ["is-theme-light" "is-theme-dark"]
@@ -629,7 +629,7 @@
 
 (reg-event-fx
   :theme/toggle
-  [(interceptors/sentry-span "theme/toggle")]
+  [(interceptors/sentry-span-no-new-tx "theme/toggle")]
   (fn [{:keys [db]} _]
     {:db       (update-in db [:athens/persist :theme/dark] not)
      :dispatch [:theme/set]}))
@@ -680,7 +680,7 @@
 
 (reg-event-fx
   :reset-conn
-  [(interceptors/sentry-span "reset-conn")]
+  [(interceptors/sentry-span-no-new-tx "reset-conn")]
   (fn-traced [_ [_ db skip-health-check?]]
              {:reset-conn! [db skip-health-check?]}))
 
@@ -730,7 +730,7 @@
 
 (reg-event-fx
   :electron-sync
-  [(interceptors/sentry-span "electron-sync")]
+  [(interceptors/sentry-span-no-new-tx "electron-sync")]
   (fn [_ _]
     (let [synced?   @(subscribe [:db/synced])
           electron? electron.utils/electron?]
@@ -811,7 +811,7 @@
 
 (reg-event-fx
   :left-sidebar/add-shortcut
-  [(interceptors/sentry-span "left-sidebar/add-shortcut")]
+  [(interceptors/sentry-span-no-new-tx "left-sidebar/add-shortcut")]
   (fn [_ [_ name]]
     (log/debug ":page/add-shortcut:" name)
     (let [add-shortcut-op (atomic-graph-ops/make-shortcut-new-op name)
@@ -821,7 +821,7 @@
 
 (reg-event-fx
   :left-sidebar/remove-shortcut
-  [(interceptors/sentry-span "left-sidebar/remove-shortcut")]
+  [(interceptors/sentry-span-no-new-tx "left-sidebar/remove-shortcut")]
   (fn [_ [_ name]]
     (log/debug ":page/remove-shortcut:" name)
     (let [remove-shortcut-op (atomic-graph-ops/make-shortcut-remove-op name)
@@ -831,7 +831,7 @@
 
 (reg-event-fx
   :left-sidebar/drop
-  [(interceptors/sentry-span "left-sidebar/drop")]
+  [(interceptors/sentry-span-no-new-tx "left-sidebar/drop")]
   (fn [_ [_ source-order target-order relation]]
     (let [[source-name target-name] (common-db/find-source-target-title @db/dsdb source-order target-order)
           drop-op                   (atomic-graph-ops/make-shortcut-move-op source-name
@@ -843,14 +843,14 @@
 
 (reg-event-fx
   :save
-  [(interceptors/sentry-span "save")]
+  [(interceptors/sentry-span-no-new-tx "save")]
   (fn [_ _]
     {:fs/write! nil}))
 
 
 (reg-event-fx
   :undo
-  [(interceptors/sentry-span "undo")]
+  [(interceptors/sentry-span-no-new-tx "undo")]
   (fn [{:keys [db]} _]
     (log/debug ":undo")
     (try
@@ -872,7 +872,7 @@
 
 (reg-event-fx
   :redo
-  [(interceptors/sentry-span "redo")]
+  [(interceptors/sentry-span-no-new-tx "redo")]
   (fn [{:keys [db]} _]
     (log/debug ":redo")
     (try
@@ -894,14 +894,14 @@
 
 (reg-event-fx
   :reset-undo-redo
-  [(interceptors/sentry-span "reset-undo-redo")]
+  [(interceptors/sentry-span-no-new-tx "reset-undo-redo")]
   (fn [{:keys [db]} _]
     {:db (undo/reset db)}))
 
 
 (reg-event-fx
   :up
-  [(interceptors/sentry-span "up")]
+  [(interceptors/sentry-span-no-new-tx "up")]
   (fn [_ [_ uid target-pos]]
     (let [prev-block-uid (db/prev-block-uid uid)]
       {:dispatch [:editing/uid (or prev-block-uid uid) target-pos]})))
@@ -909,7 +909,7 @@
 
 (reg-event-fx
   :down
-  [(interceptors/sentry-span "down")]
+  [(interceptors/sentry-span-no-new-tx "down")]
   (fn [_ [_ uid target-pos]]
     (let [next-block-uid (db/next-block-uid uid)]
       {:dispatch [:editing/uid (or next-block-uid uid) target-pos]})))
@@ -976,7 +976,7 @@
 ;; which might not be same as blur is not yet called
 (reg-event-fx
   :backspace
-  [(interceptors/sentry-span "backspace")]
+  [(interceptors/sentry-span-no-new-tx "backspace")]
   (fn [_ [_ uid value maybe-local-updates]]
     (backspace uid value maybe-local-updates)))
 
@@ -1312,7 +1312,7 @@
 
 (reg-event-fx
   :enter
-  [(interceptors/sentry-span "enter")]
+  [(interceptors/sentry-span-no-new-tx "enter")]
   (fn [{rfdb :db} [_ uid d-event]]
     (enter rfdb uid d-event)))
 
@@ -1528,7 +1528,7 @@
 
 (reg-event-fx
   :paste-internal
-  [(interceptors/sentry-span "paste-internal")]
+  [(interceptors/sentry-span-no-new-tx "paste-internal")]
   (fn [_ [_ uid local-str internal-representation]]
     (let [[uid]  (db/uid-and-embed-id uid)
           op     (bfs/build-paste-op @db/dsdb
@@ -1542,7 +1542,7 @@
 
 (reg-event-fx
   :paste-image
-  [(interceptors/sentry-span "paste-image")]
+  [(interceptors/sentry-span-no-new-tx "paste-image")]
   (fn [{:keys [db]} [_ items head tail callback]]
     (let [local?     (not (db-picker/remote-db? db))
           img-regex  #"(?i)^image/(p?jpeg|gif|png)$"]
@@ -1563,7 +1563,7 @@
 
 (reg-event-fx
   :paste-verbatim
-  [(interceptors/sentry-span "paste-verbatim")]
+  [(interceptors/sentry-span-no-new-tx "paste-verbatim")]
   (fn [_ [_ uid text]]
     ;; NOTE: use of `value` is questionable, it's the DOM so it's what users sees,
     ;; but what users sees should taken from DB. How would `value` behave with multiple editors?

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -11,7 +11,7 @@
     [athens.common-events.resolver.undo   :as undo-resolver]
     [athens.common-events.schema          :as schema]
     [athens.common.logging                :as log]
-    [athens.common.sentry                 :refer-macros [wrap-span wrap-span-no-new-tx]]
+    [athens.common.sentry                 :refer-macros [wrap-span-no-new-tx]]
     [athens.common.utils                  :as common.utils]
     [athens.dates                         :as dates]
     [athens.db                            :as db]
@@ -1030,7 +1030,7 @@
     (log/debug ":backspace/delete-only-child:" (pr-str uid))
     (let [sentry-tx   (close-and-get-sentry-tx "backspace/delete-only-child")
           op          (wrap-span-no-new-tx "build-block-remove-op"
-                                 (graph-ops/build-block-remove-op @db/dsdb uid))
+                                           (graph-ops/build-block-remove-op @db/dsdb uid))
           event       (common-events/build-atomic-event op)]
       {:fx [(transact-async-flow :backspace-delete-only-child event sentry-tx [[:editing/uid nil]])]})))
 
@@ -1114,10 +1114,10 @@
     (log/debug ":backspace/delete-merge-block args:" (pr-str args))
     (let [sentry-tx   (close-and-get-sentry-tx "backspace/delete-merge-block")
           op          (wrap-span-no-new-tx "build-block-remove-merge-op"
-                                 (graph-ops/build-block-remove-merge-op @db/dsdb
-                                                                        uid
-                                                                        prev-block-uid
-                                                                        value))
+                                           (graph-ops/build-block-remove-merge-op @db/dsdb
+                                                                                  uid
+                                                                                  prev-block-uid
+                                                                                  value))
           event       (common-events/build-atomic-event  op)]
       {:fx [(transact-async-flow :backspace-delete-merge-block event sentry-tx
                                  [(focus-on-uid prev-block-uid embed-id
@@ -1130,11 +1130,11 @@
     (log/debug ":backspace/delete-merge-block-with-save args:" (pr-str args))
     (let [sentry-tx   (close-and-get-sentry-tx "backspace/delete-merge-block-with-save")
           op          (wrap-span-no-new-tx "build-block-merge-with-updated-op"
-                                 (graph-ops/build-block-merge-with-updated-op @db/dsdb
-                                                                              uid
-                                                                              prev-block-uid
-                                                                              value
-                                                                              local-update))
+                                           (graph-ops/build-block-merge-with-updated-op @db/dsdb
+                                                                                        uid
+                                                                                        prev-block-uid
+                                                                                        value
+                                                                                        local-update))
           event       (common-events/build-atomic-event  op)]
       {:fx [(transact-async-flow :backspace-delete-merge-block-with-save event sentry-tx
                                  [(focus-on-uid prev-block-uid embed-id (count local-update))])]})))
@@ -1149,8 +1149,8 @@
     (log/debug ":enter/add-child args:" (pr-str args))
     (let [sentry-tx   (close-and-get-sentry-tx "enter/add-child")
           position    (wrap-span-no-new-tx "compat-position"
-                                 (common-db/compat-position @db/dsdb {:block/uid (:block/uid block)
-                                                                      :relation  :first}))
+                                           (common-db/compat-position @db/dsdb {:block/uid (:block/uid block)
+                                                                                :relation  :first}))
           event       (common-events/build-atomic-event (atomic-graph-ops/make-block-new-op new-uid position))]
       {:fx [(transact-async-flow :enter-add-child event sentry-tx [(focus-on-uid new-uid embed-id)])]})))
 
@@ -1161,12 +1161,12 @@
     (log/debug ":enter/split-block" (pr-str args))
     (let [sentry-tx   (close-and-get-sentry-tx "enter/split-block")
           op          (wrap-span-no-new-tx "build-block-split-op"
-                                 (graph-ops/build-block-split-op @db/dsdb
-                                                                 {:old-block-uid uid
-                                                                  :new-block-uid new-uid
-                                                                  :string        value
-                                                                  :index         index
-                                                                  :relation      relation}))
+                                           (graph-ops/build-block-split-op @db/dsdb
+                                                                           {:old-block-uid uid
+                                                                            :new-block-uid new-uid
+                                                                            :string        value
+                                                                            :index         index
+                                                                            :relation      relation}))
           event       (common-events/build-atomic-event op)]
       {:fx [(transact-async-flow :enter-split-block event sentry-tx [(focus-on-uid new-uid embed-id)])]})))
 
@@ -1177,8 +1177,8 @@
     (log/debug ":enter/bump-up args" (pr-str args))
     (let [sentry-tx   (close-and-get-sentry-tx "enter/bump-up")
           position    (wrap-span-no-new-tx "compat-position"
-                                 (common-db/compat-position @db/dsdb {:block/uid uid
-                                                                      :relation  :before}))
+                                           (common-db/compat-position @db/dsdb {:block/uid uid
+                                                                                :relation  :before}))
           event       (common-events/build-atomic-event (atomic-graph-ops/make-block-new-op new-uid position))]
       {:fx [(transact-async-flow :enter-bump-up event sentry-tx [(focus-on-uid new-uid embed-id)])]})))
 
@@ -1194,8 +1194,8 @@
           block-open-op           (atomic-graph-ops/make-block-open-op block-uid
                                                                        true)
           position                (wrap-span-no-new-tx "compat-position"
-                                             (common-db/compat-position @db/dsdb {:block/uid (:block/uid block)
-                                                                                  :relation  :first}))
+                                                       (common-db/compat-position @db/dsdb {:block/uid (:block/uid block)
+                                                                                            :relation  :first}))
           add-child-op            (atomic-graph-ops/make-block-new-op new-uid position)
           open-block-add-child-op (composite-ops/make-consequence-op {:op/type :open-block-add-child}
                                                                      [block-open-op
@@ -1351,13 +1351,13 @@
     ;;                 transaction that updates the string).
     (let [sentry-tx                     (close-and-get-sentry-tx "indent")
           block                         (wrap-span-no-new-tx "get-block"
-                                                   (common-db/get-block @db/dsdb [:block/uid uid]))
+                                                             (common-db/get-block @db/dsdb [:block/uid uid]))
           block-zero?                   (zero? (:block/order block))
           [prev-block-uid
            target-rel]                  (wrap-span-no-new-tx "get-prev-block-uid-and-target-rel"
-                                                   (get-prev-block-uid-and-target-rel uid))
+                                                             (get-prev-block-uid-and-target-rel uid))
           sib-block                     (wrap-span-no-new-tx "get-block-sib-block"
-                                                   (common-db/get-block @db/dsdb [:block/uid prev-block-uid]))
+                                                             (common-db/get-block @db/dsdb [:block/uid prev-block-uid]))
           ;; if sibling block is closed with children, open
           {sib-open     :block/open
            sib-children :block/children
@@ -1394,11 +1394,11 @@
           dsdb                     @db/dsdb
           [prev-block-uid
            target-rel]             (wrap-span-no-new-tx "get-prev-block-uid-and-target-rel"
-                                              (get-prev-block-uid-and-target-rel f-uid))
+                                                        (get-prev-block-uid-and-target-rel f-uid))
           same-parent?             (wrap-span-no-new-tx "same-parent"
-                                              (common-db/same-parent? dsdb sanitized-selected-uids))
+                                                        (common-db/same-parent? dsdb sanitized-selected-uids))
           first-block-order        (:block/order (wrap-span-no-new-tx "get-block"
-                                                            (common-db/get-block dsdb [:block/uid f-uid])))
+                                                                      (common-db/get-block dsdb [:block/uid f-uid])))
           block-zero?              (zero? first-block-order)]
       (log/debug ":indent/multi same-parent?" same-parent?
                  ", not block-zero?" (not  block-zero?))
@@ -1417,8 +1417,8 @@
     (log/debug ":unindent args" (pr-str args))
     (let [sentry-tx                 (close-and-get-sentry-tx "unindent")
           parent                    (wrap-span-no-new-tx "parent"
-                                               (common-db/get-parent @db/dsdb
-                                                                     (common-db/e-by-av @db/dsdb :block/uid uid)))
+                                                         (common-db/get-parent @db/dsdb
+                                                                               (common-db/e-by-av @db/dsdb :block/uid uid)))
           is-parent-root-embed?     (= (some-> d-key-down
                                                :target
                                                (.. (closest ".block-embed"))
@@ -1447,15 +1447,15 @@
     (log/debug ":unindent/multi" uids)
     (let [sentry-tx                   (close-and-get-sentry-tx "unindent/multi")
           [f-uid f-embed-id]          (wrap-span-no-new-tx "uid-and-embed-id"
-                                                 (common-db/uid-and-embed-id (first uids)))
+                                                           (common-db/uid-and-embed-id (first uids)))
           sanitized-selected-uids     (mapv (comp
                                               first
                                               common-db/uid-and-embed-id) uids)
           {parent-title :node/title
            parent-uid   :block/uid}   (wrap-span-no-new-tx "get-parent"
-                                                 (common-db/get-parent @db/dsdb [:block/uid f-uid]))
+                                                           (common-db/get-parent @db/dsdb [:block/uid f-uid]))
           same-parent?                (wrap-span-no-new-tx "same-parent"
-                                                 (common-db/same-parent? @db/dsdb sanitized-selected-uids))
+                                                           (common-db/same-parent? @db/dsdb sanitized-selected-uids))
           is-parent-root-embed?       (when same-parent?
                                         (some-> "#editable-uid-"
                                                 (str f-uid "-embed-" f-embed-id)

--- a/src/cljs/athens/events/remote.cljs
+++ b/src/cljs/athens/events/remote.cljs
@@ -222,7 +222,7 @@
 
 (rf/reg-event-db
   :remote/start-event-sync
-  [(interceptors/sentry-span ":remote/start-event-sync")]
+  [(interceptors/sentry-span-no-new-tx ":remote/start-event-sync")]
   (fn [db _]
     (assoc db
            :remote/event-sync (event-sync/create-state :athens [:memory :server])
@@ -231,21 +231,21 @@
 
 (rf/reg-event-db
   :remote/stop-event-sync
-  [(interceptors/sentry-span ":remote/stop-event-sync")]
+  [(interceptors/sentry-span-no-new-tx ":remote/stop-event-sync")]
   (fn [db _]
     (dissoc db :remote/event-sync :remote/rollback-tx-data)))
 
 
 (rf/reg-event-fx
   :remote/clear-server-event
-  [(interceptors/sentry-span ":remote/clear-server-event")]
+  [(interceptors/sentry-span-no-new-tx ":remote/clear-server-event")]
   (fn [{db :db} [_ event]]
     {:db (update db :remote/event-sync #(event-sync/remove % :server (:event/id event) event))}))
 
 
 (rf/reg-event-fx
   :remote/reject-forwarded-event
-  [(interceptors/sentry-span ":remote/apply-forwarded-event")]
+  [(interceptors/sentry-span ":remote/reject-forwarded-event")]
   (fn [{db :db} [_ event]]
     (log/debug ":remote/reject-forwarded-event event:" (pr-str event))
     (let [[db']      (-> [db db/dsdb]

--- a/src/cljs/athens/interceptors.cljs
+++ b/src/cljs/athens/interceptors.cljs
@@ -48,4 +48,30 @@
                   auto-tx (dissoc :sentry-auto-tx))))))
 
 
+(defn sentry-span-no-new-tx
+  "Wraps Event Handler into Sentry Span for measurement."
+  [span-name]
+  (rf/->interceptor
+    :id     :sentry-span
+    :before (fn [context]
+              (let [tx-running?   (sentry/tx-running?)
+                    auto-tx       (if tx-running?
+                                    (sentry/transaction-get-current))
+                    existing-span (sentry/span-active)
+                    sentry-span   (sentry/span-start (or existing-span
+                                                         auto-tx)
+                                                     span-name)]
+                (cond-> (assoc context :sentry-span sentry-span)
+                        (not tx-running?) (assoc :sentry-auto-tx auto-tx))))
+    :after  (fn [context]
+              (let [sentry-span (:sentry-span context)
+                    auto-tx     (:sentry-auto-tx context)]
+                (when sentry-span
+                  (sentry/span-finish sentry-span))
+                (when auto-tx
+                  (sentry/transaction-finish auto-tx))
+                (cond-> (dissoc context :sentry-span)
+                        auto-tx (dissoc :sentry-auto-tx))))))
+
+
 (rf/reg-global-interceptor persist-db)

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -2,7 +2,7 @@
   (:require
     [athens.common-db            :as common-db]
     [athens.common.logging       :as log]
-    [athens.common.sentry        :refer-macros [wrap-span]]
+    [athens.common.sentry        :refer-macros [wrap-span wrap-span-no-new-tx]]
     [athens.dates                :as dates]
     [athens.db                   :as db]
     [athens.electron.db-picker   :as db-picker]
@@ -138,7 +138,7 @@
 (rf/reg-fx
   :navigate!
   (fn-traced [route]
-             (wrap-span "push-state"
+             (wrap-span-no-new-tx "push-state"
                         (apply rfee/push-state route))))
 
 

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -44,7 +44,7 @@
 ;; events
 (rf/reg-event-fx
   :navigate
-  [(interceptors/sentry-span "navigate")]
+  [(interceptors/sentry-span-no-new-tx "navigate")]
   (fn [{:keys [db]} [_ & route]]
     (log/debug ":navigate route:" (pr-str route))
     (let [db-id       (-> db db-picker/selected-db :id)
@@ -123,7 +123,7 @@
 ;; doesn't reliably work. notably, Daily Notes are often not remembered as last open page, leading to incorrect restore
 (reg-event-fx
   :restore-navigation
-  [(interceptors/sentry-span "restore-navigation")]
+  [(interceptors/sentry-span-no-new-tx "restore-navigation")]
   (fn [{:keys [db]} _]
     (let [prev-title (-> db db-picker/selected-db :current-route/title)
           prev-uid   (-> db db-picker/selected-db :current-route/uid)]

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -2,7 +2,7 @@
   (:require
     [athens.common-db            :as common-db]
     [athens.common.logging       :as log]
-    [athens.common.sentry        :refer-macros [wrap-span wrap-span-no-new-tx]]
+    [athens.common.sentry        :refer-macros [wrap-span-no-new-tx]]
     [athens.dates                :as dates]
     [athens.db                   :as db]
     [athens.electron.db-picker   :as db-picker]
@@ -139,7 +139,7 @@
   :navigate!
   (fn-traced [route]
              (wrap-span-no-new-tx "push-state"
-                        (apply rfee/push-state route))))
+                                  (apply rfee/push-state route))))
 
 
 ;; router definition

--- a/src/cljs/athens/views/hoc/perf_mon.cljs
+++ b/src/cljs/athens/views/hoc/perf_mon.cljs
@@ -30,7 +30,7 @@
   "Higher Order Component for Performance Monitoring with Sentry which does not create new tx if it does not exist"
   [{:keys [span-name]} _component]
   (let [tx-present? (sentry/tx-running?)
-        sentry-tx   (if tx-present?
+        sentry-tx   (when tx-present?
                       (sentry/transaction-get-current))
         sentry-span (sentry/span-start sentry-tx span-name false)
         did-mount   (fn [_this]

--- a/src/cljs/athens/views/hoc/perf_mon.cljs
+++ b/src/cljs/athens/views/hoc/perf_mon.cljs
@@ -24,3 +24,22 @@
        :reagent-render      (fn [{:keys [_span-name]} component]
                               [:<> component])
        :component-did-mount did-mount})))
+
+
+(defn hoc-perfmon-no-new-tx
+  "Higher Order Component for Performance Monitoring with Sentry which does not create new tx if it does not exist"
+  [{:keys [span-name]} _component]
+  (let [tx-present? (sentry/tx-running?)
+        sentry-tx   (if tx-present?
+                      (sentry/transaction-get-current))
+        sentry-span (sentry/span-start sentry-tx span-name false)
+        did-mount   (fn [_this]
+                      (when sentry-span
+                        (sentry/span-finish sentry-span false)))]
+    (when sentry-span
+      (log/debug "hoc-perfmon-no-new-tx:" span-name "setup-finished")
+      (r/create-class
+        {:display-name        "hoc-perfmon-no-new-tx"
+         :reagent-render      (fn [{:keys [_span-name]} component]
+                                [:<> component])
+         :component-did-mount did-mount}))))

--- a/src/cljs/athens/views/pages/core.cljs
+++ b/src/cljs/athens/views/pages/core.cljs
@@ -43,9 +43,9 @@
                              {:on-scroll (when (= @route-name :home)
                                            #(rf/dispatch [:daily-note/scroll]))})
      (case @route-name
-       :settings      [perf-mon/hoc-perfmon {:span-name "pages/settings"}
+       :settings      [perf-mon/hoc-perfmon-no-new-tx {:span-name "pages/settings"}
                        [settings/page]]
-       :pages         [perf-mon/hoc-perfmon {:span-name "pages/all-pages"}
+       :pages         [perf-mon/hoc-perfmon-no-new-tx {:span-name "pages/all-pages"}
                        [all-pages/page]]
        :page          [perf-mon/hoc-perfmon {:span-name "pages/page"}
                        [page/page]]
@@ -53,7 +53,7 @@
                        [page/page-by-title]]
        :home          [perf-mon/hoc-perfmon {:span-name "pages/home-page"}
                        [daily-notes/page]]
-       :graph         [perf-mon/hoc-perfmon {:span-name "pages/graph"}
+       :graph         [perf-mon/hoc-perfmon-no-new-tx {:span-name "pages/graph"}
                        [graph/page]]
-       [perf-mon/hoc-perfmon {:span-name "pages/default"}
+       [perf-mon/hoc-perfmon-no-new-tx {:span-name "pages/default"}
         [daily-notes/page]])]))

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -13,7 +13,7 @@
     ["@material-ui/icons/Link" :default Link]
     ["@material-ui/icons/MoreHoriz" :default MoreHoriz]
     [athens.common-db :as common-db]
-    [athens.common.sentry :refer-macros [wrap-span]]
+    [athens.common.sentry :refer-macros [wrap-span wrap-span-no-new-tx]]
     [athens.common.utils :as utils]
     [athens.dates :as dates]
     [athens.db :as db :refer [get-unlinked-references]]
@@ -410,7 +410,7 @@
 (defn linked-ref-el
   [state daily-notes? title]
   (let [linked? "Linked References"
-        linked-refs (wrap-span "get-reactive-linked-references"
+        linked-refs (wrap-span-no-new-tx "get-reactive-linked-references"
                                (reactive/get-reactive-linked-references [:node/title title]))]
     (when (or (and daily-notes? (not-empty linked-refs))
               (not daily-notes?))
@@ -595,6 +595,6 @@
 
 (defn page
   [ident]
-  (let [node (wrap-span "db/get-reactive-node-document"
+  (let [node (wrap-span-no-new-tx "db/get-reactive-node-document"
                         (reactive/get-reactive-node-document ident))]
     [node-page-el node]))

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -587,9 +587,9 @@
                [blocks/block-el child]])])
 
          ;; References
-         [perf-mon/hoc-perfmon {:span-name "linked-ref-el"}
+         [perf-mon/hoc-perfmon-no-new-tx {:span-name "linked-ref-el"}
           [linked-ref-el state on-daily-notes? title]]
-         [perf-mon/hoc-perfmon {:span-name "unlinked-ref-el"}
+         [perf-mon/hoc-perfmon-no-new-tx {:span-name "unlinked-ref-el"}
           [unlinked-ref-el state on-daily-notes? unlinked-refs title]]]))))
 
 

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -13,7 +13,7 @@
     ["@material-ui/icons/Link" :default Link]
     ["@material-ui/icons/MoreHoriz" :default MoreHoriz]
     [athens.common-db :as common-db]
-    [athens.common.sentry :refer-macros [wrap-span wrap-span-no-new-tx]]
+    [athens.common.sentry :refer-macros [wrap-span-no-new-tx]]
     [athens.common.utils :as utils]
     [athens.dates :as dates]
     [athens.db :as db :refer [get-unlinked-references]]
@@ -411,7 +411,7 @@
   [state daily-notes? title]
   (let [linked? "Linked References"
         linked-refs (wrap-span-no-new-tx "get-reactive-linked-references"
-                               (reactive/get-reactive-linked-references [:node/title title]))]
+                                         (reactive/get-reactive-linked-references [:node/title title]))]
     (when (or (and daily-notes? (not-empty linked-refs))
               (not daily-notes?))
       [:section (use-style references-style)
@@ -596,5 +596,5 @@
 (defn page
   [ident]
   (let [node (wrap-span-no-new-tx "db/get-reactive-node-document"
-                        (reactive/get-reactive-node-document ident))]
+                                  (reactive/get-reactive-node-document ident))]
     [node-page-el node]))


### PR DESCRIPTION
Please review new functions to see if this is what we need out of them:
- `wrap-span-no-new-tx`
- `sentry-span-no-new-tx`
- `hoc-perfmon-no-new-tx`