### PR TITLE
fix: restore the alert/js event

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -473,6 +473,12 @@
 
 
 (reg-event-fx
+  :alert/js
+  (fn [_ [_ message]]
+    {:alert/js! message}))
+
+
+(reg-event-fx
   :confirm/js
   (fn [_ [_ message true-cb false-cb]]
     {:confirm/js! [message true-cb false-cb]}))


### PR DESCRIPTION
There's still a bunch of places that are calling it.
