### PR TITLE
More on tasks

### DIFF
--- a/src/cljs/athens/self_hosted/presence/views.cljs
+++ b/src/cljs/athens/self_hosted/presence/views.cljs
@@ -106,9 +106,9 @@
                                  (str/join ", "))}
          [:> AvatarGroup {:max 1
                           :zIndex 2
+                          :className "inline-presence"
                           :size "xs"
-                          :cursor "default"
-                          :gridArea "presence"}
+                          :cursor "default"}
           (->> @users
                (map user->person)
                (remove nil?)

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -3,7 +3,7 @@
   (:require
     ["/components/Block/BlockFormInput"         :refer [BlockFormInput]]
     ["/components/Block/Taskbox"                :refer [Taskbox]]
-    ["/components/Icons/Icons"                  :refer [CheckmarkIcon]]
+    ["/components/Icons/Icons"                  :refer [CheckmarkIcon PencilIcon]]
     ["/components/ModalInput/ModalInput"        :refer [ModalInput]]
     ["/components/ModalInput/ModalInputPopover" :refer [ModalInputPopover]]
     ["/components/ModalInput/ModalInputTrigger" :refer [ModalInputTrigger]]
@@ -13,6 +13,7 @@
                                                         Flex
                                                         MenuGroup
                                                         AvatarGroup
+                                                        VStack
                                                         Avatar
                                                         Box
                                                         Divider
@@ -177,7 +178,8 @@
          [:> FormLabel {:html-for prop-id}
           prop-title]
          [:> Box [:> BlockFormInput
-                  {:isMultiline multiline?}
+                  {:isMultiline multiline?
+                   :size "sm"}
                   ;; NOTE: we generate temporary uid for prop if it doesn't exist, so editor can work
                   [editor/block-editor {:block/uid (or prop-block-uid
                                                        ;; NOTE: temporary magic, stripping `:task/` 🤷‍♂️
@@ -521,7 +523,7 @@
                                                                                :block/string
                                                                                (common-db/strip-markup "((" "))"))])
                                 :block/string)
-            _title          (-> props (get ":task/title") :block/string)
+            title          (-> props (get ":task/title") :block/string)
             assignee        (-> props (get ":task/assignee") :block/string (common-db/strip-markup "[[" "]]"))
             priority        (-> (common-db/get-block @db/dsdb [:block/uid  (-> props
                                                                                (get ":task/priority")
@@ -569,12 +571,12 @@
            true
            false]]
          [:> ModalInput {:placement "left-start"
+                         :closeOnBlur false
                          :isLazy    true}
           [:> ModalInputTrigger
            [:> Button {:size         "sm"
                        :flex         "1 0 auto"
-                       :variant      "outline"
-                       :borderRadius "full"
+                       :variant      "ghost"
                        :onClick      #(.. % stopPropagation)
                        :lineHeight   "unset"
                        :whiteSpace   "unset"
@@ -601,20 +603,30 @@
                [:> AvatarGroup {:size "xs"}
                 [:> Avatar {:name creator}]])
              (when (and show-created-date? created-date)
-               [:> Text {:fontSize "xs"} created-date])]]]
-          [:> ModalInputPopover {:popoverContentProps {:display             "grid"
-                                                       :onClick             #(.. % stopPropagation)
-                                                       :gridTemplateColumns "max-content 1fr"
-                                                       :gap                 2
-                                                       :p                   4
-                                                       :maxWidth            "20em"}}
-           [generic-textarea-view-for-task-props block-uid description-uid ":task/description" "Description" false true]
+               [:> Text {:fontSize "xs"} created-date])]
+            [:> PencilIcon {:color "foreground.secondary"}]]]
+          [:> ModalInputPopover {:popoverContentProps
+                                 {:display             "grid"
+                                  :onClick             #(.. % stopPropagation)
+                                  :gridTemplateColumns "max-content 1fr"
+                                  :gap                 2
+                                  :py                  2
+                                  :px                  4
+                                  :maxWidth            "20em"}}
+           [:> HStack {:gridColumn "1 / -1" :align "flex-start"}
+            [:> Text {:fontSize "sm"
+                      :color "foreground.secondary"}
+             title]]
            [:> Divider {:gridColumn "1 / -1"}]
            [task-priority-view block-uid priority-uid]
            [generic-textarea-view-for-task-props block-uid assignee-uid ":task/assignee" "Assignee" false false]
            ;; Making assumption that for now we can add due date manually without date-picker.
            [generic-textarea-view-for-task-props block-uid due-date-uid ":task/due-date" "Due Date" false false]
-           [:> Text creator-uid]]]]))))
+           [:> Divider {:gridColumn "1 / -1"}]
+           [:> Text {:color "foreground.secondary" :fontSize "sm"} "Created by"]
+           [:> Text {:fontSize "sm"} creator]
+           [:> Text {:color "foreground.secondary" :fontSize "sm"} "Created"]
+           [:> Text {:fontSize "sm"} created-date]]]]))))
 
 
 (defrecord TaskView

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -124,7 +124,8 @@
       (let [prop-block          (reactive/get-reactive-block-document [:block/uid prop-block-uid])
             prop-str            (or (:block/string prop-block) "")
             local-value         (r/atom prop-str)
-            invalid-prop-str?   (and (str/blank? prop-str)
+            invalid-prop-str?   (and required?
+                                     (str/blank? prop-str)
                                      (not (nil? prop-str)))
             save-fn             (fn
                                   ([]
@@ -392,10 +393,9 @@
         allowed-priorities (find-allowed-priorities)
         priority-string    (:block/string priority-block "(())")
         priority-uid       (subs priority-string 2 (- (count priority-string) 2))]
-    [:> FormControl {:is-required true
-                     :display "contents"}
+    [:> FormControl {:display "contents"}
      [:> FormLabel {:html-for priority-id}
-      "Task priority"]
+      "Priority"]
      [:> Box [:> Select {:id          priority-id
                          :value       priority-uid
                          :size "sm"
@@ -571,7 +571,6 @@
            true
            false]]
          [:> ModalInput {:placement "left-start"
-                         :closeOnBlur false
                          :isLazy    true}
           [:> ModalInputTrigger
            [:> Button {:size         "sm"
@@ -615,6 +614,7 @@
                                   :maxWidth            "20em"}}
            [:> HStack {:gridColumn "1 / -1" :align "flex-start"}
             [:> Text {:fontSize "sm"
+                      :noOfLines 2
                       :color "foreground.secondary"}
              title]]
            [:> Divider {:gridColumn "1 / -1"}]

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -538,8 +538,8 @@
             show-assignee?     true
             show-description?  true
             show-priority?     true
-            show-creator?      true
-            show-created-date? true
+            show-creator?      false
+            show-created-date? false
             _show-status?      true
             show-due-date?     true]
         [:> HStack {:spacing                  1
@@ -590,7 +590,6 @@
                priority])
             (when (or due-date assignee)
               [:> Flex {:gap 1 :align "center"}
-               [:> Text {:fontSize "xs"} "Due"]
                (when (and show-assignee? assignee)
                  [:> AvatarGroup {:size "xs"}
                   [:> Avatar {:name assignee}]])

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -538,7 +538,7 @@
                                 (common-db/strip-markup "[[" "]]"))
 
             show-assignee?     true
-            show-description?  true
+            show-description?  false
             show-priority?     true
             show-creator?      false
             show-created-date? false
@@ -581,10 +581,12 @@
                        :whiteSpace   "unset"
                        :px           2
                        :py           1}
+
             ;; description
             (when (and show-description? description)
               [:> Text {:fontSize "sm" :flexGrow 1 :flexBasis "100%" :m 0 :py 1 :lineHeight 1.4 :color "foreground.secondary"}
                description])
+
             ;; tasking/assignment
             (when (and show-priority? priority)
               [:> Badge {:size "sm" :variant "primary"}
@@ -596,6 +598,7 @@
                   [:> Avatar {:name assignee}]])
                (when (and show-due-date? due-date)
                  [:> Text {:fontSize "xs"} due-date])])
+
             ;; provenance
             [:> Flex {:gap 1 :align "center"}
              (when (and show-creator? creator)

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -627,7 +627,7 @@
            [generic-textarea-view-for-task-props block-uid due-date-uid ":task/due-date" "Due Date" false false]
            [:> Divider {:gridColumn "1 / -1"}]
            [:> Text {:color "foreground.secondary" :fontSize "sm"} "Created by"]
-           [:> Text {:fontSize "sm"} creator]
+           [:> Flex {:align "center"} [:> Avatar {:size "2xs" :marginInlineEnd 1 :name creator}] [:> Text {:fontSize "sm" :noOfLines 0} creator]]
            [:> Text {:color "foreground.secondary" :fontSize "sm"} "Created"]
            [:> Text {:fontSize "sm"} created-date]]]]))))
 

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -13,7 +13,6 @@
                                                         Flex
                                                         MenuGroup
                                                         AvatarGroup
-                                                        VStack
                                                         Avatar
                                                         Box
                                                         Divider
@@ -486,12 +485,6 @@
                         [(graph-ops/build-block-save-op db uid (str "((" (find-status-uid "Done") "))"))]))])))
 
 
