### PR TITLE
fix: right sidebar els align to top

### DIFF
--- a/src/js/components/Layout/RightSidebar.tsx
+++ b/src/js/components/Layout/RightSidebar.tsx
@@ -74,7 +74,7 @@ export const RightSidebar = (props: RightSidebarProps) => {
             onResizeSidebar={onResize}
           />
           <Box
-            pt={`calc(${toolbarHeight} + 1rem)`}
+            pt={`calc(${toolbarHeight} + 0.5rem)`}
             width={unsavedRightSidebarWidth + "vw"}
             overflowX="hidden"
             overflowY="auto"


### PR DESCRIPTION
Right sidebar contents should align with top of daily notes and left sidebar elements