### PR TITLE
fix: right sidebar items have proper bg

### DIFF
--- a/src/js/components/Layout/RightSidebar.tsx
+++ b/src/js/components/Layout/RightSidebar.tsx
@@ -101,7 +101,8 @@ export const SidebarItem = ({ title, type, isOpen, onToggle, onRemove, onNavigat
   const className = { "page": "node-page", "block": "block-page", "graph": "graph-page" }[type];
   return (
     <VStack
-      layerStyle="card"
+      bg="background.upper"
+      borderRadius="md"
       overflow="hidden"
       align="stretch"
       position="relative"
@@ -112,7 +113,8 @@ export const SidebarItem = ({ title, type, isOpen, onToggle, onRemove, onNavigat
         "--page-left-gutter-width": "1em",
         "--page-right-gutter-width": "3em",
       }}
-      mt={2}>
+      mt={2}
+    >
       <Flex
         alignItems="center"
         justifyContent="center"


### PR DESCRIPTION
Not sure why, but it seems like chakra `layerStyles` aren't working. Not sure that's worth debugging, so I've refactored to just use normal styles.