### PR TITLE
properties outliner

### DIFF
--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -225,13 +225,17 @@
 
 (defn add-property-map
   [block]
-  (if-let [properties (-> block :block/_property-of seq)]
-    (assoc block :block/properties
-           (->> properties
-                (map (fn [block]
-                       [(-> block :block/key :node/title) (add-property-map block)]))
-                (into {})))
-    block))
+  (let [block'     (if (:block/children block)
+                     (update block :block/children (partial mapv add-property-map))
+                     block)
+        properties (-> block' :block/_property-of seq)]
+    (if properties
+      (assoc block' :block/properties
+             (->> properties
+                  (map (fn [block]
+                         [(-> block :block/key :node/title) (add-property-map block)]))
+                  (into {})))
+      block')))
 
 
 (defn get-block

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -358,6 +358,13 @@
         (get-children-uids db eid)))
 
 
+(defn property-key
+  [db eid]
+  (->> (d/entity db eid)
+       :block/key
+       :node/title))
+
+
 (def block-document-pull-vector
   '[:db/id :block/uid :block/string :block/open :block/order {:block/children ...} :block/refs :block/_refs
     {:block/key [:node/title]} {:block/_property-of ...}])

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -339,16 +339,23 @@
          (mapv :block/uid))))
 
 
-(defn prev-sib
-  [db uid prev-sib-order]
-  (d/q '[:find ?sib .
-         :in $ % ?target-uid ?prev-sib-order
-         :where
-         (siblings ?target-uid ?sib)
-         [?sib :block/order ?prev-sib-order]
-         [?sib :block/uid ?uid]
-         [?sib :block/children ?ch]]
-       db rules uid prev-sib-order))
+(defn get-property-uids
+  "Fetches page or block sorted property uids based on eid lookup."
+  [db eid]
+  (when (d/entity db eid)
+    (->> (d/pull db '[{:block/_property-of [:block/uid
+                                            {:block/key [:node/title]}]}]
+                 eid)
+         add-property-map
+         :block/properties
+         sort-block-properties
+         (mapv :block/uid))))
+
+
+(defn sorted-prop+children-uids
+  [db eid]
+  (into (get-property-uids db eid)
+        (get-children-uids db eid)))
 
 
 (def block-document-pull-vector

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -464,22 +464,6 @@
       [uid nil]))
 
 
-(defn nth-sibling
-  "Find sibling that has order+n of current block.
-  Negative n means previous sibling.
-  Positive n means next sibling."
-  [db uid n]
-  (let [block      (get-block db [:block/uid uid])
-        {:block/keys [order]} block
-        find-order (+ n order)]
-    (d/q '[:find (pull ?sibs [*]) .
-           :in $ % ?curr-uid ?find-order
-           :where
-           (siblings ?curr-uid ?sibs)
-           [?sibs :block/order ?find-order]]
-         db rules uid find-order)))
-
-
 (defn nth-child
   "Find child that has order n in parent."
   [db parent-uid order]
@@ -504,37 +488,6 @@
   (-> db
       (d/entity [:block/uid uid])
       :block/string))
-
-
-(defn deepest-child-block
-  [db id]
-  (when (d/entity db id)
-    (let [document (->> (d/pull db '[:block/order :block/uid {:block/children ...}] id)
-                        sort-block-children)]
-      (loop [block document]
-        (let [{:block/keys [children]} block
-              n (count children)]
-          (if (zero? n)
-            block
-            (recur (get children (dec n)))))))))
-
-
-(defn prev-block-uid
-  "If order 0, go to parent.
-   If order n but block is closed, go to prev sibling.
-   If order n and block is OPEN, go to prev sibling's deepest child."
-  [db uid]
-  (let [[uid embed-id]  (uid-and-embed-id uid)
-        block           (get-block db [:block/uid uid])
-        parent          (get-parent db [:block/uid uid])
-        prev-sibling    (nth-sibling db uid -1)
-        {:block/keys    [open uid]} prev-sibling
-        prev-block      (cond
-                          (zero? (:block/order block)) parent
-                          (false? open) prev-sibling
-                          (true? open) (deepest-child-block db [:block/uid uid]))]
-    (cond-> (:block/uid prev-block)
-      embed-id (str "-embed-" embed-id))))
 
 
 (defn same-parent?

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -127,34 +127,6 @@
   (get (d/entity db e) a))
 
 
-(def rules
-  '[[(after ?p ?at ?ch ?o)
-     [?p :block/children ?ch]
-     [?ch :block/order ?o]
-     [(> ?o ?at)]]
-    [(between ?p ?lower-bound ?upper-bound ?ch ?o)
-     [?p :block/children ?ch]
-     [?ch :block/order ?o]
-     [(> ?o ?lower-bound)]
-     [(< ?o ?upper-bound)]]
-    [(inc-after ?p ?at ?ch ?new-o)
-     (after ?p ?at ?ch ?o)
-     [(inc ?o) ?new-o]]
-    [(dec-after ?p ?at ?ch ?new-o)
-     (after ?p ?at ?ch ?o)
-     [(dec ?o) ?new-o]]
-    [(plus-after ?p ?at ?ch ?new-o ?x)
-     (after ?p ?at ?ch ?o)
-     [(+ ?o ?x) ?new-o]]
-    [(minus-after ?p ?at ?ch ?new-o ?x)
-     (after ?p ?at ?ch ?o)
-     [(- ?o ?x) ?new-o]]
-    [(siblings ?uid ?sib-e)
-     [?e :block/uid ?uid]
-     [?p :block/children ?e]
-     [?p :block/children ?sib-e]]])
-
-
 (defn get-sidebar-elements
   [db]
   (->> (d/q '[:find [(pull ?e [*]) ...]

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -244,6 +244,13 @@
     block))
 
 
+(defn sort-block-properties
+  [properties]
+  (->> properties
+       (sort-by (comp str first))
+       (map second)))
+
+
 (defn add-property-map
   [block]
   (if-let [properties (-> block :block/_property-of seq)]

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -747,6 +747,15 @@
        db))
 
 
+(defn breadcrumb-string
+  [db uid]
+  (let [{:block/keys [key string]
+         :keys       [node/title]} (d/entity db [:block/uid uid])
+        prop                       (:node/title key)
+        prop-fragment              (when prop (str ": " prop " - "))]
+    (or title (str prop-fragment string))))
+
+
 (defn extract-tag-values
   "Extracts `tag` values from `children-fn` children with `extractor-fn` from parser AST."
   [ast tag-selector children-fn extractor-fn]

--- a/src/cljc/athens/common_db.cljc
+++ b/src/cljc/athens/common_db.cljc
@@ -697,7 +697,8 @@
   (let [title->uid (get-page-uid db title)
         uid->title (get-page-title db uid)
         key       (:page/title relation)
-        keys      (->> [:block/uid (or uid title->uid)] (get-block db) :block/properties keys set)]
+        block     (get-block db [:block/uid (or uid title->uid)])
+        keys      (->> block :block/properties keys set)]
     ;; Fail on error conditions.
     (when-some [fail-msg (cond
                            (and uid uid->title)
@@ -712,7 +713,10 @@
 
                            ;; TODO: this could be idempotent and instead overwrite the name.
                            (and key (keys key))
-                           (str "Location already contains key: " key))]
+                           (str "Location already contains key: " key)
+
+                           (and (#{:before :after} relation) (:block/key block))
+                           (str "Location is a property, cannot use :after/:before relation."))]
       (throw (ex-info fail-msg position)))))
 
 

