### PR TITLE
improvement: ux polish to db menu

### DIFF
--- a/src/cljs/athens/electron/db_menu/core.cljs
+++ b/src/cljs/athens/electron/db_menu/core.cljs
@@ -1,6 +1,6 @@
 (ns athens.electron.db-menu.core
   (:require
-    ["@chakra-ui/react" :refer [Box IconButton Tooltip Heading VStack ButtonGroup PopoverTrigger ButtonGroup Popover PopoverContent Portal Button]]
+    ["@chakra-ui/react" :refer [Box IconButton Spinner Center Text Tooltip Heading VStack ButtonGroup PopoverTrigger ButtonGroup Popover PopoverContent Portal Button]]
     ["react-focus-lock" :default FocusLock]
     [athens.electron.db-menu.db-icon :refer [db-icon]]
     [athens.electron.db-menu.db-list-item :refer [db-list-item]]
@@ -70,14 +70,22 @@
                        :color "foreground.secondary"}
            "Other databases"]
           [:> VStack {:align "stretch"
+                      :position "relative"
                       :spacing 0
                       :overflow-y "auto"}
-           {:align "stretch" :spacing 0}
            (doall
-             (for [[key db] inactive-dbs]
-               [db-list-item {:db db
-                              :is-current false
-                              :key key}]))]
+            (for [[key db] inactive-dbs]
+              [db-list-item {:db db
+                             :is-disabled (= sync-status :synchronising)
+                             :is-current false
+                             :key key}]))
+           (when (= :synchronising sync-status)
+             [:> VStack {:align "center"
+                         :background "background.vibrancy"
+                         :backdropFilter "blur(0.25ch)"
+                         :justify "center" :position "absolute" :inset 0}
+              [:> Spinner]
+              [:> Text "Syncing..."]])]
           ;; Add DB control
           [:> ButtonGroup {:borderTop "1px solid" :borderTopColor "separator.divider" :p 2 :pt 0 :pl 10 :size "sm" :width "100%" :ml 10 :justifyContent "flex-start"}
            [:> Button {:onClick #(dispatch [:modal/toggle])}

--- a/src/cljs/athens/electron/db_menu/core.cljs
+++ b/src/cljs/athens/electron/db_menu/core.cljs
@@ -1,6 +1,6 @@
 (ns athens.electron.db-menu.core
   (:require
-    ["@chakra-ui/react" :refer [Box IconButton Spinner Center Text Tooltip Heading VStack ButtonGroup PopoverTrigger ButtonGroup Popover PopoverContent Portal Button]]
+    ["@chakra-ui/react" :refer [Box IconButton Spinner Text Tooltip Heading VStack ButtonGroup PopoverTrigger ButtonGroup Popover PopoverContent Portal Button]]
     ["react-focus-lock" :default FocusLock]
     [athens.electron.db-menu.db-icon :refer [db-icon]]
     [athens.electron.db-menu.db-list-item :refer [db-list-item]]
@@ -74,11 +74,11 @@
                       :spacing 0
                       :overflow-y "auto"}
            (doall
-            (for [[key db] inactive-dbs]
-              [db-list-item {:db db
-                             :is-disabled (= sync-status :synchronising)
-                             :is-current false
-                             :key key}]))
+             (for [[key db] inactive-dbs]
+               [db-list-item {:db db
+                              :is-disabled (= sync-status :synchronising)
+                              :is-current false
+                              :key key}]))
            (when (= :synchronising sync-status)
              [:> VStack {:align "center"
                          :background "background.vibrancy"

--- a/src/cljs/athens/electron/db_menu/db_icon.cljs
+++ b/src/cljs/athens/electron/db_menu/db_icon.cljs
@@ -34,4 +34,4 @@
       :x "50%"
       :y "75%"}
      (nth (:name db) 0)]]
-   (when status [status-indicator {:status status}])])
+   (when (and status (not= status :running)) [status-indicator {:status status}])])

