### PR TITLE
Ensure block navigation just through keyboard works

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -471,7 +471,7 @@
 
 
 (defntrace prev-block-uid
-  "If order 0, go to parent.
+  "If order 0, go to parent (if not a page).
    If order n but block is closed, go to prev sibling.
    If order n and block is OPEN, go to prev sibling's deepest child."
   [uid]
@@ -484,9 +484,12 @@
         prev-block                    (cond
                                         (zero? (:block/order block)) parent
                                         (false? open)                prev-sibling
-                                        (true? open)                 (deepest-child-block [:block/uid prev-sibling-uid]))]
-    (cond-> (:block/uid prev-block)
-      embed-id (str "-embed-" embed-id))))
+                                        (true? open)                 (deepest-child-block [:block/uid prev-sibling-uid]))
+        prev-block-uid                (:block/uid prev-block)]
+    (when (and prev-block-uid
+               (not (:node/title prev-block)))
+      (cond-> prev-block-uid
+        embed-id (str "-embed-" embed-id)))))
 
 
 (defntrace next-sibling-recursively

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -516,14 +516,14 @@
 
 (reg-event-db
   :daily-note/reset
-  (fn [db [_ uid]]
-    (assoc db :daily-notes/items uid)))
+  (fn [db [_ uids]]
+    (assoc db :daily-notes/items uids)))
 
 
 (reg-event-db
   :daily-note/add
   (fn [db [_ uid]]
-    (update db :daily-notes/items (comp rseq sort distinct conj) uid)))
+    (update db :daily-notes/items (comp vec rseq sort distinct conj) uid)))
 
 
 (reg-event-fx

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -405,6 +405,14 @@
       {:dispatch [:editing/uid first-block-uid]})))
 
 
+(reg-event-fx
+  :editing/last-child
+  [(interceptors/sentry-span-no-new-tx "editing/last-child")]
+  (fn [_ [_ uid]]
+    (when-let [last-block-uid (db/get-last-child-uid uid @db/dsdb)]
+      {:dispatch [:editing/uid last-block-uid]})))
+
+
 (defn select-up
   [selected-items]
   (let [first-item       (first selected-items)
@@ -909,9 +917,7 @@
   Only works for the main window."
   [uid]
   (let [[uid _]    (db/uid-and-embed-id uid)
-        window-uid (or @(subscribe [:current-route/uid])
-                       (->> @(subscribe [:current-route/page-title])
-                            (common-db/get-page-uid @db/dsdb)))]
+        window-uid @(subscribe [:current-route/uid-compat])]
     (and uid window-uid (= uid window-uid))))
 
 

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -88,8 +88,21 @@
                 shift
                 alt]
          :as   destruct-keys} (util/destruct-key-down e)
-        editing-uid           @(subscribe [:editing/uid])]
+        editing-uid           @(subscribe [:editing/uid])
+        window-uid            (or @(subscribe [:current-route/uid-compat])
+                                  (when (= @(subscribe [:current-route/name]) :home)
+                                    ;; On daily notes, assume you're on the first note.
+                                    (-> @(subscribe [:daily-notes/items])
+                                        first)))]
     (cond
+      (and (nil? editing-uid)
+           window-uid
+           (= key-code KeyCodes.UP))     (dispatch [:editing/last-child window-uid])
+
+      (and (nil? editing-uid)
+           window-uid
+           (= key-code KeyCodes.DOWN))   (dispatch [:editing/first-child window-uid])
+
       (util/navigate-key? destruct-keys) (condp = key-code
                                            KeyCodes.LEFT  (when (nil? editing-uid)
                                                             (.back js/window.history))

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -113,9 +113,21 @@
                                                                 (if shift
                                                                   (dispatch [:redo])
                                                                   (dispatch [:undo])))
-                                           ;; Disable the default "Open file..." behaviour.
-                                           ;; We use this for navigation instead.
-                                           KeyCodes.O         (.. e preventDefault)
+                                           KeyCodes.O         (do
+                                                                ;; Disable the default "Open file..." behaviour.
+                                                                ;; We use this for navigation instead.
+                                                                (.. e preventDefault)
+                                                                (when alt
+                                                                  ;; When alt is also pressed, zoom out of current block page
+                                                                  (when-let [parent-uid (->> [:block/uid @(subscribe [:current-route/uid])]
+                                                                                             (common-db/get-parent-eid @db/dsdb)
+                                                                                             second)]
+                                                                    (rf/dispatch [:reporting/navigation {:source :kbd-ctrl-alt-o
+                                                                                                         :target :block
+                                                                                                         :pane   (if shift
+                                                                                                                   :right-pane
+                                                                                                                   :main-pane)}])
+                                                                    (router/navigate-uid parent-uid e))))
                                            KeyCodes.BACKSLASH (if shift
                                                                 (dispatch [:right-sidebar/toggle])
                                                                 (dispatch [:left-sidebar/toggle]))

--- a/src/cljs/athens/listeners.cljs
+++ b/src/cljs/athens/listeners.cljs
@@ -113,6 +113,9 @@
                                                                 (if shift
                                                                   (dispatch [:redo])
                                                                   (dispatch [:undo])))
