### PR TITLE
fix: items on page shouldn't overlap

### DIFF
--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -769,22 +769,20 @@
                     (and @show-comments?
                          thread-uid))
             ^{:key uid}
-            [inline-comments/inline-comments comments-data  uid false])]
+            [inline-comments/inline-comments comments-data  uid false])
 
          ;; Properties
          (when (and @properties-enabled?
                     (seq properties))
-           [:> PageBody
-            (for [prop (common-db/sort-block-properties properties)]
-              ^{:key (:db/id prop)}
-              [:f> block-el prop])])
+           (for [prop (common-db/sort-block-properties properties)]
+             ^{:key (:db/id prop)}
+             [:f> block-el prop]))
 
 
          ;; Children
-         [:> PageBody
-          (for [child children]
-            (let [{:keys [db/id]} child]
-              ^{:key id} [:f> block-el child]))]
+         (for [child children]
+           (let [{:keys [db/id]} child]
+             ^{:key id} [:f> block-el child]))]
 
          ;; Refs
          [:> PageFooter

--- a/src/js/theme/theme.js
+++ b/src/js/theme/theme.js
@@ -819,10 +819,9 @@ const components = {
     parts: ["container", "header", "overline", "headerImage", "title", "body", "footer"],
     baseStyle: {
       container: {
-        display: "grid",
+        display: "flex",
+        flexDirection: "column",
         alignSelf: "stretch",
-        gridTemplateAreas: "'header' 'content' 'footer'",
-        gridTemplateRows: "auto 1fr auto",
         transitionProperty: "background",
         transitionTimingFunction: "ease-in-out",
         transitionDuration: "fast",
@@ -834,12 +833,10 @@ const components = {
         px: "var(--page-padding)",
         position: 'relative',
         pb: 4,
-        gridArea: "header",
         alignItems: "center",
       },
       headerImage: {
         marginTop: 4,
-        gridArea: "image",
         borderRadius: "md",
         width: "100%",
         height: "auto",
@@ -868,10 +865,8 @@ const components = {
       body: {
         px: "calc(var(--page-padding) - 1em)",
         pr: "calc(var(--page-padding) - var(--page-right-gutter-width) + 1.5em)",
-        gridArea: 'content',
       },
       footer: {
-        gridArea: "footer",
         p: "var(--page-padding)",
       }
     },


### PR DESCRIPTION
Fixes an issue where comments, properties, and content could all be overlapping on a page