--- a/src/cljs/athens/electron/db_menu/db_list_item.cljs
+++ b/src/cljs/athens/electron/db_menu/db_list_item.cljs
@@ -27,7 +27,7 @@
     [:> Text {:textOverflow "ellipsis"
               :overflow "hidden"
               :fontWeight "bold"}
-     (:name db) ]
+     (:name db)]
     [:> Text {:textOverflow "ellipsis"
               :fontSize "sm"
               :color "foreground.secondary"

--- a/src/cljs/athens/electron/db_menu/db_list_item.cljs
+++ b/src/cljs/athens/electron/db_menu/db_list_item.cljs
@@ -1,8 +1,7 @@
 (ns athens.electron.db-menu.db-list-item
   (:require
+    ["/components/Icons/Icons" :refer [XmarkIcon]]
     ["@chakra-ui/react" :refer [VStack Box Flex Text Button IconButton]]
-    ["@material-ui/icons/Clear" :default Clear]
-    ["@material-ui/icons/Link" :default Link]
     [athens.electron.db-menu.db-icon :refer [db-icon]]
     [athens.electron.dialogs :as dialogs]
     [re-frame.core :refer [dispatch]]))
@@ -28,29 +27,27 @@
     [:> Text {:textOverflow "ellipsis"
               :overflow "hidden"
               :fontWeight "bold"}
-     (:name db)]
+     (:name db) ]
     [:> Text {:textOverflow "ellipsis"
               :fontSize "sm"
               :color "foreground.secondary"
               :overflow "hidden"
               :title (:id db)}
-     (when (:is-remote db)
-       [:> Link])
      (:id db)]]])
 
 
 (defn db-item
-  [{:keys [db on-click on-remove]}]
+  [{:keys [db on-click on-remove is-disabled]}]
   [:> Box {:display "grid"
-           :borderTopWidth "1px"
-           :borderTopStyle "solid"
-           :borderTopColor "separator.divider"
+           :_notFirst {:borderTopWidth "1px"
+                       :borderTopStyle "solid"
+                       :borderTopColor "separator.divider"}
            :gridTemplateAreas "'main'"}
    [:> Button {:onClick (when on-click on-click)
+               :isDisabled (or is-disabled (not on-click))
                :gridArea "main"
                :whiteSpace "nowrap"
                :bg "transparent"
-               :isDisabled (not on-click)
                :display "flex"
                :gap 2
                :py 2
@@ -75,8 +72,6 @@
                :color "foreground.secondary"
                :overflow "hidden"
                :title (:id db)}
-      (when (:is-remote db)
-        [:> Link])
       (:id db)]]]
    (when on-remove
      [:> IconButton
@@ -87,17 +82,18 @@
        :size "sm"
        :mr 2
        :bg "transparent"}
-      [:> Clear]])])
+      [:> XmarkIcon]])])
 
 
 (defn db-list-item
-  [{:keys [db is-current]}]
+  [{:keys [db is-current is-disabled]}]
   (let [remove-db-click-handler (fn [e]
                                   (dialogs/delete-dialog! db)
                                   (.. e stopPropagation))]
     (if is-current
       [active-db {:db db}]
       [db-item {:db db
+                :is-disabled is-disabled
                 :on-click #(dispatch [:db-picker/select-db db])
                 :on-remove remove-db-click-handler}])))
 

--- a/src/cljs/athens/electron/db_menu/status_indicator.cljs
+++ b/src/cljs/athens/electron/db_menu/status_indicator.cljs
@@ -1,8 +1,8 @@
 (ns athens.electron.db-menu.status-indicator
   (:require
-   ["@chakra-ui/react" :refer [Box Tooltip Spinner]]
-   ["@material-ui/icons/CheckCircle" :default CheckCircle]
-   ["@material-ui/icons/Error" :default Error]))
+    ["@chakra-ui/react" :refer [Box Tooltip Spinner]]
+    ["@material-ui/icons/CheckCircle" :default CheckCircle]
+    ["@material-ui/icons/Error" :default Error]))
 
 
 (defn status-indicator
@@ -22,8 +22,8 @@
            :right 0
            :borderRadius "full"
            :sx {"svg" {:fontSize "1em"
-                         :background "background.floor"
-                         :borderRadius "full"}}}
+                       :background "background.floor"
+                       :borderRadius "full"}}}
    (cond
      (= status :closed) [:> Tooltip
                          {:label "Disconnected"}

--- a/src/cljs/athens/electron/db_menu/status_indicator.cljs
+++ b/src/cljs/athens/electron/db_menu/status_indicator.cljs
@@ -1,9 +1,8 @@
 (ns athens.electron.db-menu.status-indicator
   (:require
-    ["@chakra-ui/react" :refer [Box Tooltip]]
-    ["@material-ui/icons/CheckCircle" :default CheckCircle]
-    ["@material-ui/icons/Error" :default Error]
-    ["@material-ui/icons/Sync" :default Sync]))
+   ["@chakra-ui/react" :refer [Box Tooltip Spinner]]
+   ["@material-ui/icons/CheckCircle" :default CheckCircle]
+   ["@material-ui/icons/Error" :default Error]))
 
 
 (defn status-indicator
@@ -23,8 +22,8 @@
            :right 0
            :borderRadius "full"
            :sx {"svg" {:fontSize "1em"
-                       :background "background.floor"
-                       :borderRadius "full"}}}
+                         :background "background.floor"
+                         :borderRadius "full"}}}
    (cond
      (= status :closed) [:> Tooltip
                          {:label "Disconnected"}
@@ -34,4 +33,4 @@
                           [:> CheckCircle]]
      :else [:> Tooltip
             {:label "Synchronizing..."}
-            [:> Sync]])])
+            [:> Spinner {:emptyColor "background.vibrancy" :speed "2s" :size "xs"}]])])

