### PR TITLE
fix: default config should use docker values

### DIFF
--- a/dev/clj/config.edn
+++ b/dev/clj/config.edn
@@ -1,3 +1,5 @@
 {;; :password   "SuchWow"
  ;; :in-memory? true
- :nrepl {:port 8877}}
+ :fluree     {:servers ["http://localhost:8090"]}
+ :datascript {:persist-base-path "./athens-data/datascript/persist/"}
+ :nrepl      {:port 8877}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     environment:
       # Uses system env vars for settings if available.
       # CONFIG_EDN is deep merged with the default config file.
-      - CONFIG_EDN=${CONFIG_EDN:-{:fluree {:servers ["http://fluree:8090"]} :datascript {:persist-base-path "/srv/athens/datascript/persist/"}}}
+      - CONFIG_EDN=${CONFIG_EDN:-{}}
     healthcheck:
       test: curl -f localhost:3010/health-check
       interval: 15s

--- a/src/clj/config.default.edn
+++ b/src/clj/config.default.edn
@@ -1,8 +1,7 @@
 {:http       {:port 3010}
- ;; Default fluree address and datascript path on dev setup.
- ;; The official Docker Compose file overwrites these values.
- :fluree     {:servers ["http://localhost:8090"]}
- :datascript {:persist-base-path "./athens-data/datascript/persist/"}
+ ;; Default fluree address and datascript path on docker compose setup.
+ :fluree     {:servers ["http://fluree:8090"]}
+ :datascript {:persist-base-path "/src/athens/datascript/persist/"}
  :in-memory? false
  ;; :password   "SuchWow"
  ;; :nrepl      {:port 8877}


### PR DESCRIPTION
Otherwise, adding things like a password via env var means the user has
to also include all docker specific config items.

This commit partially reverts
https://github.com/athensresearch/athens/commit/712759dabe37e4f5a6a61ebc1733e594021c65db.
Paths in the commit above were changed afterwards by https://github.com/athensresearch/athens/commit/f62f829f2cf9347446571ab3c9594443237d2ed3.
