### PR TITLE
rfct: use standard icons for block element anchors

### DIFF
--- a/src/js/components/Block/Anchor.tsx
+++ b/src/js/components/Block/Anchor.tsx
@@ -1,14 +1,12 @@
 import React, { ReactNode } from 'react';
-import { IconButton, Text, MenuList, MenuDivider, MenuGroup, Box, useMergeRefs } from '@chakra-ui/react';
+import { IconButton, Text, MenuList, MenuGroup, Box, useMergeRefs } from '@chakra-ui/react';
+import { ColonIcon, BulletIcon, DashIcon, ArrowRightIcon } from '@/Icons/Icons';
 import { useContextMenu } from '@/utils/useContextMenu';
 
 const ANCHORS = {
-  CIRCLE: <svg viewBox="0 0 24 24">
-    <circle cx="12" cy="12" r="4" />
-  </svg>,
-  DASH: <svg viewBox="0 0 1 1">
-    <line x1="-1" y1="0" x2="1" y2="0" />
-  </svg>
+  "bullet": <BulletIcon />,
+  "colon": <ColonIcon />,
+  "dash": <DashIcon />
 }
 
 const showValue = (value) => {
@@ -57,8 +55,11 @@ const propertiesList = (block) => {
   })
 }
 
+type Anchors = typeof ANCHORS;
+type AnchorImage = keyof Anchors;
+
 export interface AnchorProps {
-  anchorElement?: 'circle' | 'dash' | number;
+  anchorElement?: AnchorImage | React.ReactNode | number;
   isClosedWithChildren: boolean;
   block: any;
   uidSanitizedBlock: any;
@@ -107,7 +108,7 @@ const anchorButtonStyleProps = (isClosedWithChildren: boolean) => {
           vectorEffect: "non-scaling-stroke"
         }
       },
-      "circle": {
+      "svg path": {
         transformOrigin: 'center',
         transition: 'all 0.15s ease-in-out',
         stroke: "transparent",
@@ -164,7 +165,7 @@ export const Anchor = React.forwardRef((props: AnchorProps, ref) => {
       onDragEnd={onDragEnd}
       isActive={isContextMenuOpen}
     >
-      {ANCHORS[anchorElement] || ANCHORS.CIRCLE}
+      {ANCHORS[anchorElement] ? ANCHORS[anchorElement] : anchorElement}
     </IconButton>
     {(menu || shouldShowDebugDetails) && <ContextMenu>
       {shouldShowDebugDetails ? (
@@ -180,3 +181,7 @@ export const Anchor = React.forwardRef((props: AnchorProps, ref) => {
   </>
 
 });
+
+Anchor.defaultProps = {
+  anchorElement: "bullet"
+}

--- a/src/js/components/Block/PropertyName.tsx
+++ b/src/js/components/Block/PropertyName.tsx
@@ -32,30 +32,30 @@ export const PropertyName = (props: PropertyNameProps) => {
       size="sm"
       p={0}
       sx={{
-      "svg": {
-        pointerEvents: "none",
-        transform: "scale(1.1001)", // Prevents the bullet being squished
-        overflow: "visible", // Prevents the bullet being cropped
-        width: "1em",
-        height: "1em",
-        "*": {
-          vectorEffect: "non-scaling-stroke"
+        "svg": {
+          pointerEvents: "none",
+          transform: "scale(1.1001)", // Prevents the bullet being squished
+          overflow: "visible", // Prevents the bullet being cropped
+          width: "1em",
+          height: "1em",
+          "*": {
+            vectorEffect: "non-scaling-stroke"
+          }
+        },
+        "circle": {
+          transformOrigin: 'center',
+          transition: 'all 0.15s ease-in-out',
+          stroke: "transparent",
+          strokeWidth: "0.125em",
+          fill: "currentColor",
         }
-      },
-      "circle": {
-        transformOrigin: 'center',
-        transition: 'all 0.15s ease-in-out',
-        stroke: "transparent",
-        strokeWidth: "0.125em",
-        fill: "currentColor",
-      }
 
       }}
-    onClick={onClick}
+      onClick={onClick}
     >
       <svg viewBox="0 0 24 24">
-        <circle cx="12" cy="6" r="3.5" />
-        <circle cx="12" cy="18" r="3.5" />
+        <circle cx="12" cy="7" r="2.5" />
+        <circle cx="12" cy="17" r="2.5" />
       </svg>
       {name}
     </Button>

--- a/src/js/components/Icons/Icons.tsx
+++ b/src/js/components/Icons/Icons.tsx
@@ -16,6 +16,30 @@ export const ArrowAngleUpLeftIcon = createIcon({
   ),
 });
 
+export const BulletIcon = createIcon({
+  displayName: 'BulletIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <path fill="currentColor" d="M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z" />
+  ),
+});
+
+export const ColonIcon = createIcon({
+  displayName: 'ColonIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <path fill="currentColor" fillRule="evenodd" d="M14.5 7a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Zm0 10a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0Z" clipRule="evenodd" />
+  ),
+});
+
+export const DashIcon = createIcon({
+  displayName: 'DashIcon',
+  viewBox: '0 0 24 24',
+  path: (
+    <rect fill="currentColor" width="12" height="3.5" x="6" y="10.25" rx="1.75" />
+  ),
+});
+
 export const ArrowLeftIcon = createIcon({
   displayName: 'ArrowLeftIcon',
   viewBox: '0 0 24 24',


### PR DESCRIPTION
Refactors block anchor icons to use icons instead of custom SVGs