--- a/src/cljs/athens/electron/dialogs.cljs
+++ b/src/cljs/athens/electron/dialogs.cljs
@@ -86,10 +86,10 @@
 (defn- delete-msg-prompt
   [{:keys [name base-dir url] :as db}]
   (let [remote-db? (utils/remote-db? db)
-        part-1 (str "Confirm removing \"" name "\" from the list?\n\n")
+        part-1 (str "Remove \"" name "\"?\n\n")
         part-2 (if remote-db?
-                 (str "The data will still remain at remote server " url ".")
-                 (str "The files will still remain locally on disk at \"" base-dir "\"."))]
+                 (str "The data will still be available at " url ".")
+                 (str "The files will still be available at \"" base-dir "\"."))]
     (str part-1 part-2)))
 
 

--- a/src/js/components/Confirmation/Confirmation.tsx
+++ b/src/js/components/Confirmation/Confirmation.tsx
@@ -1,35 +1,62 @@
-import { Modal, ModalOverlay, ModalContent, ModalBody, ModalHeader, ModalFooter, Button, ButtonGroup } from '@chakra-ui/react';
+import React from 'react';
+import { Portal, useDisclosure, AlertDialog, AlertDialogOverlay, AlertDialogContent, AlertDialogHeader, AlertDialogFooter, AlertDialogBody, Button, ButtonGroup } from "@chakra-ui/react"
 
 export const Confirmation = ({
+  db,
   isOpen,
-  onClose,
-  onConfirm,
   title,
-  description
+  message,
+  onConfirm,
+  cancelText,
+  confirmText,
+  onClose
 }) => {
-  return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      closeOnOverlayClick={false}
-      closeOnEsc={false}
-      size='sm'
-    >
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>{title}</ModalHeader>
-        {description && <ModalBody>{description}</ModalBody>}
-        <ModalFooter>
-          <ButtonGroup>
-            <Button mr={3} onClick={onConfirm}>
-              Confirm
-            </Button>
-            <Button onClick={onClose}>
-              Cancel
-            </Button>
-          </ButtonGroup>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  );
-};
+  const cancelRef = React.useRef();
+
+  const { isOpen: isConfirmOpen,
+    onClose: onConfirmClose } = useDisclosure({
+      defaultIsOpen: isOpen,
+      onClose: onClose
+    })
+
+  console.log(db, isOpen, title, message);
+  console.log('alerting!');
+
+  return (<AlertDialog
+    isOpen={isConfirmOpen}
+    leastDestructiveRef={cancelRef}
+    onClose={onConfirmClose}
+  >
+    <Portal>
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          {title &&
+            <AlertDialogHeader fontSize='lg' fontWeight='bold'>
+              {title}
+            </AlertDialogHeader>
+          }
+          {message && <AlertDialogBody>
+            {message}
+          </AlertDialogBody>}
+          <AlertDialogFooter>
+            <ButtonGroup>
+              <Button
+                ref={cancelRef}
+                onClick={onClose}>
+                {cancelText || 'Cancel'}
+              </Button>
+              <Button
+                colorScheme='red'
+                onClick={() => {
+                  onConfirm();
+                  onClose()
+                }}>
+                {confirmText || 'Confirm'}
+              </Button>
+            </ButtonGroup>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </Portal>
+  </AlertDialog>);
+}

--- a/src/js/components/Icons/Icons.tsx
+++ b/src/js/components/Icons/Icons.tsx
@@ -26,6 +26,14 @@ export const XmarkIcon = createIcon({
   ),
 })
 
+export const CheckmarkIcon = createIcon({
+  displayName: 'CheckmarkIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <path fillRule="evenodd" clipRule="evenodd" d="M18.2601 5.32733C18.6316 4.91867 19.264 4.88855 19.6727 5.26006C20.0813 5.63157 20.1114 6.26401 19.7399 6.67267L9.73994 17.6727C9.55042 17.8811 9.28174 18 9 18C8.71825 18 8.44958 17.8811 8.26006 17.6727L3.26006 12.1727C2.88855 11.764 2.91867 11.1316 3.32733 10.7601C3.73598 10.3886 4.36843 10.4187 4.73994 10.8273L9 15.5134L18.2601 5.32733Z" fill="currentColor" />
+  ),
+})
+
 export const DailyNotesIcon = createIcon({
   displayName: 'DailyNotesIcon',
   viewBox: '0 0 24 24',


### PR DESCRIPTION
- Disables the database buttons while Athens is still syncing
- Hides the "synced" status indicator from the DB icon in the toolbar. Spinner means it's working, nothing means it’s done. The 'synced' status indicator was more useful when syncing took longer and was perhaps more fragile.
- Minor style and language enhancements

- This PR blocks in a new 'Confirmation' component to replace the JS confirmation dialog, but is currently unused.