### PR TITLE
Bug fixes and property update

### DIFF
--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -821,13 +821,14 @@
                                                                           :notification-for-users [assignee]
                                                                           :author                 username
                                                                           :trigger-block-uid      uid
-                                                                          :notification-type      "athens/task/assigned/to"}))
-          task-creator-op   (comments/create-notification-op-for-users {:db                     @db/dsdb
-                                                                        :parent-block-uid       uid
-                                                                        :notification-for-users [(str "[[@" username "]]")]
-                                                                        :author                 username
-                                                                        :trigger-block-uid      uid
-                                                                        :notification-type      "athens/task/assigned/by"})
+                                                                          :notification-type      "athens/notification/type/task/assigned/to"}))
+          task-creator-op   (when (not= assignee (str "[[@" username "]]"))
+                              (comments/create-notification-op-for-users {:db                     @db/dsdb
+                                                                          :parent-block-uid       uid
+                                                                          :notification-for-users [(str "[[@" username "]]")]
+                                                                          :author                 username
+                                                                          :trigger-block-uid      uid
+                                                                          :notification-type      "athens/notification/type/task/assigned/by"}))
           event             (common-events/build-atomic-event  (composite-ops/make-consequence-op {:op/type :mention-notifications}
                                                                                                   (concat
                                                                                                     assignee-op

--- a/src/cljs/athens/views/notifications/core.cljs
+++ b/src/cljs/athens/views/notifications/core.cljs
@@ -23,10 +23,10 @@
     (= notification-type  "athens/notification/type/mention")
     (str "**" notification-trigger-author "** " "mentioned you: " "**((" notification-trigger-uid "))**")
 
-    (= notification-type "athens/task/assigned/to")
+    (= notification-type "athens/notification/type/task/assigned/to")
     (str "**" notification-trigger-author "** " "assigned you task: " "***((" notification-trigger-uid "))***")
 
-    (= notification-type "athens/task/assigned/by")
+    (= notification-type "athens/notification/type/task/assigned/by")
     (str "You assigned a new task: " "***((" notification-trigger-uid "))*** to " notification-for-user)))
 
 

--- a/src/cljs/athens/views/notifications/popover.cljs
+++ b/src/cljs/athens/views/notifications/popover.cljs
@@ -32,7 +32,7 @@
   [prop]
   (let [type (:block/string (get prop "athens/notification/type"))]
     (cond
-      (= type "[[athens/notification/type/comment]]")           "Comments"
+      (= type "[[athens/notification/type/comment]]")            "Comments"
       (= type "[[athens/notification/type/mention]]")           "Mentions"
       (= type "[[athens/notification/type/task/assigned/to]]")  "Assignments"
       (= type "[[athens/notification/type/task/assigned/by]]")  "Created")))

--- a/src/cljs/athens/views/notifications/popover.cljs
+++ b/src/cljs/athens/views/notifications/popover.cljs
@@ -32,8 +32,10 @@
   [prop]
   (let [type (:block/string (get prop "athens/notification/type"))]
     (cond
-      (= type "[[athens/notification/type/comment]]")  "Comments"
-      (= type "[[athens/notification/type/mention]]")  "Mentions")))
+      (= type "[[athens/notification/type/comment]]")           "Comments"
+      (= type "[[athens/notification/type/mention]]")           "Mentions"
+      (= type "[[athens/notification/type/task/assigned/to]]")  "Assignments"
+      (= type "[[athens/notification/type/task/assigned/by]]")  "Created")))
 
 
 (defn get-archive-state


### PR DESCRIPTION
- Bug: If a user assignes a task to themselves they will get notified about it 2 times
- Bug: Popover does not show the message when task is assigned
- Update: notification-type property for notifications generated by tasks