### PR TITLE
feat: Parsing to text wraps block-refs in `(())`

### DIFF
--- a/src/cljs/athens/parse_renderer.cljs
+++ b/src/cljs/athens/parse_renderer.cljs
@@ -317,7 +317,7 @@
 
 (defn transform->text
   "Transforms Instaparse output to Hiccup."
-  [tree uid]
+  [tree]
   (insta/transform
     {:block   (fn [& contents]
                 (str/join contents))
@@ -341,7 +341,7 @@
                                    ff         @(rf/subscribe [:feature-flags])
                                    renderer-k (block-type-dispatcher/block-type->protocol-k block-type ff)
                                    renderer   (block-type-dispatcher/block-type->protocol renderer-k {})]
-                               (types/text-view renderer block attr ref-uid uid)))
+                               (str "((" (types/text-view renderer block attr) "))")))
      :url-image            (fn [{url :src alt :alt}]
                              (str "![" alt "](" url ")"))
      :url-link             (fn [{url :url} text]
@@ -416,9 +416,9 @@
 
 
 (defn parse-to-text
-  [string uid]
+  [string]
   (let [ast    (parser-impl/staged-parser->ast string)
         result (if (insta/failure? ast)
                  (insta/get-failure ast)
-                 (transform->text ast uid))]
+                 (transform->text ast))]
     (str/join result)))

--- a/src/cljs/athens/types/core.cljs
+++ b/src/cljs/athens/types/core.cljs
@@ -6,7 +6,7 @@
   "Block/Entity Type Protocol for rendering aspects"
 
   (text-view
-    [this block-data attr ref-uid uid]
+    [this block-data attr]
     "Renders Block/Entity Type as textual representation.
      Recursively resolves references and all.")
 

--- a/src/cljs/athens/types/default/view.cljs
+++ b/src/cljs/athens/types/default/view.cljs
@@ -33,10 +33,10 @@
   types/BlockTypeProtocol
 
   (text-view
-    [_this block {:keys [_from title]} ref-uid _uid]
+    [_this {:block/keys [string]} {:keys [_from title]}]
     (if (not (str/blank? title))
-      (parser/parse-to-text title ref-uid)
-      (parser/parse-to-text (:block/string block) ref-uid)))
+      (parser/parse-to-text title)
+      (parser/parse-to-text string)))
 
 
   (inline-ref-view

--- a/src/cljs/athens/types/tasks/view.cljs
+++ b/src/cljs/athens/types/tasks/view.cljs
@@ -271,8 +271,8 @@
   types/BlockTypeProtocol
 
   (text-view
-    [_this _block-data _attr _ref-uid uid]
-    (str "Task: " uid))
+    [_this block-data _attr]
+    (str "Task: " (:block/uid block-data)))
 
 
   (inline-ref-view

--- a/src/cljs/athens/views/right_sidebar/shared.cljs
+++ b/src/cljs/athens/views/right_sidebar/shared.cljs
@@ -102,7 +102,7 @@
                           block/string
                           block/uid]} (reactive/get-reactive-right-sidebar-item eid)
                   ;; NOTE: add support for BlockTypeProtocol
-                  entity-title        (parse-renderer/parse-to-text (or title string) name)]
+                  entity-title        (parse-renderer/parse-to-text (or title string))]
               {:isOpen     open?
                :key        source-uid
                :id         source-uid


### PR DESCRIPTION
<img width="1552" alt="Screenshot 2022-09-21 at 11 47 33" src="https://user-images.githubusercontent.com/19492/191473236-c089fed2-ef09-4c41-9417-c74a16b85e40.png">
