### PR TITLE
fix: Allow to start with empty line

### DIFF
--- a/src/cljc/athens/parser/impl.cljc
+++ b/src/cljc/athens/parser/impl.cljc
@@ -24,7 +24,8 @@ block = (thematic-break /
          indented-code-block /
          fenced-code-block /
          block-quote /
-         paragraph-text)*
+         paragraph-text /
+         newline)*
 thematic-break = #'[_-]{3}'
 heading = #'[#]+' <space> #'.+' <newline>*
 indented-code-block = (<'    '> code-text)+

--- a/test/athens/parser/compatibility_test.cljc
+++ b/test/athens/parser/compatibility_test.cljc
@@ -342,3 +342,15 @@
            (sut/staged-parser->ast "$$a b $ c$$")))))
 
 
+(t/deftest allow-starting-with-empty-line
+  (t/are [text-in ast] (= ast (sut/block-parser->ast text-in))
+    "\nText"
+    [:block
+     [:newline "\n"]
+     [:paragraph-text "Text"]]
+
+    "> \n> More"
+    [:block
+     [:block-quote
+      [:newline "\n"]
+      [:paragraph-text "More"]]]))


### PR DESCRIPTION
Used to be severely broken if block would have a block level
element with 1st line empty like following blockquote
```
>
> Text
```