### PR TITLE
Virtualize all pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "react-force-graph-2d": "^1.19.0",
     "react-highlight.js": "1.0.7",
     "react-intersection-observer": "^8.32.1",
+    "react-window": "^1.8.6",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -1,8 +1,6 @@
 (ns athens.views.pages.all-pages
   (:require
-    ["/components/Icons/Icons" :refer [ChevronUpIcon ChevronDownIcon]]
     ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
-    ["@chakra-ui/react" :refer [Table Thead Tr Th Tbody Td Button Box]]
     [athens.common-db          :as common-db]
     [athens.dates              :as dates]
     [athens.db                 :as db]
@@ -61,78 +59,25 @@
        :dispatch [:posthog/report-feature :all-pages]})))
 
 
-;; Components
-
-(defn- sortable-header
-  ([column-id label width is-numeric?]
-   (let [sorted-by @(rf/subscribe [:all-pages/sorted-by])
-         growing?  @(rf/subscribe [:all-pages/sort-order-ascending?])
-         sort-icon (if growing? (r/as-element [:> ChevronUpIcon])
-                       (r/as-element [:> ChevronDownIcon]))]
-     [:> Th {:width width
-             :border 0
-             :isNumeric is-numeric?}
-      [:> Button {:onClick #(rf/dispatch [:all-pages/sort-by column-id])
-                  :size "sm"
-                  :textTransform "uppercase"
-                  :justifyContent (if is-numeric? "flex-end" "flex-start")
-                  :display "flex"
-                  :height "1em"
-                  :overflow "hidden"
-                  :gap "0.25em"
-                  :variant "link"
-                  :leftIcon (when (and is-numeric?
-                                       (= column-id sorted-by))
-                              sort-icon)
-                  :rightIcon (when (and (not is-numeric?)
-                                        (= column-id sorted-by))
-                               sort-icon)
-                  :_hover {:textDecoration "none"}}
-       label]])))
-
 
 (defn page
   []
   (let [all-pages (common-db/get-all-pages @db/dsdb)]
     (fn []
       (let [sorted-pages @(rf/subscribe [:all-pages/sorted all-pages])]
-        [:> AllPagesTable {:sortedPages sorted-pages}]
-        #_[:> Box {:px 4
-                   :width "100%"
-                   :maxWidth "75rem"
-                   :margin "calc(var(--app-header-height) + 2rem) auto 5rem"}
-           #_[:> Table {:variant "striped"}
-              [:> Thead
-               [:> Tr
-                [sortable-header :title "Title"]
-                [sortable-header :links-count "Links" "6rem" true]
-                [sortable-header :modified "Modified" "14rem" false {:date? true}]
-                [sortable-header :created "Created" "14rem" false {:date? true}]]]
-              [:> Tbody
-               (doall
-                (for [{:keys    [block/uid node/title block/_refs]
-                       modified :edit/time
-                       created  :create/time} sorted-pages]
-                  [:> Tr {:key uid}
-                   [:> Td
-                    [:> Button {:variant "link"
-                                :justifyContent "flex-start"
-                                :textAlign "left"
-                                :padding "0"
-                                :color "link"
-                                :display "block"
-                                :maxWidth "100%"
-                                :whiteSpace "wrap"
-                                :wordBreak "break-all"
-                                :onClick (fn [e]
-                                           (let [shift? (.-shiftKey e)]
-                                             (rf/dispatch [:reporting/navigation {:source :all-pages
-                                                                                  :target :page
-                                                                                  :pane   (if shift?
-                                                                                            :right-pane
-                                                                                            :main-pane)}])
-                                             (router/navigate-page title e)))}
-                     title]]
-                   [:> Td {:width "6rem" :whiteSpace "nowrap"  :color "foreground.secondary" :isNumeric true} (count _refs)]
-                   [:> Td {:width "14rem" :whiteSpace "nowrap" :fontSize "sm" :color "foreground.secondary"} (dates/date-string modified)]
-                   [:> Td {:width "14rem" :whiteSpace "nowrap" :fontSize "sm" :color "foreground.secondary"} (dates/date-string created)]]))]]]))))
+        [:> AllPagesTable {:sortedPages (clj->js sorted-pages)
+                           :sortedBy @(rf/subscribe [:all-pages/sorted-by])
+                           :sortDirection (if @(rf/subscribe [:all-pages/sort-order-ascending?]) "asc" "desc")
+                           :onClickSort #(rf/dispatch [:all-pages/sort-by (cond
+                                                                            (= % "title") :title
+                                                                            (= % "links-count") :links-count
+                                                                            (= % "modified") :modified
+                                                                            (= % "created") :created)])
+                           :onClickItem (fn [e title]
+                                          (let [shift? (.-shiftKey e)]
+                                            (rf/dispatch [:reporting/navigation {:source :all-pages
+                                                                                 :target :page
+                                                                                 :pane   (if shift?
+                                                                                           :right-pane
+                                                                                           :main-pane)}])
+                                            (router/navigate-page title e)))}]))))

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -1,12 +1,12 @@
 (ns athens.views.pages.all-pages
   (:require
-   ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
-   [athens.common-db          :as common-db]
-   [athens.dates              :as dates]
-   [athens.db                 :as db]
-   [athens.router             :as router]
-   [clojure.string            :refer [lower-case]]
-   [re-frame.core             :as rf]))
+    ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
+    [athens.common-db          :as common-db]
+    [athens.dates              :as dates]
+    [athens.db                 :as db]
+    [athens.router             :as router]
+    [clojure.string            :refer [lower-case]]
+    [re-frame.core             :as rf]))
 
 
 ;; Sort state and logic

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -64,7 +64,7 @@
   (let [all-pages (common-db/get-all-pages @db/dsdb)]
     (fn []
       (let [sorted-pages @(rf/subscribe [:all-pages/sorted all-pages])]
-        [:> AllPagesTable {:sortedPages (clj->js sorted-pages)
+        [:> AllPagesTable {:sortedPages (clj->js sorted-pages :keyword-fn str)
                            :sortedBy @(rf/subscribe [:all-pages/sorted-by])
                            :sortDirection (if @(rf/subscribe [:all-pages/sort-order-ascending?]) "asc" "desc")
                            :onClickSort #(rf/dispatch [:all-pages/sort-by (cond

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -1,13 +1,12 @@
 (ns athens.views.pages.all-pages
   (:require
-    ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
-    [athens.common-db          :as common-db]
-    #_ [athens.dates              :as dates]
-    [athens.db                 :as db]
-    [athens.router             :as router]
-    [clojure.string            :refer [lower-case]]
-    [re-frame.core             :as rf]
-    #_ [reagent.core              :as r]))
+   ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
+   [athens.common-db          :as common-db]
+   [athens.dates              :as dates]
+   [athens.db                 :as db]
+   [athens.router             :as router]
+   [clojure.string            :refer [lower-case]]
+   [re-frame.core             :as rf]))
 
 
 ;; Sort state and logic
@@ -66,6 +65,7 @@
       (let [sorted-pages @(rf/subscribe [:all-pages/sorted all-pages])]
         [:> AllPagesTable {:sortedPages (clj->js sorted-pages :keyword-fn str)
                            :sortedBy @(rf/subscribe [:all-pages/sorted-by])
+                           :dateFormatFn #(dates/date-string %)
                            :sortDirection (if @(rf/subscribe [:all-pages/sort-order-ascending?]) "asc" "desc")
                            :onClickSort #(rf/dispatch [:all-pages/sort-by (cond
                                                                             (= % "title") :title

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -1,6 +1,7 @@
 (ns athens.views.pages.all-pages
   (:require
     ["/components/Icons/Icons" :refer [ChevronUpIcon ChevronDownIcon]]
+    ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
     ["@chakra-ui/react" :refer [Table Thead Tr Th Tbody Td Button Box]]
     [athens.common-db          :as common-db]
     [athens.dates              :as dates]
@@ -95,42 +96,43 @@
   (let [all-pages (common-db/get-all-pages @db/dsdb)]
     (fn []
       (let [sorted-pages @(rf/subscribe [:all-pages/sorted all-pages])]
-        [:> Box {:px 4
-                 :width "100%"
-                 :maxWidth "75rem"
-                 :margin "calc(var(--app-header-height) + 2rem) auto 5rem"}
-         [:> Table {:variant "striped"}
-          [:> Thead
-           [:> Tr
-            [sortable-header :title "Title"]
-            [sortable-header :links-count "Links" "6rem" true]
-            [sortable-header :modified "Modified" "14rem" false {:date? true}]
-            [sortable-header :created "Created" "14rem" false {:date? true}]]]
-          [:> Tbody
-           (doall
-             (for [{:keys    [block/uid node/title block/_refs]
-                    modified :edit/time
-                    created  :create/time} sorted-pages]
-               [:> Tr {:key uid}
-                [:> Td
-                 [:> Button {:variant "link"
-                             :justifyContent "flex-start"
-                             :textAlign "left"
-                             :padding "0"
-                             :color "link"
-                             :display "block"
-                             :maxWidth "100%"
-                             :whiteSpace "wrap"
-                             :wordBreak "break-all"
-                             :onClick (fn [e]
-                                        (let [shift? (.-shiftKey e)]
-                                          (rf/dispatch [:reporting/navigation {:source :all-pages
-                                                                               :target :page
-                                                                               :pane   (if shift?
-                                                                                         :right-pane
-                                                                                         :main-pane)}])
-                                          (router/navigate-page title e)))}
-                  title]]
-                [:> Td {:width "6rem" :whiteSpace "nowrap"  :color "foreground.secondary" :isNumeric true} (count _refs)]
-                [:> Td {:width "14rem" :whiteSpace "nowrap" :fontSize "sm" :color "foreground.secondary"} (dates/date-string modified)]
-                [:> Td {:width "14rem" :whiteSpace "nowrap" :fontSize "sm" :color "foreground.secondary"} (dates/date-string created)]]))]]]))))
+        [:> AllPagesTable {:sortedPages sorted-pages}]
+        #_[:> Box {:px 4
+                   :width "100%"
+                   :maxWidth "75rem"
+                   :margin "calc(var(--app-header-height) + 2rem) auto 5rem"}
+           #_[:> Table {:variant "striped"}
+              [:> Thead
+               [:> Tr
+                [sortable-header :title "Title"]
+                [sortable-header :links-count "Links" "6rem" true]
+                [sortable-header :modified "Modified" "14rem" false {:date? true}]
+                [sortable-header :created "Created" "14rem" false {:date? true}]]]
+              [:> Tbody
+               (doall
+                (for [{:keys    [block/uid node/title block/_refs]
+                       modified :edit/time
+                       created  :create/time} sorted-pages]
+                  [:> Tr {:key uid}
+                   [:> Td
+                    [:> Button {:variant "link"
+                                :justifyContent "flex-start"
+                                :textAlign "left"
+                                :padding "0"
+                                :color "link"
+                                :display "block"
+                                :maxWidth "100%"
+                                :whiteSpace "wrap"
+                                :wordBreak "break-all"
+                                :onClick (fn [e]
+                                           (let [shift? (.-shiftKey e)]
+                                             (rf/dispatch [:reporting/navigation {:source :all-pages
+                                                                                  :target :page
+                                                                                  :pane   (if shift?
+                                                                                            :right-pane
+                                                                                            :main-pane)}])
+                                             (router/navigate-page title e)))}
+                     title]]
+                   [:> Td {:width "6rem" :whiteSpace "nowrap"  :color "foreground.secondary" :isNumeric true} (count _refs)]
+                   [:> Td {:width "14rem" :whiteSpace "nowrap" :fontSize "sm" :color "foreground.secondary"} (dates/date-string modified)]
+                   [:> Td {:width "14rem" :whiteSpace "nowrap" :fontSize "sm" :color "foreground.secondary"} (dates/date-string created)]]))]]]))))

--- a/src/cljs/athens/views/pages/all_pages.cljs
+++ b/src/cljs/athens/views/pages/all_pages.cljs
@@ -2,12 +2,12 @@
   (:require
     ["/components/AllPagesTable/AllPagesTable" :refer [AllPagesTable]]
     [athens.common-db          :as common-db]
-    [athens.dates              :as dates]
+    #_ [athens.dates              :as dates]
     [athens.db                 :as db]
     [athens.router             :as router]
     [clojure.string            :refer [lower-case]]
     [re-frame.core             :as rf]
-    [reagent.core              :as r]))
+    #_ [reagent.core              :as r]))
 
 
 ;; Sort state and logic
@@ -57,7 +57,6 @@
                               (assoc :all-pages/sort-order-ascending? (= column-id :title))))]
       {:db db'
        :dispatch [:posthog/report-feature :all-pages]})))
