### PR TITLE
fix: defaultIsOpen state for linked refs

### DIFF
--- a/src/js/components/References/References.tsx
+++ b/src/js/components/References/References.tsx
@@ -76,7 +76,7 @@ export const PageReferences = withErrorBoundary(({ children, count, title, defau
     onOpen: onOpen
   });
 
-  const isShowingContent = isOpen && !!children;
+  const isShowingContent = defaultIsOpen;
 
   return (
     <VStack


### PR DESCRIPTION
Linked refs should not be open by default if there are more than 10. However, this was not always working when: linked refs were open for a page, and then user navigates to another page with more than 10 linked refs. `isShowingContent` uses `isOpen` which persists previous linked refs state.