### PR TITLE
Block actions in container

### DIFF
--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -342,11 +342,21 @@
 
          [:> Container {:isDragging (and dragging (not is-selected))
                         :isSelected is-selected
+                        :isEditing @(rf/subscribe [:editing/is-editing uid])
                         :hasChildren (seq children)
                         :isOpen open
                         :isLinkedRef (and (false? initial-open) (= uid linked-ref-uid))
                         :hasPresence is-presence
                         :uid uid
+                        :actions (clj->js [{:children
+                                            (if (> (count selected-items) 1)
+                                              "Copy selected block refs"
+                                              "Copy block ref")
+                                            :isExtra true
+                                            :onClick #(handle-copy-refs nil uid)}
+                                           {:children "Copy unformatted text"
+                                            :isExtra true
+                                            :onClick #(handle-copy-unformatted uid)}])
                         ;; need to know children for selection resolution
                         :childrenUids children-uids
                         ;; :show-editable-dom allows us to render the editing elements (like the textarea)

--- a/src/js/components/Block/Actions.tsx
+++ b/src/js/components/Block/Actions.tsx
@@ -64,6 +64,9 @@ export const Actions = ({ actions, setIsUsingActions }: ActionsProps): JSX.Eleme
                 >
                   <EllipsisHorizontalIcon />
                 </MenuButton>
+                {/* Create a backdrop to capture
+                mouse events and prevent accidentally
+                closing the menu */}
                 {isOpen && <Box
                   position="fixed"
                   left="-100vw"

--- a/src/js/components/Block/Actions.tsx
+++ b/src/js/components/Block/Actions.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Box, Button, ButtonGroup, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
+import { EllipsisHorizontalIcon } from "@/Icons/Icons";
+
+interface Action {
+  label: string;
+  onClick: () => void;
+  isExtra?: boolean;
+  children?: React.ReactNode;
+}
+
+export interface ActionsProps {
+  actions: Action[];
+  setIsUsingActions: (isUsingActions: boolean) => void;
+}
+
+export const Actions = ({ actions, setIsUsingActions }: ActionsProps): JSX.Element | null => {
+  if (!actions)
+    return null;
+
+  const defaultActions = actions.filter(a => !a.isExtra);
+  const extraActions = actions.filter(a => a.isExtra);
+
+  return (
+    <ButtonGroup
+      className="block-actions"
+      size="xs"
+      zIndex="tooltip"
+      isAttached={true}
+      position="absolute"
+      right={0}
+      transform="translateY(-50%)"
+      top="1em"
+      borderRadius="md"
+      onFocus={() => setIsUsingActions(true)}
+      onBlur={() => setIsUsingActions(false)}
+      _after={{
+        content: "''",
+        zIndex: -1,
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        borderRadius: "inherit",
+        bg: "background.vibrancy",
+        backdropFilter: "blur(12px)"
+      }}
+    >
+      {defaultActions.map(a => <Button
+        key={a.label}
+        {...a} />)}
+      {extraActions.length > 0 && (
+        <Menu isLazy={true} size="sm" placement="bottom-end">
+          {({ isOpen }) => {
+            setIsUsingActions(isOpen);
+
+            return (
+              <>
+                <MenuButton
+                  as={Button}
+                  size="xs"
+                  zIndex="tooltip"
+                >
+                  <EllipsisHorizontalIcon />
+                </MenuButton>
+                {isOpen && <Box
+                  position="fixed"
+                  left="-100vw"
+                  top="-100vh"
+                  width="200vw"
+                  height="200vh"
+                  zIndex="1" />}
+                <MenuList>
+                  {extraActions.map(a => <MenuItem key={a.label} {...a} />)}
+                </MenuList>
+              </>
+            );
+          }}
+        </Menu>
+      )}
+    </ButtonGroup>
+  );
+};


### PR DESCRIPTION
- Adds actions menu to blocks
- Individual actions are objects of Button props, so `icon`, `children`, `onClick`, `label`, `command`, etc. are all available.
- Actions menu appears on hover of block, but not its children.
- Actions menu disappears when editing a block
- Menu positioning is a little inelegant and overlaps some things.


https://user-images.githubusercontent.com/8952138/167670027-39b1404d-5a4f-4c51-88a2-9a100a42cb82.mp4
