### PR TITLE
chore: update chakra to last 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@chakra-ui/react": "^1.8.6",
+    "@chakra-ui/react": "^1.8.8",
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/sortable": "^7.0.1",
     "@emotion/react": "^11",


### PR DESCRIPTION
I took a shot at upgrading to 2.x but there were a few hiccups in updating to React 18. Chakra 2.x should fix a couple minor bugs e.g. tooltips persisting when they shouldn't, like in reactions.