### PR TITLE
feat: add feature flag for property UIs

### DIFF
--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -161,7 +161,8 @@
         inline-refs-open?     (rf/subscribe [::inline-refs.subs/open? uid])
         feature-flags         (rf/subscribe [:feature-flags])
         show-inline-comments  (rf/subscribe [:comment/show-inline-comments?])
-        show-textarea         (rf/subscribe [:comment/show-comment-textarea? uid])]
+        show-textarea         (rf/subscribe [:comment/show-comment-textarea? uid])
+        enable-properties?    (rf/subscribe [:feature-flags/enabled? :properties])]
     (fn editor-component-render
       [_block-el _block-o _children? _block _linked-ref-data _uid-sanitized-block _state-hooks _opts]
       (let [{:block/keys [;; uid
@@ -266,7 +267,7 @@
            [inline-linked-refs-el block-el uid])
 
          ;; Properties
-         (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
+         (when (and @enable-properties?
                     (or (and (true? linked-ref) @linked-ref-open?)
                         (and (false? linked-ref) open)))
            (for [prop (common-db/sort-block-properties properties)]

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -266,7 +266,7 @@
            [inline-linked-refs-el block-el uid])
 
          ;; Properties
-         (when (and (seq properties)
+         (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
                     (or (and (true? linked-ref) @linked-ref-open?)
                         (and (false? linked-ref) open)))
            (for [prop (common-db/sort-block-properties properties)]

--- a/src/cljs/athens/views/blocks/textarea_keydown.cljs
+++ b/src/cljs/athens/views/blocks/textarea_keydown.cljs
@@ -871,7 +871,8 @@
                                       (rf/dispatch [::inline-search.events/set-index! uid 0])
                                       (rf/dispatch [::inline-search.events/clear-results! uid])
                                       (rf/dispatch [::inline-search.events/clear-query! uid]))
-      (and (= key ":" look-behind-char)
+      (and @(rf/subscribe [:feature-flags/enabled? :properties])
+           (= key ":" look-behind-char)
            (nil? type))             (do
                                       (rf/dispatch [::inline-search.events/set-type! uid :property])
                                       (rf/dispatch [::inline-search.events/set-index! uid 0])

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -146,11 +146,11 @@
 
          ;; Properties
          (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
-                     (seq properties))
+                    (seq properties))
            [:> PageBody
-             (for [prop (common-db/sort-block-properties properties)]
-               ^{:key (:db/id prop)}
-               [blocks/block-el prop])])
+            (for [prop (common-db/sort-block-properties properties)]
+              ^{:key (:db/id prop)}
+              [blocks/block-el prop])])
 
          ;; Children
          [:> PageBody

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -93,7 +93,9 @@
 (defn block-page-el
   [_block]
   (let [state (r/atom {:string/local    nil
-                       :string/previous nil})]
+                       :string/previous nil})
+        properties-enabled? (rf/subscribe [:feature-flags/enabled? :properties])]
+
     (fn [block]
       (let [{:block/keys [string children uid properties] :db/keys [id]} block
             is-current-route? (= @(subscribe [:current-route/uid]) uid)]
@@ -145,7 +147,7 @@
             [inline-comments/inline-comments (comments/get-comments-in-thread @db/dsdb (comments/get-comment-thread-uid @db/dsdb uid)) uid false])]
 
          ;; Properties
-         (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
+         (when (and @properties-enabled?
                     (seq properties))
            [:> PageBody
             (for [prop (common-db/sort-block-properties properties)]

--- a/src/cljs/athens/views/pages/block_page.cljs
+++ b/src/cljs/athens/views/pages/block_page.cljs
@@ -95,7 +95,7 @@
   (let [state (r/atom {:string/local    nil
                        :string/previous nil})]
     (fn [block]
-      (let [{:block/keys [string children uid] :db/keys [id]} block
+      (let [{:block/keys [string children uid properties] :db/keys [id]} block
             is-current-route? (= @(subscribe [:current-route/uid]) uid)]
         (when (not= string (:string/previous @state))
           (swap! state assoc :string/previous string :string/local string))
@@ -144,6 +144,13 @@
                          (comments/get-comment-thread-uid @db/dsdb uid)))
             [inline-comments/inline-comments (comments/get-comments-in-thread @db/dsdb (comments/get-comment-thread-uid @db/dsdb uid)) uid false])]
 
+         ;; Properties
+         (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
+                     (seq properties))
+           [:> PageBody
+             (for [prop (common-db/sort-block-properties properties)]
+               ^{:key (:db/id prop)}
+               [blocks/block-el prop])])
 
          ;; Children
          [:> PageBody

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -432,7 +432,8 @@
   (let [state         (r/atom init-state)
         unlinked-refs (r/atom [])
         block-uid     (r/atom nil)
-        feature-flags (rf/subscribe [:feature-flags])]
+        properties-enabled? (rf/subscribe [:feature-flags/enabled? :properties])
+        cover-photo-enabled? (rf/subscribe [:feature-flags/enabled? :cover-photo])]
     (fn [node]
       (when (not= @block-uid (:block/uid node))
         (reset! state init-state)
@@ -443,8 +444,7 @@
             daily-note?                                                         (dates/is-daily-note uid)
             on-daily-notes?                                                     (= :home @(subscribe [:current-route/name]))
             is-current-route?                                                   (or (= @(subscribe [:current-route/uid]) uid)
-                                                                                    (= @(subscribe [:current-route/page-title]) title))
-            cover-photo-enabled?                                                (:cover-photo @feature-flags)]
+                                                                                    (= @(subscribe [:current-route/page-title]) title))]
 
         (sync-title title state)
 
@@ -461,8 +461,8 @@
                                                      (fn [e] (router/navigate-page title e)))
                            :onClickOpenInSidebar   (when-not (contains? @(subscribe [:right-sidebar/items]) uid)
                                                      #(dispatch [:right-sidebar/open-item uid]))}
-                          (when cover-photo-enabled?
-                            {:headerImageEnabled     cover-photo-enabled?
+                          (when @cover-photo-enabled?
+                            {:headerImageEnabled     @cover-photo-enabled?
                              :headerImageUrl         (-> properties (get ":header/url") :block/string)
                              :onChangeHeaderImageUrl (fn [url]
                                                        (dispatch [:properties/update-in [:node/title title] [":header/url"]
@@ -506,7 +506,7 @@
 
           ;; Properties
           [:div
-           (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
+           (when (and @properties-enabled?
                       (seq properties))
              (for [prop (common-db/sort-block-properties properties)]
                ^{:key (:db/id prop)}

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -506,7 +506,8 @@
 
           ;; Properties
           [:div
-           (when (seq properties)
+           (when (and @(rf/subscribe [:feature-flags/enabled? :properties])
+                      (seq properties))
              (for [prop (common-db/sort-block-properties properties)]
                ^{:key (:db/id prop)}
                [blocks/block-el prop]))]

--- a/src/cljs/athens/views/pages/settings.cljs
+++ b/src/cljs/athens/views/pages/settings.cljs
@@ -5,7 +5,7 @@
     [athens.util :refer [toast]]
     [cljs-http.client :as http]
     [cljs.core.async :refer [<!]]
-    [re-frame.core :refer [subscribe dispatch reg-event-fx]]
+    [re-frame.core :as rf :refer [subscribe dispatch reg-event-fx]]
     [reagent.core :as r])
   (:require-macros
     [cljs.core.async.macros :refer [go]]))
@@ -70,6 +70,13 @@
   (if monitoring
     (monitoring-off (partial update-fn false))
     (monitoring-on (partial update-fn true))))
+
+
+(rf/reg-sub
+  :feature-flags/enabled?
+  :<- [:feature-flags]
+  (fn [a [_ flag]]
+    (get a flag)))
 
 
 ;; Components
@@ -192,7 +199,7 @@
 
 
 (defn feature-flags-comp
-  [{:keys [comments reactions notifications cover-photo time-controls]} update-fn]
+  [{:keys [comments reactions notifications properties cover-photo time-controls]} update-fn]
   [setting-wrapper
    [:<>
     [header
@@ -211,6 +218,10 @@
        [:> Switch {:isChecked notifications
                    :onChange #(update-fn :notifications %)}
         "Notifications"]]
+      [:> FormControl
+       [:> Switch {:isChecked properties
+                   :onChange #(update-fn :properties %)}
+        "Properties"]]
       [:> FormControl
        [:> Switch {:isChecked cover-photo
                    :onChange #(update-fn :cover-photo %)}


### PR DESCRIPTION
The point of this is to hide property blocks on the outliner, which add a ton of visual noise. The point isn't to turn off all properties code.