### PR TITLE
fix: right sidebar dom events

### DIFF
--- a/src/js/components/Layout/List.tsx
+++ b/src/js/components/Layout/List.tsx
@@ -4,7 +4,6 @@ import {
   DndContext,
   useSensors,
   closestCenter,
-  KeyboardSensor,
   PointerSensor,
   DragOverlay,
   useSensor
@@ -12,7 +11,6 @@ import {
 import {
   SortableContext,
   verticalListSortingStrategy,
-  sortableKeyboardCoordinates,
   arrayMove
 } from "@dnd-kit/sortable";
 import { Item, ItemDragOverlay } from "./Item";

--- a/src/js/components/Layout/List.tsx
+++ b/src/js/components/Layout/List.tsx
@@ -53,9 +53,6 @@ export const List = (props) => {
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates
-    })
   );
 
   const handleDragStart = (e) => {

--- a/src/js/components/Layout/RightSidebar.tsx
+++ b/src/js/components/Layout/RightSidebar.tsx
@@ -144,6 +144,7 @@ export const SidebarItem = ({ title, type, isOpen, onToggle, onRemove, onNavigat
         unmountOnExit
         zIndex={1}
         px={4}
+        onPointerDown={(e) => {e.stopPropagation()}}
       >
         {children}
       </Box>


### PR DESCRIPTION
- previously dragging and dropping bullets within right sidebar items reordered top-level items, not bullet
- previously space turned on reorder via keyboard
- reference: https://github.com/clauderic/dnd-kit/issues/90