### PR TITLE
Get clipboard data in HTML format

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "react-intersection-observer": "^8.32.1",
     "react-window": "^1.8.6",
     "textarea-caret": "^3.1.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "turndown": "^7.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/src/cljs/athens/utils/markdown.cljs
+++ b/src/cljs/athens/utils/markdown.cljs
@@ -1,0 +1,12 @@
+(ns athens.utils.markdown
+  (:require ["turndown" :as turndown]))
+
+(set! (.-escape (.-prototype turndown)) (fn [string] string))
+
+(defonce turndown-instance
+  (new turndown))
+
+(defn html->md 
+  "Transforms text to markdown."
+  [text]
+  (.turndown turndown-instance text))

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -7,6 +7,7 @@
     [athens.parse-renderer                       :refer [parse-and-render]]
     [athens.subs.selection                       :as select-subs]
     [athens.util                                 :as util]
+    [athens.utils.markdown                       :as markdown]
     [athens.views.blocks.autocomplete-search     :as autocomplete-search]
     [athens.views.blocks.autocomplete-slash      :as autocomplete-slash]
     [athens.views.blocks.internal-representation :as internal-representation]
@@ -105,7 +106,6 @@
 
 ;; Event Handlers
 
-
 (defn textarea-paste
   "Clipboard data can only be accessed if user triggers JavaScript paste event.
   Uses previous keydown event to determine if shift was held, since the paste event has no knowledge of shift key.
@@ -127,7 +127,11 @@
           :or   {default-verbatim-paste? false}
           :as   _state-hooks} last-key-w-shift?]
   (let [data                    (.. e -clipboardData)
+        md-data                 (-> data
+                                    (.getData "text/html")
+                                    (markdown/html->md))
         text-data               (.getData data "text/plain")
+        
         ;; With internal representation
         internal-representation (some-> (.getData data "application/athens-representation")
                                         edn/read-string)
@@ -144,7 +148,10 @@
                                              50))
 
         ;; External to internal representation
-        text-to-inter (when-not (str/blank? text-data)
+        text-to-inter (cond
+                        (not (str/blank? md-data))
+                        (internal-representation/text-to-internal-representation md-data)
+                        (not (str/blank? text-data))
                         (internal-representation/text-to-internal-representation text-data))
         line-breaks   (re-find #"\r?\n" text-data)
         no-shift      (not @last-key-w-shift?)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7292,6 +7292,11 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
+domino@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
+  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
+
 domutils@^2.5.2, domutils@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.7.0.tgz#8ebaf0c41ebafcf55b0b72ec31c56323712c5442"
@@ -14255,6 +14260,13 @@ tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
+turndown@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"
+  integrity sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==
+  dependencies:
+    domino "^2.1.6"
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Makes it possible to paste complex data such as lists and formatted HTML text to Athens. 
The original goal of it was to make it possible to insert nested lists from different sources while maintaining the structure.  I wanted to extend the parser and make it work with HTML first but quickly figured that the easiest would be to just get the HTML data (`text/html`) from the clipboard and transform it to markdown — this solution makes it possible to not only work with lists but with literally any rich data.

**How to test:**
1. Go to any source of rich data (I was using https://github.com/HumbleUI/HumbleUI#motivation)
2. Just copy the HTML and paste it to Athens.
3. You can also insert the raw data in Markdown format, it will also be parsed and inserted correctly.

<img width="714" alt="Screenshot 2022-10-04 at 14 22 32" src="https://user-images.githubusercontent.com/911127/193818156-db8ba91f-198d-4d6e-a215-6fca2941105b.png">
