### PR TITLE
feat: more consistent style for refs

### DIFF
--- a/src/cljs/athens/components.cljs
+++ b/src/cljs/athens/components.cljs
@@ -85,7 +85,8 @@
     (if (db/e-by-av :block/uid block-uid)
       (r/with-let [embed-id (random-uuid)]
                   [:> Box {:class "block-embed"
-                           :bg "background.basement"
+                           :borderLeft "1px dotted"
+                           :borderLeftColor "ref.foreground"
                            :flex 1
                            :pr 1
                            :position "relative"

--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -147,15 +147,15 @@
                   :fontSize "inherit"
                   :fontWeight "inherit"
                   :lineHeight "inherit"
-                  :marginInline "-2px"
-                  :paddingInline "2px"
+                  :marginInline "-0.125ch"
+                  :paddingInline "0.125ch"
                   :borderBottomWidth "1px"
-                  :borderBottomStyle "solid"
+                  :borderBottomStyle "dotted"
                   :borderBottomColor "ref.foreground"
                   :cursor "alias"
                   :sx {"WebkitBoxDecorationBreak" "clone"}
                   :_hover {:textDecoration "none"
-                           :borderBottomColor "transparent"
+                          ;;  :borderBottomColor "transparent"
                            :bg "ref.background"}
                   :onClick (fn [e]
                              (.. e stopPropagation)

--- a/src/js/components/Block/Container.tsx
+++ b/src/js/components/Block/Container.tsx
@@ -101,8 +101,7 @@ const _Container = ({ children, isDragging, isSelected, isOpen, hasChildren, has
         },
         ".block-embed": {
           borderRadius: "sm",
-          "--block-surface-color": "background.basement",
-          bg: "background.basement",
+          borderLeftRadius: 0,
           // Blocks nested in an embed get normal indentation...
           ".block-container": { marginLeft: 8 },
           // ...except for the first one, where that would be excessive

--- a/src/js/components/Block/Content.tsx
+++ b/src/js/components/Block/Content.tsx
@@ -47,6 +47,9 @@ const _Content = ({ children, fontSize, ...props }) => {
         opacity: 0,
         fontFamily: "inherit"
       },
+      ".block-embed textarea ": {
+        caretColor: "var(--chakra-colors-ref-foreground)",
+      },
       "& > span": {
         gridArea: "main",
       },

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -164,7 +164,8 @@ const semanticTokens = {
     // block content colors
     "ref.foreground": {
       default: "#fbbe63bb",
-      _dark: "#fbbe6366",
+      // _dark: "#fbbe6366",
+      _dark: "#fbbe63bb",
     },
     "ref.background": {
       default: "#fbbe63bb",


### PR DESCRIPTION
Use a dotted gold border to indicate embedded content

Addresses inline and block embeds in content.

<img width="1104" alt="CleanShot 2022-06-26 at 15 17 31@2x" src="https://user-images.githubusercontent.com/98312/175830358-3b85cdde-1c3c-4aff-b5d6-1cb6636bd777.png">
