### PR TITLE
fix: mark/highlight colors are global

### DIFF
--- a/src/js/components/Block/Content.tsx
+++ b/src/js/components/Block/Content.tsx
@@ -127,11 +127,6 @@ const _Content = ({ children, fontSize, ...props }) => {
         paddingBottom: "1em",
         "&last:-child": { paddingBottom: 0 },
       },
-      "mark.contents.highlight": {
-        padding: "0 0.2em",
-        borderRadius: "0.125rem",
-        background: "highlight",
-      }
     }}
     {...props}
   > {children}</Box>

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -606,6 +606,12 @@ const styles = {
     },
     "#chakra-toast-manager-top-right, #chakra-toast-manager-top, #chakra-toast-manager-top-left": {
       margin: "3rem 1rem"
+    },
+    mark: {
+      background: "highlight",
+      color: "highlightContrast",
+      padding: '0 0.2em',
+      borderRadius: "sm",
     }
   }
 }


### PR DESCRIPTION
- all `mark` elements use the highlight style, not just ones in block content