### PR TITLE
Fix-highlight-colors

### DIFF
--- a/src/cljs/athens/views/athena.cljs
+++ b/src/cljs/athens/views/athena.cljs
@@ -28,10 +28,11 @@
     (map-indexed (fn [i part]
                    (if (= part query)
                      [:> Text {:as           "span"
-                               :background   "highlight"
-                               :color        "highlightContrast"
-                               :borderRadius "0.1rem"
-                               :padding      "0 0.125em"
+                               :background   "interaction.surface.hover"
+                               :color        "foreground.primary"
+                               :borderRadius "sm"
+                               :py           0
+                               :px           0.25
                                :key i} part]
                      part))
                  (patterns/split-on txt query))))

--- a/src/cljs/athens/views/notifications/popover.cljs
+++ b/src/cljs/athens/views/notifications/popover.cljs
@@ -132,8 +132,8 @@
                              :icon          (r/as-element [:> BellFillIcon])}]
              (when (> num-notifications 0)
                [:> Badge {:position "absolute"
-                          :bg "info"
-                          :color "infoText"
+                          :bg "gold"
+                          :color "goldContrast"
                           :right "-3px"
                           :bottom "-1px"
                           :zIndex 1} num-notifications])]]

--- a/src/cljs/athens/views/notifications/popover.cljs
+++ b/src/cljs/athens/views/notifications/popover.cljs
@@ -132,9 +132,11 @@
                              :icon          (r/as-element [:> BellFillIcon])}]
              (when (> num-notifications 0)
                [:> Badge {:position "absolute"
-                          :bg "highlight"
-                          :color "highlightContrast"
-                          :right "-3px" :bottom "-1px" :variant "ghost" :zIndex 1} num-notifications])]]
+                          :bg "info"
+                          :color "infoText"
+                          :right "-3px"
+                          :bottom "-1px"
+                          :zIndex 1} num-notifications])]]
 
 
            [:> PopoverContent {:maxHeight "calc(100vh - 4rem)"}

--- a/src/js/components/Page/Page.tsx
+++ b/src/js/components/Page/Page.tsx
@@ -356,7 +356,8 @@ export const TitleContainer = ({ children, isEditing, props }) => <Box
     "mark.contents.highlight": {
       padding: "0 0.2em",
       borderRadius: "0.125rem",
-      background: "highlight",
+      background: "gold",
+      color: "goldContrast",
     }
   }}
   {...props}>

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -152,6 +152,16 @@ const semanticTokens = {
       _dark: '#498eda'
     },
 
+    // Notifications
+    notification: {
+      default: '#d70015',
+      _dark: '#ff6961'
+    },
+    notificationText: {
+      default: '#fff',
+      _dark: '#fff'
+    },
+
     // other colors
     textHighlight: {
       default: '#ffdb8a',
@@ -173,6 +183,16 @@ const semanticTokens = {
       default: '#fff',
       _dark: '#fff'
     },
+
+    gold: {
+      default: '#F9A132',
+      _dark: '#FBBE63'
+    },
+    goldContrast: {
+      default: '#000',
+      _dark: '#000'
+    },
+
     // block content colors
     "ref.foreground": {
       default: "#fbbe63bb",
@@ -652,8 +672,8 @@ const styles = {
       margin: "3rem 1rem"
     },
     mark: {
-      background: "highlight",
-      color: "highlightContrast",
+      background: "gold",
+      color: "goldContrast",
       padding: '0 0.2em',
       borderRadius: "sm",
     }

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -139,6 +139,10 @@ const semanticTokens = {
       default: '#0071DB',
       _dark: '#498eda'
     },
+    infoText: {
+      default: '#fff',
+      _dark: '#fff'
+    },
     warning: {
       default: '#D20000',
       _dark: '#DE3C21'
@@ -147,12 +151,13 @@ const semanticTokens = {
       default: '#4CBB17',
       _dark: '#498eda'
     },
+
     // other colors
     textHighlight: {
       default: '#ffdb8a',
       _dark: '#FBBE63'
     },
-    highlight: {
+    "highlight": {
       default: '#F9A132',
       _dark: '#FBBE63'
     },


### PR DESCRIPTION
Addresses specific cases of "highlight" color to avoid system colors bleeding into the theme.

Punting on theme value naming considerations because that's hard.