### PR TITLE
Fix page height on mobile

### DIFF
--- a/src/cljs/athens/views.cljs
+++ b/src/cljs/athens/views.cljs
@@ -50,7 +50,7 @@
             (and @loading @modal) [db-modal/window]
 
             @loading
-            [:> Center {:height "100vh"}
+            [:> Center {:height "var(--app-height)"}
              [:> Flex {:width 28
                        :flexDirection "column"
                        :gap 2
@@ -70,7 +70,7 @@
                                :id "main-layout"
                                :spacing 0
                                :overflowY "auto"
-                               :height "100vh"
+                               :height "var(--app-height)"
                                :bg "background.floor"
                                :transitionDuration "fast"
                                :transitionProperty "background"

--- a/src/cljs/athens/views/notifications/popover.cljs
+++ b/src/cljs/athens/views/notifications/popover.cljs
@@ -152,7 +152,7 @@
                         :bottom "-1px"
                         :zIndex 1} num-notifications])]]
 
-         [:> PopoverContent {:maxHeight "calc(100vh - 4rem)"}
+         [:> PopoverContent {:maxHeight "calc(var(--app-height) - 4rem)"}
           [:> PopoverCloseButton]
           [:> PopoverHeader
            [:> Button {:onClick navigate-user-page :rightIcon (r/as-element [:> ArrowRightIcon])}

--- a/src/cljs/athens/views/pages/daily_notes.cljs
+++ b/src/cljs/athens/views/pages/daily_notes.cljs
@@ -31,8 +31,8 @@
         (let [notes (reactive-pull-many @note-refs)]
           [:> DailyNotesList {:id "daily-notes"
                               :onGetAnotherNote get-another-note
-                              :minHeight     "calc(100vh + 1px)"
-                              :height        "calc(100vh + 1px)"
+                              :minHeight     "calc(var(--app-height) + 1px)"
+                              :height        "calc(var(--app-height) + 1px)"
                               :display       "flex"
                               :overflowY     "auto"
                               :gap           "1.5rem"

--- a/src/js/components/AllPagesTable/AllPagesTable.tsx
+++ b/src/js/components/AllPagesTable/AllPagesTable.tsx
@@ -117,7 +117,7 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
   return <Box
     flex="1 1 100%"
     alignSelf="stretch"
-    height="100vh"
+    height="var(--app-height)"
     px={4}
     sx={{
       "--margin-top": "2rem",
@@ -127,7 +127,7 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
     }}
   >
     <Table variant="striped"
-      height="100vh"
+      height="var(--app-height)"
       sx={{
         "tr > *:nth-of-type(1)": {
           flex: "0 0 calc(100% - 39rem)"
@@ -187,7 +187,7 @@ export const AllPagesTable = ({ sortedPages, onClickItem, sortedBy, sortDirectio
         position="relative"
         display="flex"
         width="100%"
-        height="calc(100vh - var(--thead-height))"
+        height="calc(var(--app-height) - var(--thead-height))"
         ref={containerRef}
         sx={{
           // target the container that renders the row items

--- a/src/js/components/Block/Autocomplete.tsx
+++ b/src/js/components/Block/Autocomplete.tsx
@@ -136,7 +136,7 @@ export const Autocomplete = ({ isOpen, onClose, event, children }) => {
           ref={menuRef}
           p={0}
           overflow="auto"
-          maxHeight={`calc(100vh - 2rem - 2rem - ${menuPosition?.top || 0}px)`}
+          maxHeight={`calc(var(--app-height) - 2rem - 2rem - ${menuPosition?.top || 0}px)`}
         >
           {children}
         </PopoverContent>

--- a/src/js/components/Layout/MainSidebar.tsx
+++ b/src/js/components/Layout/MainSidebar.tsx
@@ -27,7 +27,7 @@ export const MainSidebar = (props) => {
           transitionTimingFunction="ease-in-out"
           transitionDuration="fast"
           pt={toolbarHeight}
-          height="100vh"
+          height="var(--app-height)"
           position="sticky"
           overflow="hidden"
           overscrollBehavior="contain"

--- a/src/js/components/Layout/RightSidebar.tsx
+++ b/src/js/components/Layout/RightSidebar.tsx
@@ -64,7 +64,7 @@ export const RightSidebar = (props: RightSidebarProps) => {
           transitionDuration="fast"
           borderLeft="1px solid"
           borderColor="separator.divider"
-          height="100vh"
+          height="var(--app-height)"
           position="fixed"
           id="right-sidebar"
           inset={0}

--- a/src/js/components/Page/Page.tsx
+++ b/src/js/components/Page/Page.tsx
@@ -37,7 +37,7 @@ const TITLE_PROPS = {
 }
 
 export const PageNotFound = ({ title, onClickHome, children }) => {
-  return <Center height="100vh" gap="1rem" flexDirection="column">
+  return <Center height="var(--app-height)" gap="1rem" flexDirection="column">
     <Heading>404: {title ? `${title} not found`
       : `Page not found`}</Heading>
     {onClickHome
@@ -235,7 +235,7 @@ export const DailyNotesPage = withErrorBoundary((props: DailyNotesPageProps) => 
       ref={pageRef}
       flex="0 0 auto"
       className="node-page daily-notes"
-      minHeight="calc(100vh - 4rem)"
+      minHeight="calc(var(--app-height) - 4rem)"
       boxShadow="page"
       bg="background.floor"
       borderWidth="1px"

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -831,11 +831,17 @@ const config = {
 
 const styles = {
   global: {
+    ":root": {
+      "--app-height": "100vh",
+      "@supports (height: 100dvh)": {
+        "--app-height": "100dvh",
+      },
+    },
     'html, body': {
       bg: 'background.floor',
       color: 'foreground.primary',
       lineHeight: '1.5',
-      height: '100vh',
+      height: 'var(--app-height)',
       fontFamily: 'default',
       sx: {
         "::WebkitScrollbar": {


### PR DESCRIPTION
Slightly better tablet support by using dynamic viewport height units, where supported.
Fixes some elements not appearing on e.g. the bottom of an iPad.