+                                           ;; Disable the default "Open file..." behaviour.
+                                           ;; We use this for navigation instead.
+                                           KeyCodes.O         (.. e preventDefault)
                                            KeyCodes.BACKSLASH (if shift
                                                                 (dispatch [:right-sidebar/toggle])
                                                                 (dispatch [:left-sidebar/toggle]))

--- a/src/cljs/athens/router.cljs
+++ b/src/cljs/athens/router.cljs
@@ -37,6 +37,16 @@
 
 
 (reg-sub
+  :current-route/uid-compat
+  :<- [:current-route/uid]
+  :<- [:current-route/page-title]
+  (fn [[uid title]]
+    (or uid
+        (when title
+          (common-db/get-page-uid @db/dsdb title)))))
+
+
+(reg-sub
   :current-route/name
   (fn [db]
     (-> db :current-route :data :name)))

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -352,6 +352,7 @@
   [e uid state]
   (let [{:keys [key-code
                 shift
+                meta
                 ctrl
                 target
                 selection]}              (destruct-key-down e)
@@ -386,18 +387,19 @@
                                                                                        up? :first
                                                                                        down? :last)])))
 
-      ;; Control: fold or unfold blocks
-      ctrl (cond
-             left?          nil
-             right?         nil
-             (or up? down?) (let [[uid _]        (db/uid-and-embed-id uid)
-                                  new-open-state (cond
-                                                   up?   false
-                                                   down? true)
-                                  event          [:block/open {:block-uid uid
-                                                               :open?     new-open-state}]]
-                              (.. e preventDefault)
-                              (dispatch event)))
+      ;; Control (Command on mac): fold or unfold blocks
+      (shortcut-key? meta ctrl)
+      (cond
+        left?          nil
+        right?         nil
+        (or up? down?) (let [[uid _]        (db/uid-and-embed-id uid)
+                             new-open-state (cond
+                                              up?   false
+                                              down? true)
+                             event          [:block/open {:block-uid uid
+                                                          :open?     new-open-state}]]
+                         (.. e preventDefault)
+                         (dispatch event)))
 
       ;; Type, one of #{:slash :block :page}: If slash commands or inline search is open, cycle through options
       type (cond

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -592,6 +592,8 @@
                                     block-ref (str (replace-first head #"(?s)(.*)\(\(" "")
                                                    (replace-first tail #"(?s)\)\)(.*)" ""))]
 
+                                (.. e preventDefault)
+
                                 ;; save block before navigating away
                                 ((:string/save-fn @state))
 

--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -161,6 +161,8 @@
    {:name  "Navigation"
     :items [{:description "Zoom into current block"
              :shortcut    "mod+o"}
+            {:description "Zoom out of current block"
+             :shortcut    "mod+alt+o"}
             {:description "Open page or block link"
              :shortcut    "mod+o"}
             {:description "Fold block"

--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -168,7 +168,7 @@
             {:description "Fold block"
              :shortcut    "mod+up"}
             {:description "Unfold block"
-             :shortcut    "mod+up"}]}
+             :shortcut    "mod+down"}]}
    {:name  "Selection"
     :items [{:description "Select previous block"
              :shortcut    "shift+up"}

--- a/src/cljs/athens/views/help.cljs
+++ b/src/cljs/athens/views/help.cljs
@@ -158,6 +158,15 @@
              :shortcut    "mod+shift+v"}
             {:description "Convert to checkbox"
              :shortcut    "mod+enter"}]}
+   {:name  "Navigation"
+    :items [{:description "Zoom into current block"
+             :shortcut    "mod+o"}
+            {:description "Open page or block link"
+             :shortcut    "mod+o"}
+            {:description "Fold block"
+             :shortcut    "mod+up"}
+            {:description "Unfold block"
+             :shortcut    "mod+up"}]}
    {:name  "Selection"
     :items [{:description "Select previous block"
              :shortcut    "shift+up"}


### PR DESCRIPTION
- fix: fold shortcut should use shortcut key on mac
- feat: add navigation section to help
- fix: disable "open file..." dialog on cmd/ctrl+o
- feat: mod+alt+o zooms out of current block
- fix: up on first window child should not lose block focus
- fix: prev-block-uid should not try to go to pages
- fix: :daily-notes/items should always be a vector
- feat: pressing up/down with no focus takes you to last/first block