-
 
 
 (defn page

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -6,7 +6,7 @@
     ["/components/Icons/Icons" :refer [EllipsisHorizontalIcon GraphIcon BookmarkIcon BookmarkFillIcon TrashIcon ArrowRightOnBoxIcon]]
     ["/components/Page/Page" :refer [PageHeader PageBody PageFooter TitleContainer]]
     ["/components/References/References" :refer [PageReferences ReferenceBlock ReferenceGroup]]
-    ["@chakra-ui/react" :refer [Flex Box HStack Button Portal IconButton MenuDivider MenuButton Menu MenuList MenuItem Breadcrumb BreadcrumbItem BreadcrumbLink VStack]]
+    ["@chakra-ui/react" :refer [Box HStack Button Portal IconButton MenuDivider MenuButton Menu MenuList MenuItem Breadcrumb BreadcrumbItem BreadcrumbLink VStack]]
     [athens.common-db :as common-db]
     [athens.common.sentry :refer-macros [wrap-span-no-new-tx]]
     [athens.common.utils :as utils]

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -77,27 +77,30 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
     px={4}
     width="100%"
     maxWidth="75rem"
-    margin="calc(var(--app-header-height) + 2rem) auto 5rem"
-    height="calc(100% - var(--app-header-height) - 6rem)"
+    sx={{ "--margin-top": "2rem" }}
+    margin="calc(var(--app-header-height) + var(--margin-top)) auto 0"
+    height="calc(100vh - var(--app-header-height) - var(--margin-top))"
   >
     <Table variant="striped"
       sx={{
         "tr > *:nth-child(1)": {
-          flex: "0 0 calc(100% - 30rem)"
+          flex: "1 1 calc(100% - 30rem)"
         },
         "tr > *:nth-child(2)": {
-          flex: "0 0 10rem"
+          flex: "0 0 12rem"
         },
         "tr > *:nth-child(3)": {
-          flex: "0 0 10rem"
+          flex: "0 0 12rem"
         },
         "tr > *:nth-child(4)": {
-          flex: "0 0 10rem"
+          flex: "0 0 12rem"
         },
       }}
     >
       <Thead>
-        <Tr display="flex">
+        <Tr
+          display="flex"
+        >
           {columns.map((column, index) => {
             return <Th key={index}>
               <Button

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { FixedSizeList as List } from 'react-window';
+import { Box, Table, Thead, Tfoot, Tbody, Th, Td, Tr } from '@chakra-ui/react';
+
+
+const Row = ({ index, data, style }) => {
+  console.log('rendered item')
+  return (
+    <Tr style={style}><Td>{data[index].title}</Td></Tr>
+  )
+};
+
+const getHeight = (el) => {
+  if (el) {
+    return el.offsetHeight;
+  } else {
+    return 500;
+  }
+}
+
+export const AllPagesTable = ({ sortedPages }) => {
+
+  const containerRef = React.useRef();
+  const [containerHeight, setContainerHeight] = React.useState(500);
+
+  React.useLayoutEffect(() => {
+    const updateSize = () => {
+      setContainerHeight(getHeight(containerRef.current))
+    };
+    window.addEventListener("resize", updateSize);
+    updateSize();
+    return () => window.removeEventListener("resize", updateSize);
+  })
+
+  return <Box
+    ref={containerRef}
+    px={4}
+    width="100%"
+    maxWidth="75rem"
+    margin="calc(var(--app-header-height) + 2rem) auto 5rem"
+    height="calc(100% - var(--app-header-height) - 7rem)"
+  >
+    <Table border="1px solid white">
+      <Tbody border="1px solid red">
+        <List
+          height={containerHeight}
+          itemCount={sortedPages.length}
+          itemSize={35}
+          itemData={sortedPages}
+          width={300}
+        >
+          {Row}
+        </List>
+      </Tbody>
+    </Table>
+  </Box>
+}

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -41,12 +41,12 @@ const Row = ({ index, data, style }) => {
           textAlign="left"
           padding="0"
         >
-          {DISPLAY_TITLES[item.title] || item.title}
+          {DISPLAY_TITLES[item[":node/title"]] || item[":node/title"]}
         </Button>
       </Td>
-      <Td>{item._refs?.length || 0}</Td>
-      <Td>{item.time}</Td>
-      <Td>test</Td>
+      <Td>{item[":block/_refs"]?.length || 0}</Td>
+      <Td>{item[":edit/time"]}</Td>
+      <Td>{item[":create/time"]}</Td>
     </Tr>
   )
 };

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -63,7 +63,7 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
   const containerRef = React.useRef();
   const [containerHeight, setContainerHeight] = React.useState(500);
   const columns = ['title', 'links-count', 'modified', 'created'];
-  const rows = React.useMemo(() => sortedPages.map((row, index) => {
+  const rows = React.useMemo(() => sortedPages.map((row) => {
     return {
       ...row,
       onClick: (e) => onClickItem(e, row.title)
@@ -81,16 +81,15 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
   })
 
   return <Box
-    ref={containerRef}
+    width="100%"
+    height="100vh"
     sx={{
       "--margin-top": "2rem",
+      "--thead-height": "8rem",
     }}
-    paddingTop="calc(var(--app-header-height) + var(--margin-top))"
-    width="100%"
-    height="100%"
   >
     <Table variant="striped"
-      height="100%"
+      height="100vh"
       sx={{
         "tr > *:nth-child(1)": {
           flex: "0 0 calc(100% - 36rem)"
@@ -114,12 +113,16 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
           margin="auto"
         >
           {columns.map((column, index) => {
-            return <Th key={index}>
+            return <Th
+              key={index}
+              height="var(--thead-height)"
+            >
               <Button
                 onClick={() => onClickSort(column)}
                 size="sm"
                 variant="link"
                 height="1em"
+                marginTop="calc(var(--thead-height) - 3em)"
                 justifyContent="flex-start"
                 display="flex"
                 rightIcon={
@@ -140,7 +143,8 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
         position="relative"
         display="flex"
         width="100%"
-        height="100%"
+        height="calc(100vh - var(--thead-height))"
+        ref={containerRef}
         sx={{
           // target the container that renders the row items
           "> div > div": {
@@ -160,6 +164,7 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
             left: "auto",
             right: "auto",
             width: "100%",
+            paddingBottom: "2rem",
           }}
         >
           {Row}

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -16,15 +16,23 @@ const Row = ({ index, data, style }) => {
   return (
     <Tr
       style={style}
-      width="100%"
+      maxWidth="75rem"
+      marginLeft="auto"
+      marginRight="auto"
       display="flex"
+      sx={{
+        left: "auto !important"
+      }}
       className={index % 2 ? 'index-even' : 'index-odd'}
     >
-      <Td>
+      <Td
+        overflow="hidden"
+      >
         <Button
           onClick={data[index].onClick}
           variant="link"
           color="link"
+          width="100%"
           display="block"
           justifyContent="flex-start"
           whiteSpace="nowrap"
@@ -74,17 +82,18 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
 
   return <Box
     ref={containerRef}
-    px={4}
+    sx={{
+      "--margin-top": "2rem",
+    }}
+    paddingTop="calc(var(--app-header-height) + var(--margin-top))"
     width="100%"
-    maxWidth="75rem"
-    sx={{ "--margin-top": "2rem" }}
-    margin="calc(var(--app-header-height) + var(--margin-top)) auto 0"
-    height="calc(100vh - var(--app-header-height) - var(--margin-top))"
+    height="100%"
   >
     <Table variant="striped"
+      height="100%"
       sx={{
         "tr > *:nth-child(1)": {
-          flex: "1 1 calc(100% - 30rem)"
+          flex: "0 0 calc(100% - 36rem)"
         },
         "tr > *:nth-child(2)": {
           flex: "0 0 12rem"
@@ -100,6 +109,9 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
       <Thead>
         <Tr
           display="flex"
+          width="100%"
+          maxWidth="75rem"
+          margin="auto"
         >
           {columns.map((column, index) => {
             return <Th key={index}>
@@ -126,7 +138,16 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
       </Thead>
       <Tbody
         position="relative"
+        display="flex"
         width="100%"
+        height="100%"
+        sx={{
+          // target the container that renders the row items
+          "> div > div": {
+            display: "flex",
+            justifyContent: "center",
+          }
+        }}
       >
         <List
           height={containerHeight}
@@ -136,10 +157,10 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
           style={{
             position: "absolute",
             top: 0,
-            left: 0,
+            left: "auto",
+            right: "auto",
             width: "100%",
           }}
-          width="100%"
         >
           {Row}
         </List>

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -1,12 +1,45 @@
 import React from 'react';
+import { ChevronDownIcon, ChevronUpIcon } from '@/Icons/Icons';
 import { FixedSizeList as List } from 'react-window';
-import { Box, Table, Thead, Tfoot, Tbody, Th, Td, Tr } from '@chakra-ui/react';
+import { Button, Box, Table, Thead, Tbody, Th, Td, Tr } from '@chakra-ui/react';
+
+const DISPLAY_TITLES = {
+  'title': 'Title',
+  'links-count': 'Links',
+  'modified': 'Modified',
+  'created': 'Created',
+}
 
 
 const Row = ({ index, data, style }) => {
-  console.log('rendered item')
+  const item = data[index];
   return (
-    <Tr style={style}><Td>{data[index].title}</Td></Tr>
+    <Tr
+      style={style}
+      width="100%"
+      display="flex"
+      className={index % 2 ? 'index-even' : 'index-odd'}
+    >
+      <Td>
+        <Button
+          onClick={data[index].onClick}
+          variant="link"
+          color="link"
+          display="block"
+          justifyContent="flex-start"
+          whiteSpace="nowrap"
+          textOverflow="ellipsis"
+          overflow="hidden"
+          textAlign="left"
+          padding="0"
+        >
+          {DISPLAY_TITLES[item.title] || item.title}
+        </Button>
+      </Td>
+      <Td>{item._refs?.length || 0}</Td>
+      <Td>{item.time}</Td>
+      <Td>test</Td>
+    </Tr>
   )
 };
 
@@ -18,11 +51,18 @@ const getHeight = (el) => {
   }
 }
 
-export const AllPagesTable = ({ sortedPages }) => {
-
+export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirection, onClickSort }) => {
   const containerRef = React.useRef();
   const [containerHeight, setContainerHeight] = React.useState(500);
+  const columns = ['title', 'links-count', 'modified', 'created'];
+  const rows = React.useMemo(() => sortedPages.map((row, index) => {
+    return {
+      ...row,
+      onClick: (e) => onClickItem(e, row.title)
+    }
+  }), [sortedPages]);
 
+  // Watch the window for resizing
   React.useLayoutEffect(() => {
     const updateSize = () => {
       setContainerHeight(getHeight(containerRef.current))
@@ -38,20 +78,69 @@ export const AllPagesTable = ({ sortedPages }) => {
     width="100%"
     maxWidth="75rem"
     margin="calc(var(--app-header-height) + 2rem) auto 5rem"
-    height="calc(100% - var(--app-header-height) - 7rem)"
+    height="calc(100% - var(--app-header-height) - 6rem)"
   >
-    <Table border="1px solid white">
-      <Tbody border="1px solid red">
+    <Table variant="striped"
+      sx={{
+        "tr > *:nth-child(1)": {
+          flex: "0 0 calc(100% - 30rem)"
+        },
+        "tr > *:nth-child(2)": {
+          flex: "0 0 10rem"
+        },
+        "tr > *:nth-child(3)": {
+          flex: "0 0 10rem"
+        },
+        "tr > *:nth-child(4)": {
+          flex: "0 0 10rem"
+        },
+      }}
+    >
+      <Thead>
+        <Tr display="flex">
+          {columns.map((column, index) => {
+            return <Th key={index}>
+              <Button
+                onClick={() => onClickSort(column)}
+                size="sm"
+                variant="link"
+                height="1em"
+                justifyContent="flex-start"
+                display="flex"
+                rightIcon={
+                  sortedBy === column ?
+                    sortDirection === 'asc' ?
+                      <ChevronUpIcon /> :
+                      <ChevronDownIcon /> :
+                    null
+                }
+              >
+                {DISPLAY_TITLES[column] || column}
+              </Button>
+            </Th>
+          })}
+        </Tr>
+      </Thead>
+      <Tbody
+        position="relative"
+        width="100%"
+      >
         <List
           height={containerHeight}
-          itemCount={sortedPages.length}
-          itemSize={35}
-          itemData={sortedPages}
-          width={300}
+          itemCount={rows.length}
+          itemSize={52}
+          itemData={rows}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+          }}
+          width="100%"
         >
           {Row}
         </List>
       </Tbody>
     </Table>
-  </Box>
+  </Box >
 }

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -12,7 +12,9 @@ const DISPLAY_TITLES = {
 
 
 const Row = ({ index, data, style }) => {
+
   const item = data[index];
+  console.log(item)
   return (
     <Tr
       style={style}
@@ -59,14 +61,16 @@ const getHeight = (el) => {
   }
 }
 
-export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirection, onClickSort }) => {
+export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirection, onClickSort, dateFormatFn }) => {
   const containerRef = React.useRef();
   const [containerHeight, setContainerHeight] = React.useState(500);
   const columns = ['title', 'links-count', 'modified', 'created'];
   const rows = React.useMemo(() => sortedPages.map((row) => {
     return {
       ...row,
-      onClick: (e) => onClickItem(e, row.title)
+      onClick: (e) => onClickItem(e, row.title),
+      ":edit/time": dateFormatFn(row[":edit/time"]),
+      ":create/time": dateFormatFn(row[":create/time"]),
     }
   }), [sortedPages]);
 
@@ -93,16 +97,22 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
       height="100vh"
       sx={{
         "tr > *:nth-child(1)": {
-          flex: "0 0 calc(100% - 36rem)"
+          flex: "0 0 calc(100% - 35rem)"
         },
         "tr > *:nth-child(2)": {
-          flex: "0 0 12rem"
+          flex: "0 0 7rem",
+          color: "foreground.secondary",
+          fontSize: "sm"
         },
         "tr > *:nth-child(3)": {
-          flex: "0 0 12rem"
+          flex: "0 0 14rem",
+          color: "foreground.secondary",
+          fontSize: "sm"
         },
         "tr > *:nth-child(4)": {
-          flex: "0 0 12rem"
+          flex: "0 0 14rem",
+          color: "foreground.secondary",
+          fontSize: "sm"
         },
       }}
     >

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -82,6 +82,7 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
 
   return <Box
     width="100%"
+    px={4}
     height="100vh"
     sx={{
       "--margin-top": "2rem",

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -528,7 +528,15 @@ const components = {
         },
         tbody: {
           tr: {
+            // Reset the default striped background so we can
+            // set it more robustly below, including support
+            // for virtualized tables.
             "&:nth-of-type(odd)": {
+              td: {
+                background: 'none'
+              }
+            },
+            "&:nth-of-type(odd):not(.index-even), &.index-odd": {
               td: {
                 background: "background.upper",
                 "&:first-of-type": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10574,6 +10574,11 @@ memfs@^3.1.2:
   dependencies:
     fs-monkey "1.0.3"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memoizerific@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"
@@ -12445,6 +12450,14 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-window@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
+  integrity sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@17.0.1:
   version "17.0.1"


### PR DESCRIPTION
- All Pages table is virtualized. Only the number of items that fit on the screen are rendered.
- All pages are still pulled from the db, which appears to be the speed limiter now, rather than rendering
- Layout slightly tweaked to support the new architecture
- Uses react-window instead of other libraries because of light weight and ease of use. Other virtualization libraries could be considered.