### PR TITLE
.block-page and .node-page class names added

### DIFF
--- a/src/cljs/athens/views/blocks/core.cljs
+++ b/src/cljs/athens/views/blocks/core.cljs
@@ -742,7 +742,7 @@
         (when (not= string (:string/previous @state))
           (swap! state assoc :string/previous string :string/local string))
 
-        [:> Page (merge opts {})
+        [:> Page (merge opts {:class "block-page"})
 
          ;; Header
          [:> PageHeader

--- a/src/cljs/athens/views/blocks/editor.cljs
+++ b/src/cljs/athens/views/blocks/editor.cljs
@@ -47,9 +47,10 @@
   (let [target              (.. e -target)
         page                (or (.. target (closest ".node-page"))
                                 (.. target (closest ".block-page")))
-        blocks              (->> (.. page (querySelectorAll ".block-container"))
-                                 array-seq
-                                 vec)
+        blocks              (some-> page 
+                                    (.. (querySelectorAll ".block-container"))
+                                    array-seq
+                                    vec)
         uids                (map util/get-dataset-uid blocks)
         uids->children-uids (->> (zipmap uids
                                          (map util/get-dataset-children-uids blocks))

--- a/src/cljs/athens/views/pages/node_page.cljs
+++ b/src/cljs/athens/views/pages/node_page.cljs
@@ -449,7 +449,7 @@
 
         (sync-title title state)
 
-        [:> Page (merge opts {})
+        [:> Page (merge opts {:class "node-page"})
 
          [:> Confirmation {:isOpen      alert-show
                            :title       message


### PR DESCRIPTION
After the recent code changes the `.block-page` and `.node-page` class names were removed => the following line in `athens.views.blocks.editor/find-selected-items` returns `nil` which makes it impossible to do manipulations with multi-line texts.
```clj
(or (.. target (closest ".node-page"))
    (.. target (closest ".block-page")))
```
<img width="512" alt="Screenshot 2022-10-05 at 13 32 04" src="https://user-images.githubusercontent.com/911127/194051127-751fbd66-d5aa-430a-a50b-6308089f576f.png">


This PR fixes that.