### PR TITLE
fix: allow remote dbs in web athens

### DIFF
--- a/src/cljs/athens/electron/db_modal.cljs
+++ b/src/cljs/athens/electron/db_modal.cljs
@@ -215,11 +215,10 @@
          [:> Tabs {:isFitted true
                    :display "contents"
                    :defaultIndex (if utils/electron? 0 2)}
-          (when utils/electron?
-            [:> TabList
-             [:> Tab "Open Local"]
-             [:> Tab "Join Remote"]
-             [:> Tab "Create New"]])
+          [:> TabList
+           [:> Tab "Open Local"]
+           [:> Tab "Join Remote"]
+           [:> Tab "Create New"]]
           [:> TabPanels {:display "contents"}
            [:> TabPanel {:display "contents"}
             [open-local-comp loading selected-db]]

--- a/src/cljs/athens/electron/db_modal.cljs
+++ b/src/cljs/athens/electron/db_modal.cljs
@@ -214,11 +214,12 @@
          ;; redesigned DB picker.
          [:> Tabs {:isFitted true
                    :display "contents"
-                   :defaultIndex (if utils/electron? 0 2)}
-          [:> TabList
-           [:> Tab "Open Local"]
-           [:> Tab "Join Remote"]
-           [:> Tab "Create New"]]
+                   :defaultIndex (if utils/electron? 0 1)}
+          (when utils/electron?
+            [:> TabList
+             [:> Tab "Open Local"]
+             [:> Tab "Join Remote"]
+             [:> Tab "Create New"]])
           [:> TabPanels {:display "contents"}
            [:> TabPanel {:display "contents"}
             [open-local-comp loading selected-db]]


### PR DESCRIPTION
- Show the remote db view in db modal when not electron