### PR TITLE
fix: right sidebar drag handle doesn't scroll away

### DIFF
--- a/src/js/components/Layout/RightSidebar.tsx
+++ b/src/js/components/Layout/RightSidebar.tsx
@@ -62,29 +62,32 @@ export const RightSidebar = (props: RightSidebarProps) => {
           transitionProperty="background"
           transitionTimingFunction="ease-in-out"
           transitionDuration="fast"
-          overflowX="hidden"
-          overflowY="auto"
           borderLeft="1px solid"
           borderColor="separator.divider"
+          height="100vh"
           position="fixed"
           id="right-sidebar"
-          height="100vh"
           inset={0}
-          pt={`calc(${toolbarHeight} + 1rem)`}
           left="auto"
         >
           <RightSidebarResizeControl
             onResizeSidebar={onResize}
           />
           <Box
-            aria-hidden
-            position="absolute"
-            ref={markerRef}
-            height="20px"
-            top={0}
-          />
-          <Box
-            width={unsavedRightSidebarWidth + "vw"}>
+            pt={`calc(${toolbarHeight} + 1rem)`}
+            overflowX="hidden"
+            overflowY="auto"
+            height="100%"
+            position="relative"
+            width={unsavedRightSidebarWidth + "vw"}
+          >
+            <Box
+              aria-hidden
+              position="absolute"
+              ref={markerRef}
+              height="20px"
+              top={0}
+            />
             {children}
           </Box>
         </Box>


### PR DESCRIPTION
Moves the scrolling containment to the inner box in the right sidebar, so the drag handle isn't part of the scrolling area.