-;; NOTE: not used right now
-(defn is-checked-fn
-  [status]
-  (contains? #{"Done" "Cancelled"} status))
-
-
 (defn task-el
   [_this block-data _callbacks _is-ref?]
   (let [block-uid (:block/uid block-data)]
@@ -501,8 +494,8 @@
             title-uid       (-> props (get ":task/title") :block/uid)
             assignee-uid    (-> props (get ":task/assignee") :block/uid)
             priority-uid    (-> props (get ":task/priority") :block/uid)
-            description-uid (-> props (get ":task/description") :block/uid)
-            creator-uid     (-> props (get ":task/creator") :block/uid)
+            _description-uid (-> props (get ":task/description") :block/uid)
+            _creator-uid     (-> props (get ":task/creator") :block/uid)
             due-date-uid    (-> props (get ":task/due-date") :block/uid)
             ;; projects-uid  (:block/uid (find-property-block-by-key-name reactive-block ":task/projects"))
             ;; status-uid      (-> props (get ":task/status") :block/uid)

--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -204,9 +204,8 @@
   [count click-fn active?]
   [:> Button {:gridArea "refs"
               :size "xs"
-              :ml "1em"
-              :mt 1
-              :mr 1
+              :variant "ghost"
+              :placeSelf "center"
               :zIndex 10
               :visibility (if (pos? count) "visible" "hidden")
               :isActive active?
@@ -562,9 +561,6 @@
                 @show-textarea? [inline-comments/inline-comments (comments/get-comments-in-thread @db/dsdb (comments/get-comment-thread-uid @db/dsdb uid)) uid false]
                 :else           [inline-comments/inline-comments (comments/get-comments-in-thread @db/dsdb (comments/get-comment-thread-uid @db/dsdb uid)) uid true]))
 
-            (when in-view?
-              [presence/inline-presence-el uid])
-
             (when (and in-view?
                        (> (count _refs) 0)
                        (not= :block-embed? opts))
@@ -574,7 +570,11 @@
                  (if (.. e -shiftKey)
                    (rf/dispatch [:right-sidebar/open-item [:block/uid uid]])
                    (rf/dispatch [::inline-refs.events/toggle-open! uid])))
-               @inline-refs-open?])]
+               @inline-refs-open?])
+
+            (when in-view?
+              [presence/inline-presence-el uid])]
+
 
            ;; Inline refs
            (when (and in-view?

--- a/src/cljs/athens/views/left_sidebar/tasks.cljs
+++ b/src/cljs/athens/views/left_sidebar/tasks.cljs
@@ -27,7 +27,6 @@
               :gap     1}
      [:> Taskbox {:position "relative"
                   :top      "3px"
-                  :isEditable true
                   :onChange #(tasks/on-update-status task-uid %)
                   :status   status-string}]
      [:> Link {:fontSize  "sm"

--- a/src/js/components/AppToolbar/components/LocationIndicator.tsx
+++ b/src/js/components/AppToolbar/components/LocationIndicator.tsx
@@ -53,7 +53,7 @@ export const LocationIndicator = (props: LocationIndicatorProps) => {
           px: 2
         })}
         rightIcon={actions ? <ChevronDownIcon color="foreground.secondary" /> : undefined}>
-        {path && <Heading isTruncated noOfLines={0} maxWidth="100%" display="block" textTransform="uppercase" textAlign="start" color="foreground.secondary" fontSize="50%">{path[0].label}</Heading>}
+        {path && <Heading noOfLines={0} maxWidth="100%" display="block" textTransform="uppercase" textAlign="start" color="foreground.secondary" fontSize="50%">{path[0].label}</Heading>}
         {title}
       </MenuButton>
       <Portal>

--- a/src/js/components/Block/Container.tsx
+++ b/src/js/components/Block/Container.tsx
@@ -106,7 +106,13 @@ const _Container = React.forwardRef(({ children, isDragging, isHidden, isSelecte
           gridArea: "presence",
           justifySelf: "flex-end"
         },
-        "&:hover > .block-toggle, &:focus-within > .block-toggle": { opacity: "1" },
+        ".block-body > .block-toggle": {
+          opacity: 0
+        },
+        ".block-body > .block-toggle:focus": {
+          opacity: 1
+        },
+        "&.is-hovered-not-child > .block-body > .block-toggle, &:focus-within > .block-body > .block-toggle": { opacity: "1" },
         "button.block-edit-toggle": {
           position: "absolute",
           appearance: "none",

--- a/src/js/components/Block/Container.tsx
+++ b/src/js/components/Block/Container.tsx
@@ -90,7 +90,7 @@ const _Container = React.forwardRef(({ children, isDragging, isHidden, isSelecte
         },
         ".block-body": {
           display: "grid",
-          gridTemplateColumns: "1em auto 1em 1fr auto",
+          gridTemplateColumns: "1em auto 1em 1fr calc(var(--page-right-gutter-width) / 2) calc(var(--page-right-gutter-width) / 2)",
           gridTemplateRows: "0 1fr auto auto 0",
           gridTemplateAreas:
             `'above above above above above above'
@@ -101,6 +101,10 @@ const _Container = React.forwardRef(({ children, isDragging, isHidden, isSelecte
           borderRadius: "0.5rem",
           minHeight: '2em',
           position: "relative",
+        },
+        ".block-body > .inline-presence": {
+          gridArea: "presence",
+          justifySelf: "flex-end"
         },
         "&:hover > .block-toggle, &:focus-within > .block-toggle": { opacity: "1" },
         "button.block-edit-toggle": {

--- a/src/js/components/Block/Toggle.tsx
+++ b/src/js/components/Block/Toggle.tsx
@@ -14,7 +14,7 @@ export const Toggle = (props: ToggleProps) => {
 
   return (
     <IconButton
-      className="toggle"
+      className="toggle block-toggle"
       bg="transparent"
       aria-label="Block toggle"
       gridArea="toggle"

--- a/src/js/components/Page/Page.tsx
+++ b/src/js/components/Page/Page.tsx
@@ -19,6 +19,8 @@ const PAGE_PROPS = {
   transitionDuration: "fast",
   sx: {
     "--page-padding": "3rem",
+    "--page-left-gutter-width": "1em",
+    "--page-right-gutter-width": "3.5em",
   }
 }
 
@@ -147,9 +149,11 @@ export const PageHeader = (props: PageHeaderProps): React.ReactChild => {
 export const PageBody = ({ children }) => <Box
   as="main"
   className="page-body"
-  // outset slightly for block toggles
-  pl="calc(var(--page-padding) - 1em)"
-  pr="var(--page-padding)"
+  // outset slightly for block toggles and refs and such
+  px="calc(var(--page-padding) - 1em)"
+
+  // pr="calc((max(0, var(--page-padding) - 3em)))"
+  pr="calc(var(--page-padding) - var(--page-right-gutter-width) + 1.5em)"
   gridArea="content"
 >
   {children}</Box>

--- a/src/js/components/PresenceDetails/PresenceDetails.tsx
+++ b/src/js/components/PresenceDetails/PresenceDetails.tsx
@@ -135,7 +135,7 @@ export const PresenceDetails = withErrorBoundary((props: PresenceDetailsProps) =
                             bg={member.color}
                           />}
                         >
-                          <Text isTruncated maxWidth="10em">{member.username}</Text>
+                          <Text maxWidth="10em">{member.username}</Text>
                         </MenuItem>
                       )
                     })}
@@ -160,8 +160,8 @@ export const PresenceDetails = withErrorBoundary((props: PresenceDetailsProps) =
                         />}
                       >
                         <VStack align="stretch" spacing={0}>
-                          <Text isTruncated maxWidth="10em">{member.username}</Text>
-                          <Text isTruncated maxWidth="10em" color="foreground.secondary">{member.pageTitle}</Text>
+                          <Text maxWidth="10em">{member.username}</Text>
+                          <Text maxWidth="10em" color="foreground.secondary">{member.pageTitle}</Text>
                         </VStack>
                       </MenuItem>
                     ))}

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -303,10 +303,6 @@ const components = {
         _active: {
           bg: "interaction.surface.active"
         },
-        _focus: {
-          outline: "none",
-          boxShadow: "none",
-        },
         _focusVisible: {
           outline: "none",
           boxShadow: "focusInset"
@@ -355,10 +351,6 @@ const components = {
       transitionTimingFunction: 'ease-in-out',
       _active: {
         transitionDuration: "0s",
-      },
-      _focus: {
-        outline: 'none',
-        boxShadow: 'none'
       },
       _focusVisible: {
         outline: 'none',
@@ -518,9 +510,6 @@ const components = {
     baseStyle: {
       dialogContainer: {
         WebkitAppRegion: 'no-drag',
-        _focus: {
-          outline: 'none'
-        }
       },
       dialog: {
         shadow: "dialog",
@@ -535,12 +524,7 @@ const components = {
     baseStyle: {
       content: {
         bg: "background.upper",
-        // border: "unset",
         shadow: "popover",
-        _focus: {
-          outline: 'none',
-          shadow: "popover",
-        },
         _focusVisible: {
           shadow: "popover",
         },
@@ -629,10 +613,6 @@ const components = {
             color: 'foreground.primary',
             borderBottomColor: "foreground.primary"
           },
-          _focus: {
-            outline: 'none',
-            shadow: 'focusInset'
-          },
           _hover: {
             bg: "interaction.surface.hover",
             shadow: 'none'
@@ -642,7 +622,7 @@ const components = {
             shadow: 'none'
           },
           _focusVisible: {
-            shadow: "focus"
+            shadow: 'focusInset'
           }
         }
       },
@@ -666,10 +646,6 @@ const components = {
             left: "1ch",
             borderRadius: "md",
             height: "1.5px",
-          },
-          _focus: {
-            outline: 'none',
-            shadow: 'none'
           },
           _focusVisible: {
             outline: 'none',


### PR DESCRIPTION
Main goal is to improve tasks by adding to the task editor form, not showing less-useful info, and by decluttering the space around them.

Major
- Adds read-only title, creator, and created date to task editor forms
- Hides creator and created date from task blocks
- Adds pencil icon to task blocks to slightly afford editing

Minor
- Block toggles hidden (once again) until hovering/editing that block
- Fixes missing focus outlines due to new defaults from Chakra
- Moves block presence and ref count into right page gutter