### PR TITLE
fix: restore focus behavior prior to chakra update

### DIFF
--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -303,6 +303,10 @@ const components = {
         _active: {
           bg: "interaction.surface.active"
         },
+        _focus: {
+          outline: "none",
+          boxShadow: "none",
+        },
         _focusVisible: {
           outline: "none",
           boxShadow: "focusInset"
@@ -351,6 +355,10 @@ const components = {
       transitionTimingFunction: 'ease-in-out',
       _active: {
         transitionDuration: "0s",
+      },
+      _focus: {
+        outline: 'none',
+        boxShadow: 'none'
       },
       _focusVisible: {
         outline: 'none',
@@ -510,6 +518,9 @@ const components = {
     baseStyle: {
       dialogContainer: {
         WebkitAppRegion: 'no-drag',
+        _focus: {
+          outline: 'none'
+        }
       },
       dialog: {
         shadow: "dialog",
@@ -525,6 +536,10 @@ const components = {
       content: {
         bg: "background.upper",
         shadow: "popover",
+        _focus: {
+          outline: 'none',
+          shadow: "popover",
+        },
         _focusVisible: {
           shadow: "popover",
         },
@@ -613,6 +628,10 @@ const components = {
             color: 'foreground.primary',
             borderBottomColor: "foreground.primary"
           },
+          _focus: {
+            outline: 'none',
+            shadow: 'focusInset'
+          },
           _hover: {
             bg: "interaction.surface.hover",
             shadow: 'none'
@@ -622,7 +641,7 @@ const components = {
             shadow: 'none'
           },
           _focusVisible: {
-            shadow: 'focusInset'
+            shadow: "focus"
           }
         }
       },
@@ -646,6 +665,10 @@ const components = {
             left: "1ch",
             borderRadius: "md",
             height: "1.5px",
+          },
+          _focus: {
+            outline: 'none',
+            shadow: 'none'
           },
           _focusVisible: {
             outline: 'none',


### PR DESCRIPTION
Minor fix to hide focus rings again unless using the keyboard.
This had been updated when we were upgrading to chakra 2, but wasn't reverted when we pulled back.