--- a/src/cljc/athens/common_events/resolver/order.cljc
+++ b/src/cljc/athens/common_events/resolver/order.cljc
@@ -1,5 +1,5 @@
 (ns athens.common-events.resolver.order
-  (:refer-clojure :exclude [remove])
+  (:refer-clojure :exclude [get remove])
   (:require
     [clojure.core :as c]))
 
@@ -15,15 +15,36 @@
   (vec (concat (take n v) [x] (drop n v))))
 
 
+(defn- index-of
+  [v x]
+  (let [n (.indexOf v x)]
+    (if (= n -1)
+      nil
+      n)))
+
+
+(defn get
+  "Get position defined by relation to target in v."
+  [v relation target]
+  (let [n (when (and target (#{:before :after} relation))
+            (index-of v target))]
+    (cond
+      (= relation :first)         (first v)
+      (= relation :last)          (last v)
+      (and n
+           (= relation :before)
+           (> n 0))               (nth v (dec n))
+      (and n
+           (= relation :after)
+           (< n (dec (count v)))) (nth v (inc n)))))
+
+
 (defn insert
   "Insert x in v, in a position defined by relation to target.
   See athens.common-events.graph.schema for position values."
   [v x relation target]
   (let [n (when (and target (#{:before :after} relation))
-            (let [n (.indexOf v target)]
-              (if (= n -1)
-                nil
-                n)))]
+            (index-of v target))]
     (cond
       (= relation :first)  (into [x] v)
       (= relation :last)   (into v [x])

--- a/src/cljc/athens/common_events/resolver/position.cljc
+++ b/src/cljc/athens/common_events/resolver/position.cljc
@@ -28,8 +28,9 @@
   (let [parent-children  (common-db/get-children-uids db [:block/uid parent-uid])
         parent-children' (order/remove parent-children uid)
         reorder          (order/reorder parent-children parent-children' order/block-map-fn)
-        update-parent    [[:db/retract [:block/uid parent-uid] :block/children [:block/uid uid]]]]
-    (concat reorder update-parent)))
+        update-parent    [[:db/retract [:block/uid parent-uid] :block/children [:block/uid uid]]]
+        remove-order     [[:db/retract [:block/uid uid] :block/order]]]
+    (concat reorder update-parent remove-order)))
 
 
 (defn move-child-within

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -1,6 +1,7 @@
 (ns athens.db
   (:require
     [athens.common-db :as common-db]
+    [athens.common-events.resolver.order :as order]
     [athens.common.logging :as log]
     [athens.common.sentry :refer-macros [defntrace]]
     [athens.electron.utils :as electron.utils]
@@ -379,15 +380,15 @@
 
 (defntrace deepest-child-block
   [id]
-  (let [document (->> (d/pull @dsdb '[:block/order :block/uid :block/open {:block/children ...}] id)
-                      sort-block-children)]
-    (loop [block document]
-      (let [{:block/keys [children open]} block
-            n (count children)]
-        (if (or (zero? n)
+  (let [db @dsdb]
+    (loop [uid (common-db/get-block-uid db id)]
+      (let [eid [:block/uid uid]
+            open (-> db (d/entity eid) :block/open)
+            children (common-db/sorted-prop+children-uids db eid)]
+        (if (or (zero? (count children))
                 (not open))
-          block
-          (recur (get children (dec n))))))))
+          (common-db/get-block db eid)
+          (recur (last children)))))))
 
 
 (defntrace search-exact-node-title
@@ -443,37 +444,39 @@
              (map #(dissoc % :block/_children)))))))))
 
 
+(defn sibling-uids
+  [uid]
+  (->> [:block/uid uid]
+       get-parent
+       :block/uid
+       (vector :block/uid)
+       (common-db/sorted-prop+children-uids @dsdb)))
+
+
 (defn nth-sibling
-  "Find sibling that has order+n of current block.
-  Negative n means previous sibling.
-  Positive n means next sibling."
-  [uid n]
-  (let [block      (get-block [:block/uid uid])
-        {:block/keys [order]} block
-        find-order (+ n order)]
-    (d/q '[:find (pull ?sibs [*]) .
-           :in $ % ?curr-uid ?find-order
-           :where
-           (siblings ?curr-uid ?sibs)
-           [?sibs :block/order ?find-order]]
-         @dsdb rules uid find-order)))
+  "Find sibling that has relation to current block.
+  Relation can be :before or :after."
+  [uid relation]
+  (-> (sibling-uids uid)
+      (order/get relation uid)
+      (->> (vector :block/uid))
+      get-block))
 
 
 (defntrace prev-block-uid
-  "If order 0, go to parent (if not a page).
-   If order n but block is closed, go to prev sibling.
-   If order n and block is OPEN, go to prev sibling's deepest child."
+  "If first sibling, go to parent (if not a page).
+   If block is closed, go to prev sibling.
+   If block is OPEN, go to prev sibling's deepest child."
   [uid]
   (let [[uid embed-id]                (uid-and-embed-id uid)
-        block                         (get-block [:block/uid uid])
-        parent                        (get-parent [:block/uid uid])
-        prev-sibling                  (nth-sibling uid -1)
+        siblings                      (sibling-uids uid)
+        prev-sibling                  (nth-sibling uid :before)
         {:block/keys      [open]
          prev-sibling-uid :block/uid} prev-sibling
         prev-block                    (cond
-                                        (zero? (:block/order block)) parent
-                                        (false? open)                prev-sibling
-                                        (true? open)                 (deepest-child-block [:block/uid prev-sibling-uid]))
+                                        (= uid (first siblings)) (get-parent [:block/uid uid])
+                                        (false? open)            prev-sibling
+                                        (true? open)             (deepest-child-block [:block/uid prev-sibling-uid]))
         prev-block-uid                (:block/uid prev-block)]
     (when (and prev-block-uid
                (not (:node/title prev-block)))
@@ -486,7 +489,7 @@
   If parent is root, go to next sibling."
   [uid]
   (loop [uid uid]
-    (let [sib    (nth-sibling uid +1)
+    (let [sib    (nth-sibling uid :after)
           parent (get-parent [:block/uid uid])
           {node :node/title}   (get-block [:block/uid uid])]
       (if (or sib (:node/title parent) node)
@@ -496,19 +499,20 @@
 
 (defn next-block-uid
   "1-arity:
-    if open and children, go to child 0
+    if open and children, go to first sibling
     else recursively find next sibling of parent
   2-arity:
     used for multi-block-selection; ignores child blocks"
   ([uid]
    (let [[uid embed-id]       (uid-and-embed-id uid)
-         block                (->> (get-block [:block/uid uid])
-                                   sort-block-children)
-         {:block/keys [children open] node :node/title} block
+         props+children       (common-db/sorted-prop+children-uids @dsdb [:block/uid uid])
+         {:block/keys [open]
+          node :node/title}   (get-block [:block/uid uid])
          next-block-recursive (next-sibling-recursively uid)
          next-block           (cond
-                                (and (or open node) children) (first children)
-                                next-block-recursive          next-block-recursive)]
+                                (and (or open node)
+                                     (seq props+children)) (get-block [:block/uid (first props+children)])
+                                next-block-recursive       next-block-recursive)]
      (cond-> (:block/uid next-block)
 
        ;; only go to next block if it's part of current embed scheme

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -344,8 +344,9 @@
            ;; Found the page.
            (:node/title b) (conj res b)
            ;; Recur with the parent.
-           :else           (recur (first (:block/_children b))
-                                  (conj res (dissoc b :block/_children)))))
+           :else           (recur (or (first (:block/_children b))
+                                      (:block/property-of b))
+                                  (conj res (dissoc b :block/_children :block/property-of)))))
        (rest)
        (reverse)
        vec))
@@ -354,7 +355,10 @@
 (defntrace get-parents-recursively
   [id]
   (when (d/entity @dsdb id)
-    (->> (d/pull @dsdb '[:db/id :node/title :block/uid :block/string :edit/time {:block/_children ...}] id)
+    (->> (d/pull @dsdb '[:db/id :node/title :block/uid :block/string :edit/time
+                         {:block/property-of ...}
+                         {:block/_children ...}]
+                 id)
          shape-parent-query)))
 
 

--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -368,16 +368,12 @@
 
 (defntrace get-block
   [id]
-  (when (d/entity @dsdb id)
-    (d/pull @dsdb '[:db/id :node/title :block/uid :block/order :block/string {:block/children [:block/uid :block/order]} :block/open] id)))
+  (common-db/get-block @dsdb id))
 
 
 (defntrace get-parent
   [id]
-  (-> (d/entity @dsdb id)
-      :block/_children
-      first
-      :db/id
+  (-> (common-db/get-parent-eid @dsdb id)
       get-block))
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -27,6 +27,7 @@
     [athens.util                          :as util]
     [athens.utils.sentry                  :as sentry]
     [athens.views.blocks.textarea-keydown :as textarea-keydown]
+    [clojure.pprint                       :as pp]
     [clojure.string                       :as string]
     [datascript.core                      :as d]
     [day8.re-frame.async-flow-fx]
@@ -748,8 +749,8 @@
         (let [explanation (-> schema/event
                               (m/explain event)
                               (me/humanize))]
-          (log/warn "Not sending invalid event. Error:" (pr-str explanation)
-                    "\nInvalid event was:" (pr-str event))
+          (log/warn "Not sending invalid event. Error:" (with-out-str (pp/pprint explanation))
+                    "\nInvalid event was:" (with-out-str (pp/pprint event)))
           {:fx [[:dispatch [:fail-resolve-forward-transact event]]]})
 
 

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -966,7 +966,7 @@
          block           (common-db/get-block db [:block/uid uid])
          {:block/keys [children order] :or {children []}} block
          parent          (common-db/get-parent db [:block/uid uid])
-         prev-block-uid  (common-db/prev-block-uid db uid)
+         prev-block-uid  (db/prev-block-uid uid)
          prev-block      (common-db/get-block db [:block/uid prev-block-uid])
          prev-sib-order  (dec (:block/order block))
          prev-sib        (some->> (common-db/prev-sib db uid prev-sib-order)
@@ -1407,7 +1407,7 @@
 
 (defn get-prev-block-uid-and-target-rel
   [uid]
-  (let [prev-block-uid            (:block/uid (common-db/nth-sibling @db/dsdb uid -1))
+  (let [prev-block-uid            (:block/uid (db/nth-sibling uid -1))
         prev-block-children?      (if prev-block-uid
                                     (seq (:block/children (common-db/get-block @db/dsdb [:block/uid prev-block-uid])))
                                     nil)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -968,9 +968,7 @@
          parent          (common-db/get-parent db [:block/uid uid])
          prev-block-uid  (db/prev-block-uid uid)
          prev-block      (common-db/get-block db [:block/uid prev-block-uid])
-         prev-sib-order  (dec (:block/order block))
-         prev-sib        (some->> (common-db/prev-sib db uid prev-sib-order)
-                                  (common-db/get-block db))
+         prev-sib        (db/nth-sibling uid :before)
          event           (cond
                            (or (not parent)
                                root-embed?
@@ -1407,7 +1405,7 @@
 
 (defn get-prev-block-uid-and-target-rel
   [uid]
-  (let [prev-block-uid            (:block/uid (db/nth-sibling uid -1))
+  (let [prev-block-uid            (:block/uid (db/nth-sibling uid :before))
         prev-block-children?      (if prev-block-uid
                                     (seq (:block/children (common-db/get-block @db/dsdb [:block/uid prev-block-uid])))
                                     nil)

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1593,7 +1593,7 @@
 (reg-event-fx
   :block/move
   (fn [_ [_ {:keys [source-uid target-uid target-rel local-string] :as args}]]
-    (log/info ":block/move args" (pr-str args))
+    (log/debug ":block/move args" (pr-str args))
     (let [sentry-tx (close-and-get-sentry-tx "block/move")
           event     (-> (block-save-block-move-composite-op source-uid target-uid target-rel local-string)
                         common-events/build-atomic-event)]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1287,7 +1287,8 @@
 
 
 (defn enter
-  "- If block is open, has children, and caret at end, create new child
+  "- If block is a property, always open and create a new child
+  - If block is open, has children, and caret at end, create new child
   - If block is CLOSED, has children, and caret at end, add a sibling block.
   - If value is empty and a root block, add a sibling block.
   - If caret is not at start, split block in half.
@@ -1316,6 +1317,11 @@
 
         {:keys [value start]} d-key-down
         event                 (cond
+                                (:block/key block)
+                                [:enter/open-block-add-child {:block    block
+                                                              :new-uid  new-uid
+                                                              :embed-id embed-id}]
+
                                 (and (:block/open block)
                                      (not-empty (:block/children block))
                                      (= start (count value)))

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -432,7 +432,7 @@
                            (and (zero? editing-idx) (> n 1)) (pop selected-items)
                            (:node/title prev-block) selected-items
                            ;; if prev block is parent, replace editing/uid and first item w parent; remove children
-                           (= (:block/uid parent) prev-block-o-uid) (let [parent-children (-> (map #(:block/uid %) (:block/children parent))
+                           (= (:block/uid parent) prev-block-o-uid) (let [parent-children (-> (common-db/sorted-prop+children-uids @db/dsdb [:block/uid prev-block-uid])
                                                                                               set)
                                                                           to-keep         (->> selected-items
                                                                                                (map #(-> % db/uid-and-embed-id first))
@@ -964,16 +964,17 @@
          db              @db/dsdb
          [uid embed-id]  (common-db/uid-and-embed-id uid)
          block           (common-db/get-block db [:block/uid uid])
-         {:block/keys [children order] :or {children []}} block
+         children-uids   (common-db/sorted-prop+children-uids @db/dsdb [:block/uid uid])
          parent          (common-db/get-parent db [:block/uid uid])
          prev-block-uid  (db/prev-block-uid uid)
          prev-block      (common-db/get-block db [:block/uid prev-block-uid])
          prev-sib        (db/nth-sibling uid :before)
+         prev-sib-children-uids (common-db/sorted-prop+children-uids @db/dsdb [:block/uid (:block/uid prev-sib)])
          event           (cond
                            (or (not parent)
                                root-embed?
-                               (and (not-empty children) (not-empty (:block/children prev-sib)))
-                               (and (not-empty children) (= parent prev-block)))
+                               (and (seq children-uids) (seq prev-sib-children-uids))
+                               (and (seq children-uids) (= parent prev-block)))
                            nil
 
                            (:block/key block)
@@ -981,7 +982,8 @@
                                          :target-uid (:block/uid parent)
                                          :target-rel :first}]
 
-                           (and (empty? children) (:node/title parent) (zero? order) (clojure.string/blank? value))
+                           (and (empty? children-uids) (:node/title parent)
+                                (= uid (first children-uids)) (clojure.string/blank? value))
                            [:backspace/delete-only-child uid]
 
                            maybe-local-updates
@@ -1312,6 +1314,7 @@
         root-block?           (boolean (:node/title parent))
         context-root-uid      (get-in rfdb [:current-route :path-params :id])
         new-uid               (common.utils/gen-block-uid)
+        has-children?         (seq (common-db/sorted-prop+children-uids @db/dsdb [:block/uid uid]))
 
         {:keys [value start]} d-key-down
         event                 (cond
@@ -1321,7 +1324,7 @@
                                                               :embed-id embed-id}]
 
                                 (and (:block/open block)
-                                     (not-empty (:block/children block))
+                                     has-children?
                                      (= start (count value)))
                                 [:enter/add-child {:block    block
                                                    :new-uid  new-uid
@@ -1334,7 +1337,7 @@
                                                               :embed-id embed-id}]
 
                                 (and (not (:block/open block))
-                                     (not-empty (:block/children block))
+                                     has-children?
                                      (= start (count value)))
                                 [:enter/new-block {:block    block
                                                    :parent   parent
@@ -1405,13 +1408,16 @@
 
 (defn get-prev-block-uid-and-target-rel
   [uid]
-  (let [prev-block-uid            (:block/uid (db/nth-sibling uid :before))
+  (let [db                        @db/dsdb
+        prev-block-uid            (:block/uid (db/nth-sibling uid :before))
         prev-block-children?      (if prev-block-uid
-                                    (seq (:block/children (common-db/get-block @db/dsdb [:block/uid prev-block-uid])))
+                                    (seq (common-db/sorted-prop+children-uids db [:block/uid prev-block-uid]))
                                     nil)
-        target-rel                (if prev-block-children?
-                                    :last
-                                    :first)]
+        prop-key                  (common-db/property-key db [:block/uid uid])
+        target-rel                (cond
+                                    prop-key             {:page/title prop-key}
+                                    prev-block-children? :last
+                                    :else                :first)]
     [prev-block-uid target-rel]))
 
 
@@ -1436,9 +1442,7 @@
     ;;                 the local string  is reset to original value, since it has not been unfocused yet (which is currently the
     ;;                 transaction that updates the string).
     (let [sentry-tx                 (close-and-get-sentry-tx "indent")
-          block                     (wrap-span-no-new-tx "get-block"
-                                                         (common-db/get-block @db/dsdb [:block/uid uid]))
-          block-zero?               (zero? (:block/order block))
+          first-block?              (= uid (first (db/sibling-uids uid)))
           [prev-block-uid
            target-rel]              (wrap-span-no-new-tx "get-prev-block-uid-and-target-rel"
                                                          (get-prev-block-uid-and-target-rel uid))
@@ -1446,9 +1450,9 @@
                                                          (common-db/get-block @db/dsdb [:block/uid prev-block-uid]))
           ;; if sibling block is closed with children, open
           {sib-open     :block/open
-           sib-children :block/children
            sib-uid      :block/uid} sib-block
-          block-closed?             (and (not sib-open) sib-children)
+          block-closed?             (and (not sib-open)
+                                         (common-db/sorted-prop+children-uids @db/dsdb [:block/uid prev-block-uid]))
           sib-block-open-op         (when block-closed?
                                       (atomic-graph-ops/make-block-open-op sib-uid true))
           {:keys [start end]}       d-key-down
@@ -1462,12 +1466,12 @@
           new-titles                (graph-ops/ops->new-page-titles composite-ops)
           [_rm add]                 (graph-ops/structural-diff @db/dsdb composite-ops)
           event                     (common-events/build-atomic-event composite-ops)]
-      (log/debug "null-sib-uid" (and block-zero?
+      (log/debug "null-sib-uid" (and first-block?
                                      prev-block-uid)
                  ", args:" (pr-str args)
-                 ", block-zero?" block-zero?)
+                 ", first-block?" first-block?)
       (when (and prev-block-uid
-                 (not block-zero?))
+                 (not first-block?))
         {:fx [(transact-async-flow :indent event sentry-tx [])
               [:set-cursor-position [uid start end]]
               [:dispatch-n (cond-> []
@@ -1491,12 +1495,10 @@
                                                         (get-prev-block-uid-and-target-rel f-uid))
           same-parent?             (wrap-span-no-new-tx "same-parent"
                                                         (common-db/same-parent? dsdb sanitized-selected-uids))
-          first-block-order        (:block/order (wrap-span-no-new-tx "get-block"
-                                                                      (common-db/get-block dsdb [:block/uid f-uid])))
-          block-zero?              (zero? first-block-order)]
+          first-block?             (= f-uid (first (db/sibling-uids f-uid)))]
       (log/debug ":indent/multi same-parent?" same-parent?
-                 ", not block-zero?" (not  block-zero?))
-      (when (and same-parent? (not block-zero?))
+                 ", not first-block?" (not  first-block?))
+      (when (and same-parent? (not first-block?))
         {:fx [[:async-flow {:id             :indent-multi-async-flow
                             :db-path        [:async-flow :indent-multi]
                             :first-dispatch [:drop-multi/sibling {:source-uids sanitized-selected-uids
@@ -1510,9 +1512,15 @@
   (fn [{:keys [_db]} [_ {:keys [uid d-key-down context-root-uid embed-id local-string] :as args}]]
     (log/debug ":unindent args" (pr-str args))
     (let [sentry-tx                (close-and-get-sentry-tx "unindent")
+          db                       @db/dsdb
+          property-key             (common-db/property-key db [:block/uid uid])
           parent                   (wrap-span-no-new-tx "parent"
-                                                        (common-db/get-parent @db/dsdb
-                                                                              (common-db/e-by-av @db/dsdb :block/uid uid)))
+                                                        (common-db/get-parent db (common-db/e-by-av db :block/uid uid)))
+          is-parent-property?      (:block/key parent)
+          parent-of-parent         (->> parent
+                                        :db/id
+                                        (common-db/get-parent db)
+                                        :block/uid)
           is-parent-root-embed?    (= (some-> d-key-down
                                               :target
                                               (.. (closest ".block-embed"))
@@ -1523,14 +1531,13 @@
                                        (:node/title parent)
                                        (= context-root-uid (:block/uid parent)))
           {:keys [start end]}      d-key-down
-          block-save-block-move-op (block-save-block-move-composite-op uid
-                                                                       (:block/uid parent)
-                                                                       :after
-                                                                       local-string)
+          block-save-block-move-op (cond
+                                     property-key        (block-save-block-move-composite-op uid parent-of-parent {:page/title property-key} local-string)
+                                     is-parent-property? (block-save-block-move-composite-op uid parent-of-parent :first local-string)
+                                     :else               (block-save-block-move-composite-op uid (:block/uid parent) :after local-string))
           new-titles               (graph-ops/ops->new-page-titles block-save-block-move-op)
           [_rm add]                (graph-ops/structural-diff @db/dsdb block-save-block-move-op)
           event                    (common-events/build-atomic-event block-save-block-move-op)]
-
       (log/debug ":unindent do-nothing?" do-nothing?)
       (when-not do-nothing?
         {:fx [(transact-async-flow :unindent event sentry-tx [(focus-on-uid uid embed-id)])

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -978,6 +978,11 @@
                                (and (not-empty children) (= parent prev-block)))
                            nil
 
+                           (:block/key block)
+                           [:block/move {:source-uid uid
+                                         :target-uid (:block/uid parent)
+                                         :target-rel :first}]
+
                            (and (empty? children) (:node/title parent) (zero? order) (clojure.string/blank? value))
                            [:backspace/delete-only-child uid]
 

--- a/src/cljs/athens/reactive.cljs
+++ b/src/cljs/athens/reactive.cljs
@@ -99,6 +99,7 @@
 
 (def block-document-pull-vector
   (vec (concat '[:db/id :block/uid :block/string :block/open :block/_refs
+                 {:block/key [:node/title]}
                  {:block/children [:block/uid :block/order]}]
                recursive-properties-document-pull-vector)))
 

--- a/src/cljs/athens/reactive.cljs
+++ b/src/cljs/athens/reactive.cljs
@@ -77,6 +77,20 @@
        rseq))
 
 
+(defn get-reactive-linked-properties
+  "For node page properties references UI."
+  [eid]
+  (->> @(p/pull db/dsdb '[:block/_key] eid)
+       :block/_key
+       (mapv :db/id)
+       db/merge-parents-and-block
+       db/group-by-parent
+       (sort-by #(-> % first second))
+       (map #(vector (ffirst %) (second %)))
+       vec
+       rseq))
+
+
 (def recursive-properties-document-pull-vector
   '[{:block/_property-of [:block/uid :block/string :block/order :block/refs
                           {:block/key [:node/title]}
@@ -113,7 +127,10 @@
 
 (defntrace get-reactive-parents-recursively
   [id]
-  (->> @(p/pull db/dsdb '[:db/id :node/title :block/uid :block/string {:block/_children ...}] id)
+  (->> @(p/pull db/dsdb '[:db/id :node/title :block/uid :block/string :edit/time
+                          {:block/property-of ...}
+                          {:block/_children ...}]
+                id)
        db/shape-parent-query))
 
 

--- a/src/cljs/athens/views/blocks/autocomplete_search.cljs
+++ b/src/cljs/athens/views/blocks/autocomplete_search.cljs
@@ -29,7 +29,7 @@
         inline-search-results (rf/subscribe [::inline-search.subs/results block-uid])
         inline-search-query   (rf/subscribe [::inline-search.subs/query block-uid])]
     (fn [block {:as _state-hooks} _last-event _state]
-      (let [is-open (some #(= % @inline-search-type) [:page :block :hashtag :template])]
+      (let [is-open (some #(= % @inline-search-type) [:page :block :hashtag :template :property])]
         [:> Autocomplete {:event   @last-event
                           :isOpen  is-open
                           :onClose #(rf/dispatch [::inline-search.events/close! block-uid])}

--- a/src/cljs/athens/views/blocks/autocomplete_search.cljs
+++ b/src/cljs/athens/views/blocks/autocomplete_search.cljs
@@ -17,6 +17,7 @@
         f      (case @type
                  :hashtag  textarea-keydown/auto-complete-hashtag
                  :template textarea-keydown/auto-complete-template
+                 :property textarea-keydown/auto-complete-property
                  textarea-keydown/auto-complete-inline)]
     (f uid state-hooks target expansion)))
 
@@ -41,9 +42,9 @@
                        :fontStyle "italics"}
               (str "Search for a " (symbol @inline-search-type))]
              (doall
-               (for [[i {:keys [node/title block/string block/uid]}] (map-indexed list @inline-search-results)]
+               (for [[i {:keys [node/title block/string block/uid text]}] (map-indexed list @inline-search-results)]
                  [:> AutocompleteButton {:key      (str "inline-search-item" uid)
                                          :isActive (= i @inline-search-index)
                                          :onClick  (fn [_] (inline-item-click state-hooks (:block/uid block) (or title uid)))
                                          :id       (str "inline-search-item" uid)}
-                  (or title string)]))))]))))
+                  (or text title string)]))))]))))

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -163,7 +163,6 @@
                  linked-ref-uid]}     linked-ref-data
          {:block/keys [uid
                        original-uid]} block
-         block-o                      (reactive/get-reactive-block-document [:block/uid uid])
          local-value                  (r/atom nil)
          old-value                    (r/atom nil)
          show-edit?                   (r/atom false)
@@ -200,11 +199,12 @@
         (fn render-block
           [block linked-ref-data opts]
           (let [ident                 [:block/uid (or original-uid uid)]
+                block-o               (reactive/get-reactive-block-document ident)
                 {:block/keys [uid
                               string
                               open
                               children
-                              _refs]} (merge (reactive/get-reactive-block-document ident) block)
+                              _refs]} (merge block-o block)
                 children-uids         (set (map :block/uid children))
                 uid-sanitized-block   (s/transform
                                         (specter-recursive-path #(contains? % :block/uid))

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -64,7 +64,7 @@
 
           [:> Breadcrumb {:fontSize "xs" :color "foreground.secondary"}
            (doall
-             (for [{:keys [node/title block/string block/uid] :as breadcrumb-block}
+             (for [{:keys [block/uid] :as breadcrumb-block}
                    (if (or @inline-ref-open?
                            (not @inline-ref-focus?))
                      @inline-ref-parents
@@ -85,7 +85,7 @@
                                                    (rf/dispatch [::inline-refs.events/set-block! orig-uid new-B])
                                                    (rf/dispatch [::inline-refs.events/set-parents! orig-uid new-P])
                                                    (rf/dispatch [::inline-refs.events/set-focus! orig-uid false]))))}
-                 [parse-renderer/parse-and-render (or title string) uid]]]))]]
+                 [parse-renderer/parse-and-render (common-db/breadcrumb-string @db/dsdb uid) uid]]]))]]
 
          (when @inline-ref-open?
            (if @inline-ref-focus?

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -237,11 +237,10 @@
          (when (and (seq properties)
                     (or (and (true? linked-ref) @linked-ref-open?)
                         (and (false? linked-ref) open)))
-           (for [child (common-db/sort-block-properties properties)
-                 :let  [child-uid (:block/uid child)]]
-             ^{:key (:db/id child)}
-             [block-el child
-              (assoc linked-ref-data :initial-open (contains? parent-uids child-uid))
+           (for [prop (common-db/sort-block-properties properties)]
+             ^{:key (:db/id prop)}
+             [block-el prop
+              (assoc linked-ref-data :initial-open (contains? parent-uids (:block/uid prop)))
               opts]))
 
          ;; Children

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -166,8 +166,9 @@
                           _refs]} (reactive/get-reactive-block-document [:block/uid uid])]
         [:<>
          [:div.block-body
-          (when (or (seq children)
-                    (seq properties))
+          (when (and children?
+                     (or (seq children)
+                         (seq properties)))
             [:> Toggle {:isOpen  (if (or (and (true? linked-ref) @linked-ref-open?)
                                          (and (false? linked-ref) open))
                                    true

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -5,6 +5,7 @@
     ["/components/Block/Toggle"                :refer [Toggle]]
     ["/components/References/InlineReferences" :refer [ReferenceGroup ReferenceBlock]]
     ["@chakra-ui/react"                        :refer [VStack Button Breadcrumb BreadcrumbItem BreadcrumbLink HStack]]
+    [athens.common-db                          :as common-db]
     [athens.db                                 :as db]
     [athens.events.inline-refs                 :as inline-refs.events]
     [athens.events.linked-refs                 :as linked-ref.events]
@@ -233,9 +234,7 @@
 
          ;; Properties
          (when (seq properties)
-           (for [child (->> properties
-                            (sort-by (comp str first))
-                            (map second))
+           (for [child (common-db/sort-block-properties properties)
                  :let  [child-uid (:block/uid child)]]
              ^{:key (:db/id child)}
              [block-el child

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -166,8 +166,8 @@
                           _refs]} (reactive/get-reactive-block-document [:block/uid uid])]
         [:<>
          [:div.block-body
-          (when (and children?
-                     (seq children))
+          (when (or (seq children)
+                    (seq properties))
             [:> Toggle {:isOpen  (if (or (and (true? linked-ref) @linked-ref-open?)
                                          (and (false? linked-ref) open))
                                    true
@@ -233,7 +233,9 @@
            [inline-linked-refs-el block-el uid])
 
          ;; Properties
-         (when (seq properties)
+         (when (and (seq properties)
+                    (or (and (true? linked-ref) @linked-ref-open?)
+                        (and (false? linked-ref) open)))
            (for [child (common-db/sort-block-properties properties)
                  :let  [child-uid (:block/uid child)]]
              ^{:key (:db/id child)}

--- a/src/cljs/athens/views/blocks/internal_representation.cljs
+++ b/src/cljs/athens/views/blocks/internal_representation.cljs
@@ -1,6 +1,8 @@
 (ns athens.views.blocks.internal-representation
+  (:refer-clojure :exclude [descendants])
   (:require
     [athens.common-db :as common-db]
+    [athens.common-events.bfs :as bfs]
     [athens.common.utils :as utils]
     [athens.parser  :as parser]
     [clojure.set  :as set]
@@ -9,11 +11,16 @@
     [datascript.core :as d]))
 
 
+(defn descendants
+  [{:block/keys [children properties]}]
+  (concat children (vals properties)))
+
+
 (defn new-uids-map
   "From Athens representation, extract the uids and create a mapping to new uids."
   [tree]
   (let [all-old-uids (mapcat #(->> %
-                                   (tree-seq :block/children :block/children)
+                                   (tree-seq bfs/has-descendants? descendants)
                                    (mapv :block/uid))
                              tree)
         mapped-uids (reduce #(assoc %1 %2 (utils/gen-block-uid)) {} all-old-uids)] ; Replace with zipmap

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -329,7 +329,7 @@
                          :block/uid)
          title (or (common-db/get-page-title @db/dsdb expansion)
                    (subs @read-value start-idx end))]
-     (if (or (nil? title)
+     (if (or (empty? title)
              (nil? parent-uid))
        (rf/dispatch [::inline-search.events/close! block-uid])
        (do

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -104,7 +104,8 @@
      ["YouTube Embed" YoutubeIcon "{{[[youtube]]: }}" nil 2]
      ["iframe Embed"  HTMLEmbedIcon "{{iframe: }}" nil 2]
      ["Block Embed"   BlockEmbedIcon "{{[[embed]]: (())}}" nil 4]
-     ["Template"      TemplateIcon ";;" nil nil]]
+     ["Template"      TemplateIcon ";;" nil nil]
+     ["Property"      TemplateIcon "::" nil nil]]
     @(subscribe [:db-picker/remote-db?])
     (conj (let [username (:username @(rf/subscribe [:presence/current-user]))]
             [(str "Me (" username ")") PersonIcon (fn [] (str "[[" username "]]")) nil nil]))))
@@ -136,12 +137,14 @@
                           :page db/search-in-node-title
                           :hashtag db/search-in-node-title
                           :template db/search-in-block-content
+                          :property db/search-in-node-title
                           :slash filter-slash-options)
         regex           (case type
                           :block #"(?s).*\(\("
                           :page #"(?s).*\[\["
                           :hashtag #"(?s).*#"
                           :template #"(?s).*;;"
+                          :property #"(?s).*::"
                           :slash #"(?s).*/")
         find            (re-find regex head)
         query-start-idx (count find)
@@ -209,6 +212,10 @@
            (rf/dispatch [::inline-search.events/clear-query! block-uid]))))
      (when (= caption "Template")
        (rf/dispatch [::inline-search.events/set-type! block-uid :template])
+       (rf/dispatch [::inline-search.events/clear-results! block-uid])
+       (rf/dispatch [::inline-search.events/clear-query! block-uid]))
+     (when (= caption "Property")
+       (rf/dispatch [::inline-search.events/set-type! block-uid :property])
        (rf/dispatch [::inline-search.events/clear-results! block-uid])
        (rf/dispatch [::inline-search.events/clear-query! block-uid])))))
 
@@ -299,6 +306,38 @@
          (set-selection target (- start-idx 2) start)
          (replace-selection-with "")
          (dispatch [:paste-internal block-uid @read-value target-ir])
+         (rf/dispatch [::inline-search.events/close! block-uid]))))))
+
+
+;; see `auto-complete-slash` for how this arity-overloaded
+;; function is used.
+(defn auto-complete-property
+  ([block-uid {:as state-hooks} e]
+   (let [inline-search-index (rf/subscribe [::inline-search.subs/index block-uid])
+         inline-search-results (rf/subscribe [::inline-search.subs/results block-uid])
+         target (.. e -target)
+         {:keys [block/uid]} (nth @inline-search-results @inline-search-index nil)
+         expansion uid]
+     (auto-complete-property block-uid state-hooks target expansion)))
+
+  ([block-uid {:keys [read-value] :as _state-hooks} target expansion]
+   (let [{:keys [start head]} (destruct-target target)
+         start-idx (count (re-find #"(?s).*::" head))
+         {:keys [end]} (destruct-target target)
+         parent-uid (->> [:block/uid block-uid]
+                         (common-db/get-parent @db/dsdb)
+                         :block/uid)
+         title (or (common-db/get-page-title @db/dsdb expansion)
+                   (subs @read-value start-idx end))]
+     (if (or (nil? title)
+             (nil? parent-uid))
+       (rf/dispatch [::inline-search.events/close! block-uid])
+       (do
+         (set-selection target (- start-idx 2) start)
+         (replace-selection-with "")
+         (dispatch [:block/move {:source-uid block-uid
+                                 :target-uid parent-uid
+                                 :target-rel {:page/title title}}])
          (rf/dispatch [::inline-search.events/close! block-uid]))))))
 
 
@@ -506,7 +545,8 @@
                                   :page     (auto-complete-inline uid state-hooks e)
                                   :block    (auto-complete-inline uid state-hooks e)
                                   :hashtag  (auto-complete-hashtag uid state-hooks e)
-                                  :template (auto-complete-template uid state-hooks e))
+                                  :template (auto-complete-template uid state-hooks e)
+                                  :property (auto-complete-property uid state-hooks e))
       ;; shift-enter: add line break to textarea and move cursor to the next line.
       shift                     (replace-selection-with "\n")
       ;; cmd-enter: cycle todo states, then move cursor to the end of the line.
@@ -776,6 +816,8 @@
       (and (= "#" look-behind-char) (= type :hashtag)) (rf/dispatch [::inline-search.events/close! uid])
       ;; semicolon: close dropdown
       (and (= ";" look-behind-char) (= type :template)) (rf/dispatch [::inline-search.events/close! uid])
+      ;; colon: close dropdown
+      (and (= ":" look-behind-char) (= type :property)) (rf/dispatch [::inline-search.events/close! uid])
       ;; dropdown is open: update query
       type (update-query uid head "" type))))
 
@@ -817,6 +859,13 @@
                                       (rf/dispatch [::inline-search.events/set-index! uid 0])
                                       (rf/dispatch [::inline-search.events/clear-results! uid])
                                       (rf/dispatch [::inline-search.events/clear-query! uid]))
+      (and (= key ":" look-behind-char)
+           (nil? type))             (do
+                                      (rf/dispatch [::inline-search.events/set-type! uid :property])
+                                      (rf/dispatch [::inline-search.events/set-index! uid 0])
+                                      (rf/dispatch [::inline-search.events/clear-results! uid])
+                                      (rf/dispatch [::inline-search.events/clear-query! uid]))
+
       type (update-query uid head key type))))
 
 

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -129,7 +129,8 @@
 (defn search-or-create-node-title
   [query]
   (let [results (db/search-in-node-title query)
-        create  (if (seq query)
+        create  (if (and (seq query)
+                         (not (some #(= query (:node/title %)) results)))
                   [{:text (str "Create property: " query)}]
                   [])]
     (into create results)))

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -337,7 +337,9 @@
          (replace-selection-with "")
          (dispatch [:block/move {:source-uid block-uid
                                  :target-uid parent-uid
-                                 :target-rel {:page/title title}}])
+                                 :target-rel {:page/title title}
+                                 :local-string (str (subs @read-value 0 start-idx)
+                                                    (subs @read-value end))}])
          (rf/dispatch [::inline-search.events/close! block-uid]))))))
 
 

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -3,6 +3,8 @@
     ["/components/Page/Page" :refer [PageHeader PageBody PageFooter TitleContainer]]
     ["/components/References/References" :refer [PageReferences ReferenceBlock ReferenceGroup]]
     ["@chakra-ui/react" :refer [Breadcrumb BreadcrumbItem BreadcrumbLink]]
+    [athens.common-db :as common-db]
+    [athens.db :as db]
     [athens.parse-renderer :as parse-renderer]
     [athens.reactive :as reactive]
     [athens.router :as router]
@@ -78,12 +80,12 @@
   (let [parents (reactive/get-reactive-parents-recursively id)]
     [:> Breadcrumb {:gridArea "breadcrumb" :opacity 0.75}
      (doall
-       (for [{:keys [node/title block/string] breadcrumb-uid :block/uid} parents]
+       (for [{breadcrumb-uid :block/uid} parents]
          ^{:key breadcrumb-uid}
          [:> BreadcrumbItem {:key (str "breadcrumb-" breadcrumb-uid)}
           [:> BreadcrumbLink {:onClick #(breadcrumb-handle-click % uid breadcrumb-uid)}
            [:span {:style {:pointer-events "none"}}
-            [parse-renderer/parse-and-render (or title string)]]]]))]))
+            [parse-renderer/parse-and-render (common-db/breadcrumb-string @db/dsdb breadcrumb-uid)]]]]))]))
 
 
 (defn block-page-el

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -401,7 +401,7 @@
         (reset! state init-state)
         (reset! unlinked-refs [])
         (reset! block-uid (:block/uid node)))
-      (let [{:block/keys [children uid] title :node/title}                      node
+      (let [{:block/keys [children uid properties] title :node/title}           node
             {:alert/keys [message confirm-fn cancel-fn confirm-text] alert-show :alert/show} @state
             daily-note?                                                         (dates/is-daily-note uid)
             on-daily-notes?                                                     (= :home @(subscribe [:current-route/name]))
@@ -451,6 +451,14 @@
             [menu-dropdown node daily-note?]]]]
 
          [:> PageBody
+
+          ;; Properties
+          (when (seq properties)
+            (for [child (->> properties
+                             (sort-by (comp str first))
+                             (map second))]
+              ^{:key (:db/id child)}
+              [blocks/block-el child]))
 
           ;; Children
           (if (empty? children)

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -487,9 +487,9 @@
           ;; Properties
           [:div
            (when (seq properties)
-             (for [child (common-db/sort-block-properties properties)]
-               ^{:key (:db/id child)}
-               [blocks/block-el child]))]
+             (for [prop (common-db/sort-block-properties properties)]
+               ^{:key (:db/id prop)}
+               [blocks/block-el prop]))]
 
           ;; Children
           [:div

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -454,9 +454,7 @@
 
           ;; Properties
           (when (seq properties)
-            (for [child (->> properties
-                             (sort-by (comp str first))
-                             (map second))]
+            (for [child (common-db/sort-block-properties properties)]
               ^{:key (:db/id child)}
               [blocks/block-el child]))
 

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -480,20 +480,23 @@
 
          [:> PageBody
 
+          (when (and (empty? properties)
+                     (empty? children))
+            [placeholder-block-el uid])
+
           ;; Properties
-          (when (seq properties)
-            (for [child (common-db/sort-block-properties properties)]
-              ^{:key (:db/id child)}
-              [blocks/block-el child]))
+          [:div
+           (when (seq properties)
+             (for [child (common-db/sort-block-properties properties)]
+               ^{:key (:db/id child)}
+               [blocks/block-el child]))]
 
           ;; Children
-          (if (empty? children)
-            [placeholder-block-el uid]
-            [:div
-             (for [{:block/keys [uid] :as child} children]
-               ^{:key uid}
-               [perf-mon/hoc-perfmon {:span-name "block-el"}
-                [blocks/block-el child]])])]
+          [:div
+           (for [{:block/keys [uid] :as child} children]
+             ^{:key uid}
+             [perf-mon/hoc-perfmon {:span-name "block-el"}
+              [blocks/block-el child]])]]
 
          ;; References
          [:> PageFooter

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -284,13 +284,13 @@
                          :variant "strict"
                          :color "foreground.secondary"}
           (doall
-            (for [{:keys [node/title block/string block/uid]} parents]
+            (for [{:keys [block/uid]} parents]
               [:> BreadcrumbItem {:key (str "breadcrumb-" uid)}
                [:> BreadcrumbLink
                 {:onClick #(let [new-B (db/get-block [:block/uid uid])
                                  new-P (drop-last parents)]
                              (swap! state assoc :block new-B :parents new-P))}
-                [parse-and-render (or title string) uid]]]))]
+                [parse-and-render (common-db/breadcrumb-string @db/dsdb uid) uid]]]))]
          [:> Box {:class "block-embed"}
           [blocks/block-el
            (recursively-modify-block-for-embed block embed-id)

--- a/src/js/components/Block/Container.tsx
+++ b/src/js/components/Block/Container.tsx
@@ -76,10 +76,10 @@ const _Container = ({ children, isDragging, isSelected, isOpen, hasChildren, has
         },
         ".block-body": {
           display: "grid",
-          gridTemplateColumns: "1em 1em 1fr auto",
+          gridTemplateColumns: "1em auto 1em 1fr auto",
           gridTemplateRows: "0 1fr 0",
           gridTemplateAreas:
-            "'above above above above above' 'toggle bullet content refs presence' 'below below below below below'",
+            "'above above above above above above' 'toggle name bullet content refs presence' 'below below below below below below'",
           borderRadius: "0.5rem",
           minHeight: '2em',
           position: "relative",

--- a/src/js/components/Block/PropertyName.tsx
+++ b/src/js/components/Block/PropertyName.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { Button } from '@chakra-ui/react';
+
+interface PropertyNameProps extends React.HTMLAttributes<HTMLButtonElement> {
+  name: string;
+}
+
+export const PropertyName = (props: PropertyNameProps) => {
+  const { name, onClick } = props;
+
+  return (
+    <Button
+      className="prop-name"
+      bg="transparent"
+      aria-label="Property name"
+      draggable={true}
+      gridArea="name"
+      flexShrink={0}
+      position='relative'
+      appearance="none"
+      border="0"
+      color="foreground.secondary"
+      display="flex"
+      placeItems="center"
+      placeContent="center"
+      alignSelf="flex-start"
+      minHeight="inherit"
+      zIndex={2}
+      minWidth="0"
+      fontSize="inherit"
+      h="auto"
+      size="sm"
+      p={0}
+      sx={{
+      "svg": {
+        pointerEvents: "none",
+        transform: "scale(1.1001)", // Prevents the bullet being squished
+        overflow: "visible", // Prevents the bullet being cropped
+        width: "1em",
+        height: "1em",
+        "*": {
+          vectorEffect: "non-scaling-stroke"
+        }
+      },
+      "circle": {
+        transformOrigin: 'center',
+        transition: 'all 0.15s ease-in-out',
+        stroke: "transparent",
+        strokeWidth: "0.125em",
+        fill: "currentColor",
+      }
+
+      }}
+    onClick={onClick}
+    >
+      <svg viewBox="0 0 24 24">
+        <circle cx="12" cy="6" r="3.5" />
+        <circle cx="12" cy="18" r="3.5" />
+      </svg>
+      {name}
+    </Button>
+  )
+};

--- a/test/athens/common_events/resolver/order_test.cljc
+++ b/test/athens/common_events/resolver/order_test.cljc
@@ -1,5 +1,5 @@
 (ns athens.common-events.resolver.order-test
-  (:refer-clojure :exclude [remove])
+  (:refer-clojure :exclude [get remove])
   (:require
     [athens.common-events.resolver.order :as order]
     [clojure.test :as t]))
@@ -10,6 +10,24 @@
     [1 2 3] [2 3] 1
     [1 2 3] [1 3] 2
     [1 2 3] [1 2] 3))
+
+
+(t/deftest get
+  (t/are [v x rel target] (= x (order/get v rel target))
+    [:x 1 2 3] :x :first nil
+    [1 2 3 :x] :x :last nil
+    [:x 1 2 3] :x :before 1
+    [1 :x 2 3] :x :after 1
+    [1 :x 2 3] :x :before 2
+    [1 2 :x 3] :x :after 2
+    [1 2 :x 3] :x :before 3
+    [1 2 3 :x] :x :after 3
+    [1 2 3]   nil :after 4
+    [1 2 3]   nil :before 4
+    [1 2 3]   nil :after 3
+    [1 2 3]   nil :before 1
+    []        nil :first nil
+    []        nil :last nil))
 
 
 (t/deftest insert


### PR DESCRIPTION
- feat: render properties in outliner
- feat: create properties via ::
- fix: removing a child should remove the order number
- feat: backspace at the start of a property will move it to first child
- fix: use db/get-block and get-parent should use common-db helpers
- feat: handle enter on props
- rfct: remove duplicated prev-block-uid code
- rfct: move property sorting into own fn
- feat: add order/get
- feat: handle up/down for properties
- feat: support indent/unindent in properties
- fix: :after/:before prop is not a valid location
- feat: show linked props on page
- feat: show properties in breadcrumbs
- rfct: remove unused rules
- fix: block move should save before moving
- fix: don't create empty prop
- fix: don't show placeholder block when there's props
- feat: allow creation of new prop on lookup
