### PR TITLE
feat: contextmenu offerors are keyed

### DIFF
--- a/src/js/components/App/ContextMenuContext.tsx
+++ b/src/js/components/App/ContextMenuContext.tsx
@@ -18,7 +18,8 @@ interface addToContextMenuProps {
   component: () => JSX.Element,
   onClose: () => void,
   anchorEl?: React.MutableRefObject<HTMLElement>,
-  isExclusive?: boolean
+  isExclusive?: boolean,
+  key?: string,
 }
 
 const useContextMenuState = () => {

--- a/src/js/components/App/ContextMenuContext.tsx
+++ b/src/js/components/App/ContextMenuContext.tsx
@@ -32,14 +32,22 @@ const useContextMenuState = () => {
 
   let components = [];
   let sources = [];
+  let keys = [];
 
   /**
    * Reveal a menu only for the clicked element.
    * To reveal a menu for all clicked menu sources, use onContextMenu instead.
    */
   const addToContextMenu = React.useCallback((props: addToContextMenuProps) => {
-    const { event, ref, component, onClose, anchorEl, isExclusive } = props;
+    const { event, ref, component, onClose, anchorEl, key, isExclusive } = props;
     event.preventDefault();
+
+    if (keys.includes(key)) {
+      // Skip if a menu with the same key is already present
+      return;
+    } else {
+      keys.push(key);
+    }
 
     if (!component) {
       console.warn("No component provided to addToContextMenu");

--- a/src/js/components/Block/Anchor.tsx
+++ b/src/js/components/Block/Anchor.tsx
@@ -166,7 +166,7 @@ export const Anchor = React.forwardRef((props: AnchorProps, ref) => {
       onContextMenu={
         (e) => {
           if (menu) {
-            addToContextMenu({ event: e, ref: innerRef, component: MenuItems, anchorEl: innerRef })
+            addToContextMenu({ event: e, ref: innerRef, component: MenuItems, anchorEl: innerRef, key: "block" })
           }
         }}
       onClick={
@@ -174,7 +174,7 @@ export const Anchor = React.forwardRef((props: AnchorProps, ref) => {
           if (buttonProps?.onClick) {
             buttonProps?.onClick(e);
           } else if (menu) {
-            addToContextMenu({ event: e, ref: innerRef, component: MenuItems, anchorEl: innerRef })
+            addToContextMenu({ event: e, ref: innerRef, component: MenuItems, anchorEl: innerRef, key: "block" })
           }
         }}
       isActive={buttonProps?.isActive || isMenuOpen}

--- a/src/js/components/Block/Container.tsx
+++ b/src/js/components/Block/Container.tsx
@@ -163,7 +163,7 @@ const _Container = React.forwardRef(({ children, isDragging, isHidden, isSelecte
           const target = e.target as HTMLElement;
           // Don't open the context menu on these e.target as HTMLElement;
           if (!CONTAINER_CONTEXT_MENU_FILTERED_TAGS.includes(target.tagName)) {
-            addToContextMenu({ event: e, ref: internalRef, component: MenuItems });
+            addToContextMenu({ event: e, ref: internalRef, component: MenuItems, key: "block" });
           } else {
             e.stopPropagation();
           }

--- a/src/js/components/Comments/Comments.tsx
+++ b/src/js/components/Comments/Comments.tsx
@@ -60,7 +60,7 @@ export const CommentAnchor = ({ menu, ...boxProps }) => {
     isActive={isMenuOpen}
     ref={ref}
     onClick={(event) => {
-      addToContextMenu({ event, ref, component: Menu, anchorEl: ref })
+      addToContextMenu({ event, ref, component: Menu, anchorEl: ref, key: "comment" })
     }}
     {...boxProps}
   />
@@ -99,7 +99,7 @@ export const CommentContainer = withErrorBoundary(({ children, menu, isFollowUp 
     'byline byline byline'
     'anchor comment refs'`}
     onContextMenu={(event) => {
-      addToContextMenu({ event, ref, component: Menu })
+      addToContextMenu({ event, ref, component: Menu, key: "comment" })
     }}
     _first={{
       borderTopWidth: 0

--- a/src/js/components/Query/KanbanBoard.tsx
+++ b/src/js/components/Query/KanbanBoard.tsx
@@ -14,7 +14,7 @@ export const KanbanCard = React.forwardRef(({ children, isOver }, ref) => {
 
   const Menu = React.memo(() => {
     return <MenuGroup title="Card">
-      <MenuItem icon={<PlusIcon/>}>Open in right sidebar</MenuItem>
+      <MenuItem icon={<PlusIcon />}>Open in right sidebar</MenuItem>
     </MenuGroup>
   })
 
@@ -53,7 +53,8 @@ export const KanbanCard = React.forwardRef(({ children, isOver }, ref) => {
         ref: innerRef,
         event: e,
         component: Menu,
-        isExclusive: true
+        isExclusive: true,
+        key: "card"
       })
     }}
     {...(isOver && {


### PR DESCRIPTION
Adds optional 'key' prop to `addToContextMenu`, to usable to prevent situations like several blocks providing indistinguishable menus.