### PR TITLE
fix: if multiple blocks selected, selection doesn't clear on context …

### DIFF
--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -362,7 +362,7 @@
                 reactions              (and reactions-enabled?
                                             (block-reaction/props->reactions properties))
                 menu                   (r/as-element
-                                         [:> MenuList
+                                         [:> MenuList {:class "anchor"}
                                           [:> MenuItem {:children (if (> (count @selected-items) 1)
                                                                     "Copy selected block refs"
                                                                     "Copy block ref")


### PR DESCRIPTION
…menuclick